### PR TITLE
Configure CORS and add frontend API rewrite proxy

### DIFF
--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -3,6 +3,7 @@ mod handlers;
 mod state;
 
 use anyhow::Result;
+use axum::http::{header, HeaderValue, Method};
 use axum::Router;
 use dotenv::dotenv;
 use sqlx::postgres::PgPoolOptions;
@@ -29,7 +30,7 @@ async fn main() -> Result<()> {
     // Database connection
     let database_url = std::env::var("DATABASE_URL")
         .expect("DATABASE_URL must be set");
-    
+
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .connect(&database_url)
@@ -45,12 +46,20 @@ async fn main() -> Result<()> {
     // Create app state
     let state = AppState::new(pool);
 
+    let cors = CorsLayer::new()
+        .allow_origin([
+            HeaderValue::from_static("http://localhost:3000"),
+            HeaderValue::from_static("https://soroban-registry.vercel.app"),
+        ])
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
+
     // Build router
     let app = Router::new()
         .merge(routes::contract_routes())
         .merge(routes::publisher_routes())
         .merge(routes::health_routes())
-        .layer(CorsLayer::permissive())
+        .layer(cors)
         .with_state(state);
 
     // Start server

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -63,7 +63,7 @@ export interface PublishRequest {
   publisher_address: string;
 }
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+const apiUrl = (path: string) => path;
 
 export const api = {
   // Contract endpoints
@@ -76,25 +76,25 @@ export const api = {
     if (params?.page) queryParams.append('page', String(params.page));
     if (params?.page_size) queryParams.append('page_size', String(params.page_size));
 
-    const response = await fetch(`${API_URL}/api/contracts?${queryParams}`);
+    const response = await fetch(apiUrl(`/api/contracts?${queryParams}`));
     if (!response.ok) throw new Error('Failed to fetch contracts');
     return response.json();
   },
 
   async getContract(id: string): Promise<Contract> {
-    const response = await fetch(`${API_URL}/api/contracts/${id}`);
+    const response = await fetch(apiUrl(`/api/contracts/${id}`));
     if (!response.ok) throw new Error('Failed to fetch contract');
     return response.json();
   },
 
   async getContractVersions(id: string): Promise<ContractVersion[]> {
-    const response = await fetch(`${API_URL}/api/contracts/${id}/versions`);
+    const response = await fetch(apiUrl(`/api/contracts/${id}/versions`));
     if (!response.ok) throw new Error('Failed to fetch contract versions');
     return response.json();
   },
 
   async publishContract(data: PublishRequest): Promise<Contract> {
-    const response = await fetch(`${API_URL}/api/contracts`, {
+    const response = await fetch(apiUrl('/api/contracts'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
@@ -105,20 +105,20 @@ export const api = {
 
   // Publisher endpoints
   async getPublisher(id: string): Promise<Publisher> {
-    const response = await fetch(`${API_URL}/api/publishers/${id}`);
+    const response = await fetch(apiUrl(`/api/publishers/${id}`));
     if (!response.ok) throw new Error('Failed to fetch publisher');
     return response.json();
   },
 
   async getPublisherContracts(id: string): Promise<Contract[]> {
-    const response = await fetch(`${API_URL}/api/publishers/${id}/contracts`);
+    const response = await fetch(apiUrl(`/api/publishers/${id}/contracts`));
     if (!response.ok) throw new Error('Failed to fetch publisher contracts');
     return response.json();
   },
 
   // Stats endpoint
   async getStats(): Promise<{ total_contracts: number; verified_contracts: number; total_publishers: number }> {
-    const response = await fetch(`${API_URL}/api/stats`);
+    const response = await fetch(apiUrl('/api/stats'));
     if (!response.ok) throw new Error('Failed to fetch stats');
     return response.json();
   },

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
+const apiOrigin = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${apiOrigin}/api/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
 ## Summary
  Adds explicit CORS support to the backend API and updates frontend API calls to work through a local `/api` proxy during
  development.

  ## Changes
  - Backend (`backend/api/src/main.rs`)
    - Replaced permissive CORS with explicit allowlist:
      - Origins:
        - `http://localhost:3000`
        - `https://soroban-registry.vercel.app`
      - Methods:
        - `GET`, `POST`, `OPTIONS`
      - Headers:
        - `Content-Type`, `Authorization`

  - Frontend (`frontend/next.config.ts`)
    - Added rewrite:
      - `/api/:path*` -> `${apiOrigin}/api/:path*`
    - `apiOrigin` resolves from:
      - `API_URL` or `NEXT_PUBLIC_API_URL`
      - fallback: `http://localhost:3001`

  - Frontend (`frontend/lib/api.ts`)
    - Switched fetch calls to relative `/api/...` paths so browser requests route through Next rewrite.

  ## Acceptance Criteria Mapping
  - `fetch("/api/contracts")` succeeds via Next rewrite proxy.
  - Dev CORS errors removed by explicit backend CORS policy.
  - Production frontend domain explicitly allowed.

  Closes #2
 