### PR TITLE
Add CLI --version output with rustc build info

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+build = "build.rs"
 
 [[bin]]
 name = "soroban-registry"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+fn main() {
+    let rustc_version = Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .and_then(|full| full.split_whitespace().nth(1).map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=RUSTC_VERSION={rustc_version}");
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,8 +3,16 @@ mod commands;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+const CLI_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (rustc ",
+    env!("RUSTC_VERSION"),
+    ")"
+);
+
 #[derive(Parser)]
 #[command(name = "soroban-registry")]
+#[command(version = CLI_VERSION, long_version = CLI_VERSION)]
 #[command(about = "CLI tool for the Soroban Contract Registry", long_about = None)]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
Changed files:

  - cli/src/main.rs:6
  - cli/Cargo.toml:7
  - cli/build.rs:1

  What I added:

  - clap version string now uses:
      - CARGO_PKG_VERSION
      - RUSTC_VERSION (injected at build time)
  - Output format is now:
      - soroban-registry <cargo_version> (rustc <rustc_version>)
  - Added cli/build.rs to run rustc --version, extract version number, and set RUSTC_VERSION.
  - --help and unknown flag handling remain under clap (no custom parsing that could panic).

  Validation note:

  - I could not run the CLI binary here because cli/Cargo.toml inherits from a workspace root manifest that is not present in this
    checkout, so cargo run --manifest-path cli/Cargo.toml ... fails before execution.
  - The code/commit is in place; runtime verification needs your normal workspace setup.
 Closes https://github.com/ALIPHATICHYD/Soroban-Registry/issues/7
  
