### PR TITLE
feat(frontend): Add aria-label attributes to search inputs for accessibility (#350)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,12 +5,13 @@ import { api } from '@/lib/api';
 import ContractCard from '@/components/ContractCard';
 import { Search, Package, CheckCircle, Users, ArrowRight, Sparkles } from 'lucide-react';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAnalytics } from '@/hooks/useAnalytics';
 import Navbar from '@/components/Navbar';
 
 export default function Home() {
   const [searchQuery, setSearchQuery] = useState('');
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const { logEvent } = useAnalytics();
 
   const { data: stats } = useQuery({
@@ -33,6 +34,30 @@ export default function Home() {
       window.location.href = `/contracts?query=${encodeURIComponent(searchQuery)}`;
     }
   };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isSlashShortcut = event.key === '/' || event.code === 'Slash';
+      if (!isSlashShortcut || event.ctrlKey || event.metaKey || event.altKey) return;
+
+      const activeElement = document.activeElement as HTMLElement | null;
+      const isTypingField = Boolean(
+        activeElement &&
+        (activeElement.tagName === 'INPUT' ||
+          activeElement.tagName === 'TEXTAREA' ||
+          activeElement.tagName === 'SELECT' ||
+          activeElement.isContentEditable),
+      );
+
+      if (isTypingField) return;
+
+      event.preventDefault();
+      searchInputRef.current?.focus();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -66,10 +91,13 @@ export default function Home() {
               <div className="relative">
                 <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
                 <input
+                  ref={searchInputRef}
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search contracts by name, category, or tag..."
+                  aria-label="Search contracts"
+                  aria-keyshortcuts="/"
                   className="w-full pl-12 pr-4 py-4 rounded-xl border border-border bg-background text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary shadow-lg"
                 />
                 <button

--- a/frontend/components/InteractionHistorySection.tsx
+++ b/frontend/components/InteractionHistorySection.tsx
@@ -99,7 +99,7 @@ export default function InteractionHistorySection({ contractId }: InteractionHis
                         borderRadius: '8px',
                       }}
                       labelFormatter={(v) => `Date: ${v}`}
-                      formatter={(value: any) => [value, 'Interactions']}
+                      formatter={(value: unknown) => [String(value), 'Interactions']}
                     />
                     <Bar dataKey="count" fill="rgb(59, 130, 246)" radius={[4, 4, 0, 0]} />
                   </BarChart>

--- a/frontend/components/contracts/SearchBar.tsx
+++ b/frontend/components/contracts/SearchBar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { Search, X } from 'lucide-react';
 
 interface SearchBarProps {
@@ -13,14 +14,43 @@ export function SearchBar({
   onClear,
   placeholder = 'Search contracts...',
 }: SearchBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isSlashShortcut = event.key === '/' || event.code === 'Slash';
+      if (!isSlashShortcut || event.ctrlKey || event.metaKey || event.altKey) return;
+
+      const activeElement = document.activeElement as HTMLElement | null;
+      const isTypingField = Boolean(
+        activeElement &&
+        (activeElement.tagName === 'INPUT' ||
+          activeElement.tagName === 'TEXTAREA' ||
+          activeElement.tagName === 'SELECT' ||
+          activeElement.isContentEditable),
+      );
+
+      if (isTypingField) return;
+
+      event.preventDefault();
+      inputRef.current?.focus();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
   return (
     <div className="relative">
       <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
       <input
+        ref={inputRef}
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        aria-label="Search contracts"
+        aria-keyshortcuts="/"
         className="w-full pl-12 pr-12 py-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
       />
       {value && (

--- a/frontend/components/publisher/PublisherContractsList.tsx
+++ b/frontend/components/publisher/PublisherContractsList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useRef, useEffect } from "react";
 import { ContractSummary } from "@/types/publisher";
 import { Tag } from "@/types/tag";
 import TagAutocomplete from "@/components/tags/TagAutocomplete";
@@ -15,6 +15,7 @@ type FilterStatus = "all" | "verified" | "failed" | "pending";
 export function PublisherContractsList({ contracts }: PublisherContractsListProps) {
   const [statusFilter, setStatusFilter] = useState<FilterStatus>("all");
   const [searchTerm, setSearchTerm] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const filteredContracts = useMemo(() => {
     return contracts
@@ -26,6 +27,30 @@ export function PublisherContractsList({ contracts }: PublisherContractsListProp
       })
       .sort((a, b) => new Date(b.deployedAt).getTime() - new Date(a.deployedAt).getTime());
   }, [contracts, statusFilter, searchTerm]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isSlashShortcut = event.key === "/" || event.code === "Slash";
+      if (!isSlashShortcut || event.ctrlKey || event.metaKey || event.altKey) return;
+
+      const activeElement = document.activeElement as HTMLElement | null;
+      const isTypingField = Boolean(
+        activeElement &&
+          (activeElement.tagName === "INPUT" ||
+            activeElement.tagName === "TEXTAREA" ||
+            activeElement.tagName === "SELECT" ||
+            activeElement.isContentEditable),
+      );
+
+      if (isTypingField) return;
+
+      event.preventDefault();
+      searchInputRef.current?.focus();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
@@ -41,10 +66,13 @@ export function PublisherContractsList({ contracts }: PublisherContractsListProp
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
             <input
+              ref={searchInputRef}
               type="text"
               placeholder="Search contracts..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
+              aria-label="Search contracts"
+              aria-keyshortcuts="/"
               className="pl-9 pr-4 py-2 w-full sm:w-64 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition-all"
             />
           </div>


### PR DESCRIPTION


## Overview
This PR improves frontend accessibility by adding explicit `aria-label` attributes to contract search inputs so screen readers announce meaningful context (`"Search contracts"`) instead of generic `"text input"`.

It also includes the keyboard shortcut bonus: pressing `/` focuses the primary search input on supported pages/components.

## Related Issue
Closes #350

## Changes

### ♿ Accessibility Updates
- **[MODIFY]** `frontend/app/page.tsx`
  - Added `aria-label="Search contracts"` to homepage hero search input.
  - Added `/` keyboard shortcut focus support.
- **[MODIFY]** `frontend/components/contracts/SearchBar.tsx`
  - Added `aria-label="Search contracts"` to contracts page search input.
  - Added `/` keyboard shortcut focus support.
- **[MODIFY]** `frontend/components/publisher/PublisherContractsList.tsx`
  - Added `aria-label="Search contracts"` to publisher contracts search input.
  - Added `/` keyboard shortcut focus support.

### ⌨️ Keyboard Shortcut Notes
- Shortcut only triggers when user is **not already typing** in an input/textarea/select/contenteditable.
- Uses both `event.key === '/'` and `event.code === 'Slash'` for better keyboard-layout reliability.
- Added `aria-keyshortcuts="/"` to the updated search inputs.

### 🧪 Supporting Lint Fixes
- **[MODIFY]** `frontend/__tests__/lib/api.test.ts`
  - Removed `any` usage and `require()` import patterns causing lint errors.
- **[MODIFY]** `frontend/components/InteractionHistorySection.tsx`
  - Replaced `any` with safer typing in chart formatter.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Homepage search input has `aria-label` | ✅ |
| Contracts page search input has `aria-label` | ✅ |
| Publisher page search input has `aria-label` | ✅ |
| Screen-reader label is meaningful (`Search contracts`) | ✅ |
| `/` keyboard shortcut focuses search input (bonus) | ✅ |
| Lint passes with 0 errors | ✅ |

## How to Test

```bash
# 1. Install deps (if needed)
pnpm -C frontend install

# 2. Start frontend
pnpm -C frontend dev

# 3. Open pages
# Homepage
http://localhost:3000/
# Contracts
http://localhost:3000/contracts
# Publisher (open any publisher from list)
http://localhost:3000/publishers
```

Manual checks:
1. Confirm each search input has `aria-label="Search contracts"` in DevTools.
2. Click empty page space, press `/`, confirm search input receives focus.
3. Confirm shortcut does not hijack typing when cursor is already inside a form field.

