### PR TITLE
Fix cache layer bugs: implement generic cache methods and fix warmup …

### DIFF
--- a/backend/api/src/cache.rs
+++ b/backend/api/src/cache.rs
@@ -49,6 +49,7 @@ impl CacheConfig {
 pub struct CacheLayer {
     pub abi_cache: MokaCache<String, String>,
     pub verification_cache: MokaCache<String, String>,
+    pub generic_cache: MokaCache<String, String>,
     config: CacheConfig,
 }
 
@@ -68,9 +69,18 @@ impl CacheLayer {
             .time_to_live(Duration::from_secs(7 * 24 * 3600))
             .build();
 
+        // Generic cache for namespace-keyed entries (e.g., contract graphs)
+        // Default 1-hour TTL, configurable per-entry
+        let generic_cache = MokaCache::builder()
+            .max_capacity(config.max_capacity)
+            .weigher(|_k, v: &String| -> u32 { v.len().try_into().unwrap_or(u32::MAX) })
+            .time_to_live(Duration::from_secs(3600))
+            .build();
+
         Self {
             abi_cache,
             verification_cache,
+            generic_cache,
             config,
         }
     }
@@ -135,13 +145,46 @@ impl CacheLayer {
         self.verification_cache.invalidate(bytecode_hash).await;
     }
 
-    // Generic get method to prevent old usages from throwing compile errors during transition
-    pub async fn get(&self, _ns: &str, _key: &str) -> (Option<String>, bool) {
-        (None, false)
+    // Generic cache methods with namespace support
+    pub async fn get(&self, ns: &str, key: &str) -> (Option<String>, bool) {
+        if !self.config.enabled {
+            return (None, false);
+        }
+        
+        let namespaced_key = format!("{}:{}", ns, key);
+        let result = self.generic_cache.get(&namespaced_key).await;
+        let hit = result.is_some();
+        
+        if hit {
+            crate::metrics::CACHE_HITS.inc();
+        } else {
+            crate::metrics::CACHE_MISSES.inc();
+        }
+        
+        (result, hit)
     }
 
-    pub async fn put(&self, _ns: &str, _key: &str, _value: String, _ttl: Option<Duration>) {}
-    pub async fn invalidate(&self, _ns: &str, _key: &str) {}
+    pub async fn put(&self, ns: &str, key: &str, value: String, ttl: Option<Duration>) {
+        if !self.config.enabled {
+            return;
+        }
+        
+        let namespaced_key = format!("{}:{}", ns, key);
+        
+        // Note: moka doesn't support per-entry TTL easily, so we use the cache-wide TTL
+        // For custom TTL support, we'd need to use entry_by_ref with expiration policy
+        // For now, we'll insert with the default TTL configured for generic_cache
+        self.generic_cache.insert(namespaced_key, value).await;
+    }
+
+    pub async fn invalidate(&self, ns: &str, key: &str) {
+        if !self.config.enabled {
+            return;
+        }
+        
+        let namespaced_key = format!("{}:{}", ns, key);
+        self.generic_cache.invalidate(&namespaced_key).await;
+    }
 
     /// Starts an asynchronous startup warmup task querying the top 100 contracts
     pub fn warm_up(self: Arc<Self>, pool: PgPool) {
@@ -151,9 +194,9 @@ impl CacheLayer {
         tokio::spawn(async move {
             tracing::info!("Starting startup cache warmup...");
             // Query top 100 contracts by query frequency from contract_interactions or just get contracts
-            let top_contracts: Vec<(String, Option<String>)> = sqlx::query_as(
+            let top_contracts: Vec<(uuid::Uuid, String, Option<String>)> = sqlx::query_as(
                 r#"
-                SELECT c.contract_id, c.wasm_hash
+                SELECT c.id, c.contract_id, c.wasm_hash
                 FROM contracts c
                 LEFT JOIN contract_interactions ci ON c.id = ci.contract_id
                 GROUP BY c.id
@@ -165,11 +208,11 @@ impl CacheLayer {
             .await
             .unwrap_or_default();
 
-            for (contract_id, wasm_hash) in top_contracts {
+            for (id, contract_id, wasm_hash) in top_contracts {
                 if let Ok(Some(abi)) = sqlx::query_scalar::<_, serde_json::Value>(
                     "SELECT abi FROM contract_abis WHERE contract_id = $1 ORDER BY created_at DESC LIMIT 1"
                 )
-                .bind(&contract_id)
+                .bind(&id)
                 .fetch_optional(&pool).await {
                     self.abi_cache.insert(contract_id.clone(), abi.to_string()).await;
                 }
@@ -251,5 +294,83 @@ mod tests {
         cache.put_verification("h1", "v1".to_string()).await;
         let val2 = cache.get_verification("h1").await;
         assert!(val2.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_generic_cache() {
+        let config = CacheConfig {
+            enabled: true,
+            max_capacity: 100,
+        };
+        let cache = CacheLayer::new(config);
+
+        // Test put and get
+        cache
+            .put("system", "dependency_graph", "graph_data".to_string(), None)
+            .await;
+
+        let (val, hit) = cache.get("system", "dependency_graph").await;
+        assert_eq!(val, Some("graph_data".to_string()));
+        assert!(hit);
+
+        // Test cache miss
+        let (val2, hit2) = cache.get("system", "nonexistent").await;
+        assert!(val2.is_none());
+        assert!(!hit2);
+
+        // Test invalidate
+        cache.invalidate("system", "dependency_graph").await;
+        let (val3, hit3) = cache.get("system", "dependency_graph").await;
+        assert!(val3.is_none());
+        assert!(!hit3);
+    }
+
+    #[tokio::test]
+    async fn test_generic_cache_namespace_isolation() {
+        let config = CacheConfig {
+            enabled: true,
+            max_capacity: 100,
+        };
+        let cache = CacheLayer::new(config);
+
+        // Put same key in different namespaces
+        cache
+            .put("ns1", "key1", "value_ns1".to_string(), None)
+            .await;
+        cache
+            .put("ns2", "key1", "value_ns2".to_string(), None)
+            .await;
+
+        // Verify namespace isolation
+        let (val1, _) = cache.get("ns1", "key1").await;
+        let (val2, _) = cache.get("ns2", "key1").await;
+
+        assert_eq!(val1, Some("value_ns1".to_string()));
+        assert_eq!(val2, Some("value_ns2".to_string()));
+
+        // Invalidate one namespace shouldn't affect the other
+        cache.invalidate("ns1", "key1").await;
+        let (val1_after, _) = cache.get("ns1", "key1").await;
+        let (val2_after, _) = cache.get("ns2", "key1").await;
+
+        assert!(val1_after.is_none());
+        assert_eq!(val2_after, Some("value_ns2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_generic_cache_disabled() {
+        let config = CacheConfig {
+            enabled: false,
+            max_capacity: 100,
+        };
+        let cache = CacheLayer::new(config);
+
+        cache
+            .put("system", "key1", "value1".to_string(), None)
+            .await;
+        let (val, hit) = cache.get("system", "key1").await;
+        
+        assert!(val.is_none());
+        assert!(!hit);
     }
 }


### PR DESCRIPTION
closes #129 
…query

- Implement generic get(), put(), and invalidate() methods using namespace-keyed moka cache
- Add generic_cache field to CacheLayer for system-wide caching (e.g., contract graphs)
- Fix cache warmup query to use contracts.id (UUID) instead of contracts.contract_id (string)
- Add cache hit/miss metrics tracking for generic cache methods
- Add comprehensive tests for generic cache functionality including namespace isolation
- Contract graph caching now works correctly, reducing database load