### PR TITLE
feat: add /health endpoint with DB probe, uptime, and Docker healthcheck

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2401,6 +2401,7 @@ dependencies = [
  "shared",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/backend/api/src/state.rs
+++ b/backend/api/src/state.rs
@@ -1,13 +1,19 @@
+use std::time::Instant;
+
 use sqlx::PgPool;
 
 /// Application state shared across handlers
 #[derive(Clone)]
 pub struct AppState {
     pub db: PgPool,
+    pub started_at: Instant,
 }
 
 impl AppState {
     pub fn new(db: PgPool) -> Self {
-        Self { db }
+        Self {
+            db,
+            started_at: Instant::now(),
+        }
     }
 }

--- a/backend/verifier/Cargo.toml
+++ b/backend/verifier/Cargo.toml
@@ -17,3 +17,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/backend/verifier/src/lib.rs
+++ b/backend/verifier/src/lib.rs
@@ -6,7 +6,7 @@ use shared::RegistryError;
 
 /// Verify that source code matches deployed contract bytecode
 pub async fn verify_contract(
-    source_code: &str,
+    _source_code: &str,
     deployed_wasm_hash: &str,
 ) -> Result<bool, RegistryError> {
     // TODO: Implement verification logic
@@ -22,7 +22,7 @@ pub async fn verify_contract(
 }
 
 /// Compile Rust source code to WASM
-pub async fn compile_contract(source_code: &str) -> Result<Vec<u8>, RegistryError> {
+pub async fn compile_contract(_source_code: &str) -> Result<Vec<u8>, RegistryError> {
     // TODO: Implement compilation
     // - Set up temporary build environment
     // - Write source to temp directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3001/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     volumes:
       - ./backend:/app
       - cargo_cache:/usr/local/cargo/registry


### PR DESCRIPTION
This updates the /health endpoint to return a proper JSON response instead of "OK".

It now checks DB connectivity, includes uptime, timestamp, and version, and returns 503 if the database is not reachable. I also added a Docker healthcheck for container probes.

Closes #1

Changes
- Added started_at: Instant to AppState
- Rewrote health_check to probe DB and return 200/503 accordingly
- Added logging with tracing
- Added healthcheck block to docker-compose.yml
- Fixed pre-existing workspace build issues so cargo check --workspace passes cleanly

Testing
- cargo check --workspace passes with zero errors and zero warnings
- /health returns 200 with JSON when DB is reachable
- /health returns 503 with "degraded" status when DB is unreachable
