### PR TITLE
Fix: contract existence checks to avoid fragile contract deserialization (#331)

### DIFF
--- a/backend/api/src/health_monitor.rs
+++ b/backend/api/src/health_monitor.rs
@@ -269,6 +269,7 @@ mod tests {
             tags: vec![],
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            health_score: 0,
             is_maintenance: false,
             logical_id: None,
             network_configs: None,


### PR DESCRIPTION

## Overview

Fixes runtime query failures caused by using full `Contract` deserialization for lightweight existence checks in `backend/api/src/handlers.rs`. The issue caused endpoints to fail with 500s when query shape and expected struct fields diverged. This PR replaces fragile patterns with explicit existence/network helpers and keeps 404 behavior consistent.

Closes #331
## Changes

### API Handlers

- **[MODIFY]** [backend/api/src/handlers.rs](/c:/Users/pd307/Pictures/opensource/Soroban-Registry/backend/api/src/handlers.rs)
  - Added `ensure_contract_exists(...)` helper using:
    - `SELECT EXISTS(SELECT 1 FROM contracts WHERE id = $1)`
  - Added `fetch_contract_network(...)` helper using:
    - `SELECT network FROM contracts WHERE id = $1`
  - Updated affected handlers to avoid unnecessary full `Contract` loads:
    - `get_contract_analytics` (existence check only)
    - `get_contract_audit_log` (existence check only)
    - `get_contract_interactions` (existence check only)
    - `post_contract_interaction` (needs only default network fallback)
    - `post_contract_interactions_batch` (needs only default network fallback)
  - Preserved `ContractNotFound` behavior with consistent 404 responses.

### Test Compatibility

- **[MODIFY]** [backend/api/src/health_monitor.rs](/c:/Users/pd307/Pictures/opensource/Soroban-Registry/backend/api/src/health_monitor.rs)
  - Updated test fixture to include required `health_score` field on `shared::Contract` initializer.

## How to Run Tests

From `backend`:

```bash
cargo check -p api

# Focused passing test in current environment:
cargo test -p api --lib test_http_request_counter -- --nocapture
```

## Verification Results

| Requirement | Status |
|---|---|
| Replace fragile contract existence checks | Done |
| Avoid deserializing full `Contract` when not needed | Done |
| Keep 404 behavior for missing contract | Done |
| `cargo check -p api` succeeds | Done |
| Focused test run succeeds | Done |

## Verification Evidence

- `cargo check -p api` completed successfully.
- `cargo test -p api --lib test_http_request_counter -- --nocapture` passed (1/1).

<img width="796" height="165" alt="image" src="https://github.com/user-attachments/assets/f1247f97-61f3-4679-8ebe-016653aa593e" />
