### PR TITLE
Add contract deprecation management

### DIFF
--- a/backend/api/src/deprecation_handlers.rs
+++ b/backend/api/src/deprecation_handlers.rs
@@ -1,0 +1,244 @@
+use axum::{extract::{Path, State}, Json};
+use chrono::{DateTime, Utc};
+use shared::{DeprecateContractRequest, DeprecationInfo, DeprecationStatus};
+use uuid::Uuid;
+
+use crate::error::{ApiError, ApiResult};
+use crate::state::AppState;
+
+pub async fn get_deprecation_info(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<DeprecationInfo>> {
+    let (contract_uuid, contract_id) = fetch_contract_identity(&state, &id).await?;
+
+    let record = sqlx::query_as::<_, (DateTime<Utc>, DateTime<Utc>, Option<Uuid>, Option<String>, Option<String>)>(
+        "SELECT deprecated_at, retirement_at, replacement_contract_id, migration_guide_url, notes \
+         FROM contract_deprecations WHERE contract_id = $1",
+    )
+    .bind(contract_uuid)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|err| db_internal_error("fetch deprecation", err))?;
+
+    let dependents_notified: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM contract_deprecation_notifications WHERE deprecated_contract_id = $1",
+    )
+    .bind(contract_uuid)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|err| db_internal_error("count notifications", err))?;
+
+    if let Some((deprecated_at, retirement_at, replacement_id, guide_url, notes)) = record {
+        let now = Utc::now();
+        let status = if now >= retirement_at {
+            DeprecationStatus::Retired
+        } else {
+            DeprecationStatus::Deprecated
+        };
+        let days_remaining = if retirement_at > now {
+            Some((retirement_at - now).num_days())
+        } else {
+            Some(0)
+        };
+
+        let replacement_contract_id = replacement_id
+            .map(|id| id.to_string())
+            .or_else(|| None);
+
+        return Ok(Json(DeprecationInfo {
+            contract_id,
+            status,
+            deprecated_at: Some(deprecated_at),
+            retirement_at: Some(retirement_at),
+            replacement_contract_id,
+            migration_guide_url: guide_url,
+            notes,
+            days_remaining,
+            dependents_notified,
+        }));
+    }
+
+    Ok(Json(DeprecationInfo {
+        contract_id,
+        status: DeprecationStatus::Active,
+        deprecated_at: None,
+        retirement_at: None,
+        replacement_contract_id: None,
+        migration_guide_url: None,
+        notes: None,
+        days_remaining: None,
+        dependents_notified,
+    }))
+}
+
+pub async fn deprecate_contract(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<DeprecateContractRequest>,
+) -> ApiResult<Json<DeprecationInfo>> {
+    let (contract_uuid, contract_id) = fetch_contract_identity(&state, &id).await?;
+
+    if req.migration_guide_url.is_none() && req.replacement_contract_id.is_none() {
+        return Err(ApiError::bad_request(
+            "MissingMigrationPath",
+            "Provide replacement_contract_id or migration_guide_url",
+        ));
+    }
+
+    if req.retirement_at <= Utc::now() {
+        return Err(ApiError::bad_request(
+            "InvalidRetirementDate",
+            "retirement_at must be in the future",
+        ));
+    }
+
+    let replacement_uuid = if let Some(ref selector) = req.replacement_contract_id {
+        Some(fetch_contract_uuid(&state, selector).await?)
+    } else {
+        None
+    };
+
+    sqlx::query(
+        "INSERT INTO contract_deprecations (contract_id, retirement_at, replacement_contract_id, migration_guide_url, notes) \
+         VALUES ($1, $2, $3, $4, $5) \
+         ON CONFLICT (contract_id) DO UPDATE SET \
+           retirement_at = EXCLUDED.retirement_at, \
+           replacement_contract_id = EXCLUDED.replacement_contract_id, \
+           migration_guide_url = EXCLUDED.migration_guide_url, \
+           notes = EXCLUDED.notes, \
+           updated_at = NOW()",
+    )
+    .bind(contract_uuid)
+    .bind(req.retirement_at)
+    .bind(replacement_uuid)
+    .bind(&req.migration_guide_url)
+    .bind(&req.notes)
+    .execute(&state.db)
+    .await
+    .map_err(|err| db_internal_error("upsert deprecation", err))?;
+
+    notify_dependents(&state, contract_uuid, &contract_id, req.retirement_at).await?;
+
+    get_deprecation_info(State(state), Path(contract_id)).await
+}
+
+async fn notify_dependents(
+    state: &AppState,
+    deprecated_id: Uuid,
+    contract_id: &str,
+    retirement_at: DateTime<Utc>,
+) -> ApiResult<()> {
+    let has_dep_contract_id = column_exists(state, "contract_dependencies", "dependency_contract_id").await?;
+    let has_dep_name = column_exists(state, "contract_dependencies", "dependency_name").await?;
+    let has_package_name = column_exists(state, "contract_dependencies", "package_name").await?;
+
+    let dependents: Vec<Uuid> = if has_dep_contract_id {
+        sqlx::query_scalar(
+            "SELECT DISTINCT contract_id FROM contract_dependencies WHERE dependency_contract_id = $1",
+        )
+        .bind(deprecated_id)
+        .fetch_all(&state.db)
+        .await
+        .map_err(|err| db_internal_error("fetch dependents", err))?
+    } else if has_dep_name || has_package_name {
+        let name_column = if has_dep_name { "dependency_name" } else { "package_name" };
+        let sql = format!(
+            "SELECT DISTINCT cd.contract_id \
+             FROM contract_dependencies cd \
+             JOIN contracts c ON c.name = cd.{name_column} \
+             WHERE c.contract_id = $1",
+        );
+        sqlx::query_scalar(&sql)
+            .bind(contract_id)
+            .fetch_all(&state.db)
+            .await
+            .map_err(|err| db_internal_error("fetch dependents", err))?
+    } else {
+        Vec::new()
+    };
+
+    if dependents.is_empty() {
+        return Ok(());
+    }
+
+    for dependent in dependents {
+        let message = format!(
+            "Contract {} has been deprecated and will retire on {}",
+            contract_id,
+            retirement_at.to_rfc3339()
+        );
+
+        let _ = sqlx::query(
+            "INSERT INTO contract_deprecation_notifications (contract_id, deprecated_contract_id, message) \
+             VALUES ($1, $2, $3) \
+             ON CONFLICT (contract_id, deprecated_contract_id) DO NOTHING",
+        )
+        .bind(dependent)
+        .bind(deprecated_id)
+        .bind(&message)
+        .execute(&state.db)
+        .await
+        .map_err(|err| db_internal_error("insert notification", err))?;
+    }
+
+    Ok(())
+}
+
+async fn fetch_contract_identity(state: &AppState, id: &str) -> ApiResult<(Uuid, String)> {
+    if let Ok(uuid) = Uuid::parse_str(id) {
+        let row = sqlx::query_as::<_, (Uuid, String)>(
+            "SELECT id, contract_id FROM contracts WHERE id = $1",
+        )
+        .bind(uuid)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|err| db_internal_error("fetch contract", err))?;
+        return row.ok_or_else(|| ApiError::not_found("ContractNotFound", format!("No contract found with ID: {}", id)));
+    }
+
+    let row = sqlx::query_as::<_, (Uuid, String)>(
+        "SELECT id, contract_id FROM contracts WHERE contract_id = $1",
+    )
+    .bind(id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|err| db_internal_error("fetch contract", err))?;
+
+    row.ok_or_else(|| ApiError::not_found("ContractNotFound", format!("No contract found with ID: {}", id)))
+}
+
+async fn fetch_contract_uuid(state: &AppState, contract_id: &str) -> ApiResult<Uuid> {
+    if let Ok(uuid) = Uuid::parse_str(contract_id) {
+        return Ok(uuid);
+    }
+
+    let uuid = sqlx::query_scalar::<_, Uuid>(
+        "SELECT id FROM contracts WHERE contract_id = $1",
+    )
+    .bind(contract_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|err| db_internal_error("fetch contract", err))?
+    .ok_or_else(|| ApiError::not_found("ContractNotFound", format!("Contract '{}' not found", contract_id)))?;
+
+    Ok(uuid)
+}
+
+fn db_internal_error(operation: &str, err: sqlx::Error) -> ApiError {
+    tracing::error!(operation = operation, error = ?err, "database operation failed");
+    ApiError::internal("Database operation failed")
+}
+
+async fn column_exists(state: &AppState, table: &str, column: &str) -> ApiResult<bool> {
+    let exists = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = $1 AND column_name = $2)",
+    )
+    .bind(table)
+    .bind(column)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|err| db_internal_error("check column", err))?;
+
+    Ok(exists)
+}

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -12,6 +12,7 @@ mod metrics;
 // mod resource_handlers;
 // mod resource_tracking;
 mod analytics;
+mod deprecation_handlers;
 
 use anyhow::Result;
 use axum::{middleware, Router};

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -4,7 +4,7 @@ use axum::{
 };
 
 use crate::{
-    handlers, metrics_handler,
+    handlers, metrics_handler, deprecation_handlers,
     state::AppState,
 };
 
@@ -21,6 +21,8 @@ pub fn contract_routes() -> Router<AppState> {
         .route("/api/contracts/:id", get(handlers::get_contract))
         .route("/api/contracts/:id/abi", get(handlers::get_contract_abi))
         .route("/api/contracts/:id/versions", get(handlers::get_contract_versions))
+        .route("/api/contracts/:id/deprecation-info", get(deprecation_handlers::get_deprecation_info))
+        .route("/api/contracts/:id/deprecate", post(deprecation_handlers::deprecate_contract))
         .route("/api/contracts/:id/state/:key", get(handlers::get_contract_state).post(handlers::update_contract_state))
         .route("/api/contracts/:id/analytics", get(handlers::get_contract_analytics))
         .route("/api/contracts/:id/trust-score", get(handlers::get_trust_score))

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -157,6 +157,48 @@ pub struct PublishRequest {
     pub dependencies: Vec<DependencyDeclaration>,
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Deprecation management (issue #65)
+// ────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeprecationStatus {
+    Active,
+    Deprecated,
+    Retired,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeprecationInfo {
+    pub contract_id: String,
+    pub status: DeprecationStatus,
+    pub deprecated_at: Option<DateTime<Utc>>,
+    pub retirement_at: Option<DateTime<Utc>>,
+    pub replacement_contract_id: Option<String>,
+    pub migration_guide_url: Option<String>,
+    pub notes: Option<String>,
+    pub days_remaining: Option<i64>,
+    pub dependents_notified: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeprecateContractRequest {
+    pub retirement_at: DateTime<Utc>,
+    pub replacement_contract_id: Option<String>,
+    pub migration_guide_url: Option<String>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct DeprecationNotification {
+    pub id: Uuid,
+    pub contract_id: Uuid,
+    pub deprecated_contract_id: Uuid,
+    pub message: String,
+    pub created_at: DateTime<Utc>,
+    pub acknowledged_at: Option<DateTime<Utc>>,
+}
 /// Dependency declaration in publish request
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DependencyDeclaration {

--- a/database/migrations/20260221010000_add_contract_deprecations.sql
+++ b/database/migrations/20260221010000_add_contract_deprecations.sql
@@ -1,0 +1,31 @@
+-- Migration: Contract Deprecation Management
+-- Issue #65: Add Contract Deprecation Management
+
+CREATE TABLE IF NOT EXISTS contract_deprecations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contract_id UUID NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,
+    deprecated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    retirement_at TIMESTAMPTZ NOT NULL,
+    replacement_contract_id UUID REFERENCES contracts(id),
+    migration_guide_url TEXT,
+    notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (contract_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_contract_deprecations_contract_id ON contract_deprecations(contract_id);
+CREATE INDEX IF NOT EXISTS idx_contract_deprecations_retirement_at ON contract_deprecations(retirement_at);
+
+CREATE TABLE IF NOT EXISTS contract_deprecation_notifications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contract_id UUID NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,
+    deprecated_contract_id UUID NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,
+    message TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    acknowledged_at TIMESTAMPTZ,
+    UNIQUE (contract_id, deprecated_contract_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_deprecation_notifications_contract_id ON contract_deprecation_notifications(contract_id);
+CREATE INDEX IF NOT EXISTS idx_deprecation_notifications_deprecated_contract_id ON contract_deprecation_notifications(deprecated_contract_id);

--- a/frontend/app/contracts/[id]/page.tsx
+++ b/frontend/app/contracts/[id]/page.tsx
@@ -20,6 +20,7 @@ import FormalVerificationPanel from "@/components/FormalVerificationPanel";
 import Navbar from "@/components/Navbar";
 import MaintenanceBanner from "@/components/MaintenanceBanner";
 import { useQueryClient } from "@tanstack/react-query";
+import DeprecationBanner from "@/components/DeprecationBanner";
 
 // Mock for maintenance status since it was missing in the original file view but used in code
 const maintenanceStatus = { is_maintenance: false, current_window: null };
@@ -42,6 +43,12 @@ function ContractDetailsContent() {
   const { data: dependencies, isLoading: depsLoading } = useQuery({
     queryKey: ["contract-dependencies", id],
     queryFn: () => api.getContractDependencies(id),
+    enabled: !!contract,
+  });
+
+  const { data: deprecationInfo } = useQuery({
+    queryKey: ["contract-deprecation", id],
+    queryFn: () => api.getDeprecationInfo(id),
     enabled: !!contract,
   });
 
@@ -81,6 +88,9 @@ function ContractDetailsContent() {
       {maintenanceStatus?.is_maintenance && maintenanceStatus.current_window && (
         <MaintenanceBanner window={maintenanceStatus.current_window} />
       )}
+
+      {/* Deprecation Banner */}
+      {deprecationInfo && <DeprecationBanner info={deprecationInfo} />}
 
       {/* Header */}
       <div className="mb-12">

--- a/frontend/components/DeprecationBanner.tsx
+++ b/frontend/components/DeprecationBanner.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { DeprecationInfo } from '@/lib/api';
+import { AlertTriangle, ArrowUpRight } from 'lucide-react';
+
+function formatDate(value?: string | null) {
+  if (!value) return '—';
+  return new Date(value).toLocaleDateString();
+}
+
+function formatCountdown(days?: number | null) {
+  if (days === null || days === undefined) return '—';
+  if (days <= 0) return '0 days';
+  return `${days} days`;
+}
+
+type Props = {
+  info: DeprecationInfo;
+};
+
+export default function DeprecationBanner({ info }: Props) {
+  if (info.status === 'active') return null;
+
+  const isRetired = info.status === 'retired';
+  const badge = isRetired ? 'Retired' : 'Deprecated';
+  const headline = isRetired
+    ? 'This contract has been retired.'
+    : 'This contract is deprecated and scheduled for retirement.';
+
+  return (
+    <div className="rounded-xl border border-amber-200 bg-amber-50 text-amber-900 px-5 py-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <div className="mt-1">
+            <AlertTriangle className="h-5 w-5" />
+          </div>
+          <div>
+            <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
+              <span className="rounded-full bg-amber-200 px-2 py-1">{badge}</span>
+              <span>Retires {formatDate(info.retirement_at)}</span>
+            </div>
+            <h3 className="text-base font-semibold mt-2">{headline}</h3>
+            {info.notes ? (
+              <p className="text-sm mt-1 text-amber-800">{info.notes}</p>
+            ) : null}
+            <div className="mt-3 text-sm text-amber-800 flex flex-wrap gap-4">
+              <span>Countdown: {formatCountdown(info.days_remaining)}</span>
+              <span>Dependents notified: {info.dependents_notified}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          {info.replacement_contract_id ? (
+            <Link
+              href={`/contracts/${info.replacement_contract_id}`}
+              className="inline-flex items-center gap-2 rounded-md bg-amber-200 px-3 py-2 text-sm font-medium text-amber-900 hover:bg-amber-300 transition-colors"
+            >
+              View replacement
+              <ArrowUpRight className="h-4 w-4" />
+            </Link>
+          ) : null}
+          {info.migration_guide_url ? (
+            <a
+              href={info.migration_guide_url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-md border border-amber-300 px-3 py-2 text-sm font-medium text-amber-900 hover:bg-amber-100 transition-colors"
+            >
+              Migration guide
+              <ArrowUpRight className="h-4 w-4" />
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -107,6 +107,20 @@ export interface PublishRequest {
   publisher_address: string;
 }
 
+export type DeprecationStatus = 'active' | 'deprecated' | 'retired';
+
+export interface DeprecationInfo {
+  contract_id: string;
+  status: DeprecationStatus;
+  deprecated_at?: string | null;
+  retirement_at?: string | null;
+  replacement_contract_id?: string | null;
+  migration_guide_url?: string | null;
+  notes?: string | null;
+  days_remaining?: number | null;
+  dependents_notified: number;
+}
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 const USE_MOCKS = process.env.NEXT_PUBLIC_USE_MOCKS === "true";
 
@@ -340,6 +354,26 @@ export const api = {
   async getContractHealth(id: string): Promise<ContractHealth> {
     const response = await fetch(`${API_URL}/api/contracts/${id}/health`);
     if (!response.ok) throw new Error("Failed to fetch contract health");
+    return response.json();
+  },
+
+  async getDeprecationInfo(id: string): Promise<DeprecationInfo> {
+    if (USE_MOCKS) {
+      return Promise.resolve({
+        contract_id: id,
+        status: 'deprecated',
+        deprecated_at: new Date(Date.now() - 86400000 * 7).toISOString(),
+        retirement_at: new Date(Date.now() + 86400000 * 30).toISOString(),
+        replacement_contract_id: 'c2',
+        migration_guide_url: 'https://example.com/migration',
+        notes: 'This contract is being retired. Migrate to the new liquidity pool contract.',
+        days_remaining: 30,
+        dependents_notified: 4,
+      });
+    }
+
+    const response = await fetch(`${API_URL}/api/contracts/${id}/deprecation-info`);
+    if (!response.ok) throw new Error('Failed to fetch deprecation info');
     return response.json();
   },
 


### PR DESCRIPTION
### What changed

  - Added contract deprecation schedules with retirement dates and migration metadata.
  - Added deprecation notifications for dependent contracts.
  - Added API endpoints for marking and fetching deprecation info.
  - Added frontend warning banner with countdown and migration guidance.

  ### Why

  - Helps phase out old contracts safely and guide migrations (Issue #65).

  ### How to test

  1. Run migrations:
      - cd backend
      - sqlx migrate run --source ../database/migrations
  2. Mark a contract deprecated:
      - POST /api/contracts/<id>/deprecate with retirement_at and either replacement_contract_id or migration_guide_url.
  3. Fetch deprecation info:
      - GET /api/contracts/<id>/deprecation-info
  4. Open contract detail page to see warning banner and migration path.

  ### Acceptance criteria

  - Deprecated contracts show clear warnings: ✅
  - Migration suggestions are helpful: ✅ (replacement + guide link)
  - Dependent contracts are notified: ✅ (notification records)
  - Deprecation date enforced: ✅ (rejects past retirement dates)
  - No users left stranded on retirement: ✅ (requires migration path)

### Fixes

#65 