### PR TITLE
fix(frontend): Use Next.js router.push instead of window.location.href for homepage search

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,11 +7,13 @@ import ContractCardSkeleton from '@/components/ContractCardSkeleton';
 import LoadingSkeleton from '@/components/LoadingSkeleton';
 import { Search, Package, CheckCircle, Users, ArrowRight, Sparkles } from 'lucide-react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { useAnalytics } from '@/hooks/useAnalytics';
 import Navbar from '@/components/Navbar';
 
 export default function Home() {
+  const router = useRouter();
   const [searchQuery, setSearchQuery] = useState('');
   const searchInputRef = useRef<HTMLInputElement>(null);
   const { logEvent } = useAnalytics();
@@ -33,7 +35,7 @@ export default function Home() {
         keyword: searchQuery.trim(),
         source: 'home_hero',
       });
-      window.location.href = `/contracts?query=${encodeURIComponent(searchQuery)}`;
+      router.push(`/contracts?query=${encodeURIComponent(searchQuery)}`);
     }
   };
 


### PR DESCRIPTION
# Description

This Pull Request addresses an issue where searching from the homepage using the hero section search bar would inadvertently wipe the React Query cache and force a hard browser refresh due to improper navigation handling.

## Changes Made
* **Router Integration**: Imported Next.js's native `useRouter` framework router from `next/navigation` into the `app/page.tsx` home component.
* **Navigation Swap**: Replaced the previous `window.location.href` reassignment inside `handleSearch` with `router.push()`, allowing Next.js to intercept the routing event client-side and dynamically push to the `/contracts` page without destroying state or triggering a white flash.

## Related Issues
Closes #347 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change to internal logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
