### PR TITLE
refactor: Remove unused `std::io::Write` and `tempfile::NamedTempFile…

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1257,8 +1257,6 @@ pub async fn scan_deps(
 #[cfg(test)]
 mod tests_network {
     use super::*;
-    use std::io::Write;
-    use tempfile::NamedTempFile;
 
     #[test]
     fn test_network_parsing() {


### PR DESCRIPTION
Summary
Removed unused imports from CLI modules to improve compilation time and code clarity.

Changes
- Ran `cargo fix --allow-dirty`
- Manually verified remaining imports are used
- Ensured no unused import warnings via clippy

Closes #216 