### PR TITLE
feat(frontend): add blurhash-based image placeholders

### DIFF
--- a/frontend/components/ExampleCard.tsx
+++ b/frontend/components/ExampleCard.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
 import { ContractExample, api } from '@/lib/api';
+import { generateBlurHashPlaceholder, generateSolidPlaceholder } from '@/lib/images';
 import CodeRunner from './CodeRunner';
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
 
@@ -9,14 +11,55 @@ interface ExampleCardProps {
   example: ContractExample;
 }
 
+type ExampleWithOptionalImage = ContractExample & {
+  repo_avatar_url?: string;
+  repo_avatar_blurhash?: string;
+  repo_avatar_placeholder_color?: string;
+  thumbnail_url?: string;
+  thumbnail_blurhash?: string;
+  thumbnail_placeholder_color?: string;
+};
+
 export default function ExampleCard({ example }: ExampleCardProps) {
   const [activeTab, setActiveTab] = useState<'js' | 'rust'>('js');
   const [rating, setRating] = useState<number | null>(null); // Just for UI feedback
   const [isRating, setIsRating] = useState(false);
+  const [avatarPlaceholder, setAvatarPlaceholder] = useState<string | null>(null);
+  const [avatarLoadError, setAvatarLoadError] = useState(false);
 
   // If no JS code, default to Rust
   const effectiveTab = example.code_js ? activeTab : 'rust';
   const hasMultipleLangs = !!(example.code_js && example.code_rust);
+  const exampleWithImage = example as ExampleWithOptionalImage;
+  const avatarSrc = exampleWithImage.repo_avatar_url ?? exampleWithImage.thumbnail_url;
+  const avatarBlurHash =
+    exampleWithImage.repo_avatar_blurhash ?? exampleWithImage.thumbnail_blurhash;
+  const avatarFallbackColor =
+    exampleWithImage.repo_avatar_placeholder_color ??
+    exampleWithImage.thumbnail_placeholder_color ??
+    '#e5e7eb';
+
+  useEffect(() => {
+    setAvatarLoadError(false);
+
+    if (!avatarSrc) {
+      setAvatarPlaceholder(null);
+      return;
+    }
+
+    if (avatarBlurHash) {
+      setAvatarPlaceholder(
+        generateBlurHashPlaceholder(avatarBlurHash, {
+          width: 24,
+          height: 24,
+          fallbackColor: avatarFallbackColor,
+        })
+      );
+      return;
+    }
+
+    setAvatarPlaceholder(generateSolidPlaceholder(avatarFallbackColor));
+  }, [avatarSrc, avatarBlurHash, avatarFallbackColor]);
 
   const handleRate = async (val: number) => {
     try {
@@ -38,17 +81,37 @@ export default function ExampleCard({ example }: ExampleCardProps) {
     <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
       <div className="p-6 border-b border-gray-200 dark:border-gray-800">
         <div className="flex items-start justify-between mb-4">
-          <div>
-            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
-              {example.title}
-            </h3>
-            <span className={`inline-block px-2 py-1 rounded text-xs font-medium uppercase tracking-wide ${
-              example.category === 'basic' ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' :
-              example.category === 'advanced' ? 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400' :
-              'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400'
-            }`}>
-              {example.category}
-            </span>
+          <div className="flex items-start gap-3 min-w-0">
+            {avatarSrc && !avatarLoadError ? (
+              <div
+                className="relative h-12 w-12 shrink-0 overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800"
+                style={{ backgroundColor: avatarFallbackColor }}
+              >
+                <Image
+                  src={avatarSrc}
+                  alt={`${example.title} repository avatar`}
+                  fill
+                  className="object-cover"
+                  sizes="48px"
+                  onError={() => setAvatarLoadError(true)}
+                  placeholder={avatarPlaceholder ? 'blur' : 'empty'}
+                  blurDataURL={avatarPlaceholder ?? undefined}
+                />
+              </div>
+            ) : null}
+
+            <div className="min-w-0">
+              <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2 truncate">
+                {example.title}
+              </h3>
+              <span className={`inline-block px-2 py-1 rounded text-xs font-medium uppercase tracking-wide ${
+                example.category === 'basic' ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' :
+                example.category === 'advanced' ? 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400' :
+                'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400'
+              }`}>
+                {example.category}
+              </span>
+            </div>
           </div>
           
           <div className="flex items-center gap-2">

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@stellar/stellar-sdk": "^14.4.3",
     "@tanstack/react-query": "^5.90.19",
+    "blurhash": "^2.0.5",
     "d3": "^7.9.0",
     "lucide-react": "^0.562.0",
     "next": "16.1.4",


### PR DESCRIPTION
Implements frontend blurhash-based image placeholders with solid-color fallback for better LQIP behavior.

  - Adds blurhash dependency in frontend/package.json
  - Adds blurhash utilities in frontend/lib/images.ts:
      - decode blurhash -> next/image placeholder data URL
      - generate blurhash + fallback color metadata during upload (client-side helper)
      - benchmark helper to compare blurhash vs solid-color placeholder generation cost
      - solid-color fallback when blurhash is missing/invalid
  - Updates frontend/components/ExampleCard.tsx to optionally render repo/avatar images using blurhash placeholders with fallback support

  Notes:

  - This repo state does not currently have an image upload pipeline or DB schema/API fields for persisting blurhash metadata, so backend storage/
    upload wiring is not included.
  - Changes are backward-compatible and only apply when optional image metadata fields are provided.

  Validation:

  - pnpm lint / full typecheck could not run because frontend/node_modules is not installed in the workspace.

  Closes #232