### PR TITLE
fix: Fix AppState Missing auth_mgr and resource_mgr Fields

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +160,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "regex",
+ "rust_decimal",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -167,9 +174,20 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "utoipa 4.2.3",
+ "utoipa-swagger-ui",
  "uuid",
  "verifier",
  "wasmparser 0.224.1",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -617,6 +635,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +741,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2163a0e204a148662b6b6816d4b5d5668a5f2f8df498ccbd5cd0e864e78fecba"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -850,6 +888,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -1687,6 +1735,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,6 +2134,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2459,6 +2551,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2687,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2719,6 +2854,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "utoipa 4.2.3",
  "uuid",
 ]
 
@@ -2747,6 +2883,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simdutf8"
@@ -3546,6 +3688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3625,6 +3773,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen 4.3.1",
+]
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen 5.4.0",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4b5ac679cc6dfc5ea3f2823b0291c777750ffd5e13b21137e0f7ac0e8f9617"
+dependencies = [
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa 5.4.0",
+ "zip",
+]
+
+[[package]]
 name = "uuid"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3670,6 +3885,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -3862,6 +4087,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4370,7 +4604,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -76,3 +76,10 @@ syn = { version = "2.0", features = ["full", "visit"] }
 
 # WASM validation
 wasmparser = "0.224"
+
+# Decimal
+rust_decimal = "1.35"
+
+# OpenAPI
+utoipa = { version = "4", features = ["axum_extras", "chrono", "uuid"] }
+utoipa-swagger-ui = { version = "8", features = ["axum"] }

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[features]
+default = []
+openapi = []
+
 [[bin]]
 name = "api"
 path = "src/main.rs"
@@ -49,3 +53,6 @@ regex = "1.10"
 lazy_static = "1.4"
 wasmparser = { workspace = true }
 contract_abi = { path = "../contract_abi" }
+rust_decimal = { workspace = true }
+utoipa = { workspace = true }
+utoipa-swagger-ui = { workspace = true }

--- a/backend/api/src/auth_handlers.rs
+++ b/backend/api/src/auth_handlers.rs
@@ -87,3 +87,97 @@ pub async fn verify_challenge(
         }),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::AuthManager;
+    use crate::cache::{CacheConfig, CacheLayer};
+    use crate::health_monitor::HealthMonitorStatus;
+    use crate::resource_tracking::ResourceManager;
+    use axum::extract::Query;
+    use ed25519_dalek::{Signer, SigningKey};
+    use prometheus::Registry;
+    use std::sync::{Arc, RwLock};
+    use std::time::Instant;
+
+    fn test_app_state() -> AppState {
+        let db = sqlx::pool::PoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://localhost/test")
+            .expect("lazy pool");
+        let registry = Registry::new();
+        let auth_mgr = Arc::new(RwLock::new(AuthManager::new(
+            "a".repeat(32), // MIN_JWT_SECRET_LEN
+        )));
+        let resource_mgr = Arc::new(RwLock::new(ResourceManager::new()));
+        AppState {
+            db,
+            started_at: Instant::now(),
+            cache: Arc::new(CacheLayer::new(CacheConfig::default())),
+            registry,
+            is_shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            health_monitor_status: HealthMonitorStatus::default(),
+            auth_mgr,
+            resource_mgr,
+        }
+    }
+
+    #[tokio::test]
+    async fn challenge_returns_nonce_for_address() {
+        let state = test_app_state();
+        let query = ChallengeQuery {
+            address: "GABCDEF".to_string(),
+        };
+        let result = get_challenge(State(state.clone()), Query(query)).await;
+        assert!(result.is_ok());
+        let Json(resp) = result.unwrap();
+        assert_eq!(resp.address, "GABCDEF");
+        assert!(!resp.nonce.is_empty());
+        assert_eq!(resp.expires_in_seconds, 300);
+    }
+
+    #[tokio::test]
+    async fn challenge_rejects_empty_address() {
+        let state = test_app_state();
+        let query = ChallengeQuery {
+            address: "   ".to_string(),
+        };
+        let result = get_challenge(State(state), Query(query)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn verify_issues_jwt_when_signature_valid() {
+        let state = test_app_state();
+        let key = SigningKey::from_bytes(&[1u8; 32]);
+        let address_hex = hex::encode(key.verifying_key().as_bytes());
+
+        let query = ChallengeQuery {
+            address: address_hex.clone(),
+        };
+        let challenge_result = get_challenge(State(state.clone()), Query(query)).await;
+        assert!(challenge_result.is_ok());
+        let Json(challenge_resp) = challenge_result.unwrap();
+        let nonce = challenge_resp.nonce;
+
+        let sig = key.sign(nonce.as_bytes());
+        let signature_hex = hex::encode(sig.to_bytes());
+
+        let payload = VerifyRequest {
+            address: address_hex.clone(),
+            public_key: address_hex.clone(),
+            signature: signature_hex,
+        };
+        let result = verify_challenge(State(state.clone()), Json(payload)).await;
+        assert!(result.is_ok(), "{:?}", result.err());
+        let (status, Json(resp)) = result.unwrap();
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(resp.token_type, "Bearer");
+        assert!(!resp.token.is_empty());
+
+        let mgr = state.auth_mgr.read().unwrap();
+        let claims = mgr.validate_jwt(&resp.token).expect("valid JWT");
+        assert_eq!(claims.sub, address_hex);
+    }
+}

--- a/backend/api/src/cache.rs
+++ b/backend/api/src/cache.rs
@@ -212,7 +212,7 @@ impl CacheLayer {
                 if let Ok(Some(abi)) = sqlx::query_scalar::<_, serde_json::Value>(
                     "SELECT abi FROM contract_abis WHERE contract_id = $1 ORDER BY created_at DESC LIMIT 1"
                 )
-                .bind(&id)
+                .bind(id)
                 .fetch_optional(&pool).await {
                     self.abi_cache.insert(contract_id.clone(), abi.to_string()).await;
                 }

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 /// Query params for GET /contracts/:id (Issue #43)
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
 pub struct GetContractQuery {
     pub network: Option<Network>,
 }
@@ -156,7 +156,6 @@ async fn write_contract_audit_log(
     Ok(())
 }
 
-openapi-doc
 #[utoipa::path(
     get,
     path = "/health",
@@ -322,7 +321,6 @@ async fn record_contract_interaction(
     Ok(interaction_id)
 }
 
-main
 struct ContractInteractionInsert<'a> {
     contract_id: Uuid,
     account: Option<&'a str>,
@@ -700,7 +698,6 @@ pub async fn get_contract_versions(
     Ok(Json(versions))
 }
 
-openapi-doc
 #[utoipa::path(
     post,
     path = "/api/contracts/{id}/versions",
@@ -785,7 +782,6 @@ pub async fn get_contract_changelog(
     }))
 }
 
-main
 pub async fn create_contract_version(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -1372,7 +1368,7 @@ pub async fn get_publisher_contracts(
     })?;
 
     // Validate and cap limit (max 100)
-    let limit = query.limit.max(1).min(100);
+    let limit = query.limit.clamp(1, 100);
     let offset = query.offset.max(0);
 
     // Get total count
@@ -1770,7 +1766,6 @@ pub async fn get_impact_analysis(
     }))
 }
 
-openapi-doc
 #[utoipa::path(
     get,
     path = "/api/contracts/trending",
@@ -1779,8 +1774,6 @@ openapi-doc
     ),
     tag = "Contracts"
 )]
-pub async fn get_trending_contracts() -> impl IntoResponse {
-    Json(json!({"trending": []}))
 pub async fn get_trending_contracts(
     State(state): State<AppState>,
     Query(params): Query<TrendingParams>,
@@ -1883,7 +1876,6 @@ pub async fn get_trending_contracts(
         "limit": limit,
         "trending": trending
     })))
-main
 }
 
 #[utoipa::path(

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code, unused)]
 
+pub mod auth;
 pub mod backup_handlers;
 pub mod backup_routes;
 pub mod cache;
@@ -11,4 +12,5 @@ pub mod notification_handlers;
 pub mod notification_routes;
 pub mod post_incident_handlers;
 pub mod post_incident_routes;
+pub mod resource_tracking;
 pub mod state;

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -4,6 +4,7 @@ mod ab_test_handlers;
 mod aggregation;
 mod analytics;
 mod auth;
+mod auth_handlers;
 mod batch_verify_handlers;
 mod breaking_changes;
 mod cache;
@@ -25,11 +26,15 @@ mod health_tests;
 mod metrics;
 mod metrics_handler;
 mod migration_handlers;
+#[cfg(feature = "openapi")]
+mod openapi;
 mod performance_handlers;
 mod rate_limit;
 mod release_notes_handlers;
 mod release_notes_routes;
 pub mod request_tracing;
+mod resource_handlers;
+mod resource_tracking;
 mod routes;
 pub mod security_log;
 pub mod signing_handlers;
@@ -135,23 +140,14 @@ async fn main() -> Result<()> {
         tracing::error!("Failed to register metrics: {}", e);
     }
 
-    // Initialize Job Engine
-    let (job_engine, job_rx) = soroban_batch::engine::JobEngine::new();
-    let job_engine = Arc::new(job_engine);
-    let job_engine_worker = job_engine.clone();
-    
-    // Spawn background worker
-    tokio::spawn(async move {
-        job_engine_worker.run_worker(job_rx).await;
-    });
+    // Job engine omitted: optional dependency; add soroban_batch and uncomment to enable.
+    // let (job_engine, job_rx) = soroban_batch::engine::JobEngine::new();
+    // let job_engine = Arc::new(job_engine);
+    // tokio::spawn(async move { job_engine.clone().run_worker(job_rx).await });
 
     // Create app state
     let is_shutting_down = Arc::new(AtomicBool::new(false));
-openapi-doc
- openapi-doc
-    let state = AppState::new(pool.clone(), registry, job_engine, is_shutting_down.clone());
-    
-
+    let state = AppState::new(pool.clone(), registry, is_shutting_down.clone());
 
     // Spawn the background DB and cache monitoring task
     db_monitoring::spawn_db_monitoring_task(pool.clone(), state.cache.clone());
@@ -198,6 +194,7 @@ openapi-doc
 
     // Build router
     let app = Router::new()
+        .merge(routes::auth_routes())
         .merge(routes::contract_routes())
         .merge(routes::publisher_routes())
         .merge(routes::health_routes())

--- a/backend/api/src/openapi.rs
+++ b/backend/api/src/openapi.rs
@@ -1,11 +1,11 @@
-use utoipa::OpenApi;
-use crate::handlers;
 use crate::breaking_changes;
 use crate::custom_metrics_handlers;
 use crate::deprecation_handlers;
+use crate::handlers;
 use crate::metrics_handler;
-use shared::models::*;
 use serde_json::Value;
+use shared::models::*;
+use utoipa::OpenApi;
 
 #[derive(OpenApi)]
 #[openapi(

--- a/backend/api/src/resource_handlers.rs
+++ b/backend/api/src/resource_handlers.rs
@@ -51,6 +51,8 @@ mod tests {
             started_at: Instant::now(),
             cache: Arc::new(CacheLayer::new(CacheConfig::default())),
             registry,
+            is_shutting_down: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            health_monitor_status: crate::health_monitor::HealthMonitorStatus::default(),
             resource_mgr: Arc::new(RwLock::new(ResourceManager::new())),
             auth_mgr: Arc::new(RwLock::new(AuthManager::new("test-secret".to_string()))),
         }

--- a/backend/api/src/resource_tracking.rs
+++ b/backend/api/src/resource_tracking.rs
@@ -59,6 +59,12 @@ pub struct ResourceManager {
     data: HashMap<String, Vec<ResourceUsage>>,
 }
 
+impl Default for ResourceManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ResourceManager {
     pub fn new() -> Self {
         Self {
@@ -162,8 +168,10 @@ impl ResourceManager {
         let cpu_step_burn_p90 = (cpu_step_burn - Z_P90 * cpu_sigma).max(EPS);
         let mem_step_burn_p90 = (mem_step_burn - Z_P90 * mem_sigma).max(EPS);
 
-        let cpu_exhaust = project_exhaustion(current_cpu, cpu_step_burn, MAX_CPU as f64, last_ts, dt);
-        let mem_exhaust = project_exhaustion(current_mem, mem_step_burn, MAX_MEM as f64, last_ts, dt);
+        let cpu_exhaust =
+            project_exhaustion(current_cpu, cpu_step_burn, MAX_CPU as f64, last_ts, dt);
+        let mem_exhaust =
+            project_exhaustion(current_mem, mem_step_burn, MAX_MEM as f64, last_ts, dt);
         let cpu_exhaust =
             project_exhaustion(current_cpu, cpu_step_burn, MAX_CPU as f64, last_ts, dt);
         let mem_exhaust =
@@ -175,8 +183,7 @@ impl ResourceManager {
 
         let n = cpu_deltas.len().max(mem_deltas.len()) as f64;
         let variance_penalty = (cpu_sigma + mem_sigma) / (cpu_step_burn + mem_step_burn + 1.0);
-        let confidence = ((1.0 - 1.0 / (n + 1.0)) * (1.0 - variance_penalty))
-            .clamp(0.0, 0.99);
+        let confidence = ((1.0 - 1.0 / (n + 1.0)) * (1.0 - variance_penalty)).clamp(0.0, 0.99);
         let confidence = ((1.0 - 1.0 / (n + 1.0)) * (1.0 - variance_penalty)).clamp(0.0, 0.99);
 
         UsageForecast {

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -1,32 +1,29 @@
+#[cfg(feature = "openapi")]
+use crate::openapi;
 use crate::{
-openapi-doc
-    openapi::ApiDoc,
-    batch_verify_handlers,
-    handlers,
-    metrics_handler,
-    breaking_changes,
-    deprecation_handlers,
-    custom_metrics_handlers,
-    state::AppState,
-    breaking_changes, compatibility_testing_handlers, custom_metrics_handlers,
-    deprecation_handlers, handlers, metrics_handler, migration_handlers, state::AppState,
+    ab_test_handlers, activity_feed_handlers, auth, auth_handlers, batch_verify_handlers,
+    breaking_changes, canary_handlers, compatibility_testing_handlers, custom_metrics_handlers,
+    deprecation_handlers, handlers, metrics_handler, migration_handlers, performance_handlers,
+    resource_handlers, simulation_handlers, state::AppState,
+};
 use axum::{
     middleware,
     routing::{get, patch, post},
     Router,
 };
-
-use crate::{
-    ab_test_handlers, activity_feed_handlers, auth, batch_verify_handlers, breaking_changes,
-    canary_handlers, compatibility_testing_handlers, custom_metrics_handlers, deprecation_handlers,
-    handlers, metrics_handler, migration_handlers, performance_handlers, simulation_handlers,
-    state::AppState,
-};
+#[cfg(feature = "openapi")]
 use utoipa::OpenApi;
+#[cfg(feature = "openapi")]
 use utoipa_swagger_ui::SwaggerUi;
 
 pub fn observability_routes() -> Router<AppState> {
     Router::new().route("/metrics", get(metrics_handler::metrics_endpoint))
+}
+
+pub fn auth_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/auth/challenge", get(auth_handlers::get_challenge))
+        .route("/api/auth/verify", post(auth_handlers::verify_challenge))
 }
 
 pub fn contract_routes() -> Router<AppState> {
@@ -139,6 +136,10 @@ pub fn contract_routes() -> Router<AppState> {
                 .post(custom_metrics_handlers::record_contract_metric),
         )
         .route(
+            "/api/contracts/:id/resources",
+            get(resource_handlers::get_contract_resources),
+        )
+        .route(
             "/api/contracts/:id/metrics/batch",
             post(custom_metrics_handlers::record_metrics_batch),
         )
@@ -188,9 +189,16 @@ pub fn contract_routes() -> Router<AppState> {
     // to be integrated with the main AppState
 }
 
+#[cfg(not(feature = "openapi"))]
 pub fn openapi_routes() -> Router<AppState> {
     Router::new()
-        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+}
+
+#[cfg(feature = "openapi")]
+pub fn openapi_routes() -> Router<AppState> {
+    Router::new().merge(
+        SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi::ApiDoc::openapi()),
+    )
 }
 
 pub fn publisher_routes() -> Router<AppState> {

--- a/backend/api/src/simulation/performance_analyzer.rs
+++ b/backend/api/src/simulation/performance_analyzer.rs
@@ -115,7 +115,7 @@ pub fn analyze_performance(
 
 fn analyze_function(func_name: &str, abi_result: &AbiExtractionResult) -> FunctionAnalysis {
     // Check if function is in ABI result
-    let has_abi = abi_result.functions.iter().any(|f| &f.name == func_name);
+    let has_abi = abi_result.functions.iter().any(|f| f.name == func_name);
 
     let (complexity, recommendation) =
         if func_name.starts_with("get_") || func_name.contains("_view") {
@@ -126,7 +126,7 @@ fn analyze_function(func_name: &str, abi_result: &AbiExtractionResult) -> Functi
                 Some("Consider adding pagination for large datasets".to_string()),
             )
         } else if has_abi {
-            let func = abi_result.functions.iter().find(|f| &f.name == func_name);
+            let func = abi_result.functions.iter().find(|f| f.name == func_name);
             if let Some(f) = func {
                 if f.param_count > 5 {
                     (

--- a/backend/api/src/simulation/wasm_validator.rs
+++ b/backend/api/src/simulation/wasm_validator.rs
@@ -40,28 +40,22 @@ pub fn validate_wasm(wasm_bytes: &[u8]) -> WasmValidationResult {
                 table_count = t.count();
             }
             Ok(wasmparser::Payload::MemorySection(m)) => {
-                for memory in m {
-                    if let Ok(mem) = memory {
-                        memory_pages = mem.initial;
-                    }
+                for mem in m.into_iter().flatten() {
+                    memory_pages = mem.initial;
                 }
             }
             Ok(wasmparser::Payload::DataSection(d)) => {
                 data_section_size = d.count();
             }
             Ok(wasmparser::Payload::ExportSection(e)) => {
-                for export in e {
-                    if let Ok(exp) = export {
-                        export_functions.push(exp.name.to_string());
-                    }
+                for exp in e.into_iter().flatten() {
+                    export_functions.push(exp.name.to_string());
                 }
             }
             Ok(wasmparser::Payload::ImportSection(i)) => {
-                for import in i {
-                    if let Ok(imp) = import {
-                        let name = format!("{}::{}", imp.module, imp.name);
-                        import_functions.push(name);
-                    }
+                for imp in i.into_iter().flatten() {
+                    let name = format!("{}::{}", imp.module, imp.name);
+                    import_functions.push(name);
                 }
             }
             Ok(wasmparser::Payload::CodeSectionStart { count, .. }) => {

--- a/backend/api/src/state.rs
+++ b/backend/api/src/state.rs
@@ -1,9 +1,11 @@
+use crate::auth::AuthManager;
 use crate::cache::{CacheConfig, CacheLayer};
 use crate::health_monitor::HealthMonitorStatus;
+use crate::resource_tracking::ResourceManager;
 use prometheus::Registry;
 use sqlx::PgPool;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 /// Application state shared across handlers
@@ -15,11 +17,17 @@ pub struct AppState {
     pub registry: Registry,
     pub is_shutting_down: Arc<AtomicBool>,
     pub health_monitor_status: HealthMonitorStatus,
+    pub auth_mgr: Arc<RwLock<AuthManager>>,
+    pub resource_mgr: Arc<RwLock<ResourceManager>>,
 }
 
 impl AppState {
     pub fn new(db: PgPool, registry: Registry, is_shutting_down: Arc<AtomicBool>) -> Self {
         let config = CacheConfig::from_env();
+        let auth_mgr = Arc::new(RwLock::new(
+            AuthManager::from_env().expect("JWT config validated at startup"),
+        ));
+        let resource_mgr = Arc::new(RwLock::new(ResourceManager::new()));
         Self {
             db,
             started_at: Instant::now(),
@@ -27,6 +35,8 @@ impl AppState {
             registry,
             is_shutting_down,
             health_monitor_status: HealthMonitorStatus::default(),
+            auth_mgr,
+            resource_mgr,
         }
     }
 }

--- a/backend/api/src/validation/extractors.rs
+++ b/backend/api/src/validation/extractors.rs
@@ -139,7 +139,7 @@ where
             .headers()
             .get("x-correlation-id")
             .and_then(|v| v.to_str().ok())
-            .unwrap_or_else(|| "unknown")
+            .unwrap_or("unknown")
             .to_string();
 
         let path = req

--- a/backend/shared/Cargo.toml
+++ b/backend/shared/Cargo.toml
@@ -12,8 +12,6 @@ sqlx = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 anyhow = { workspace = true }
-openapi-doc
 utoipa = { workspace = true }
 base64 = { workspace = true }
-main
 rust_decimal = "1.35"

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -374,7 +374,7 @@ pub enum SortOrder {
 }
 
 /// Search/filter parameters for contracts
-#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema, utoipa::IntoParams)]
 pub struct ContractSearchParams {
     pub query: Option<String>,
     pub network: Option<Network>,


### PR DESCRIPTION
Fix AppState missing auth_mgr and resource_mgr (Fixes #329)

Summary
Restores the auth and resource-tracking systems by adding the missing auth_mgr and resource_mgr fields to AppState, wiring them in at startup, and enabling the auth and resource routes so the auth flow compiles and can be used.

Problem
auth_handlers.rs and resource_handlers.rs use state.auth_mgr and state.resource_mgr, but these fields were not on AppState after a refactor.
Auth and resource modules were not part of the main binary, so the auth system could not be used.

Changes

AppState & startup
backend/api/src/state.rs: Added auth_mgr: Arc<RwLock<AuthManager>> and resource_mgr: Arc<RwLock<ResourceManager>> to AppState. In AppState::new(), auth_mgr is created from AuthManager::from_env() (after startup validation) and resource_mgr from ResourceManager::new().

backend/api/src/main.rs: Declared mod auth_handlers, mod resource_handlers, mod resource_tracking, and mod openapi. Updated AppState::new to the 3-arg form (removed unused job_engine). Merged auth routes first in the router. Commented out the optional job-engine block so the binary builds without the soroban_batch dependency.

Routes
backend/api/src/routes.rs: Added auth_routes() with GET /api/auth/challenge and POST /api/auth/verify. Added GET /api/contracts/:id/resources to contract routes. Cleaned up duplicate/broken use blocks. When the openapi feature is off, openapi_routes() returns an empty router so the default build does not depend on broken OpenAPI types.

Library
backend/api/src/lib.rs: Added pub mod auth and pub mod resource_tracking so the library’s state module can use AuthManager and ResourceManager when the crate is built as a lib.

Handlers & tests
backend/api/src/auth_handlers.rs: Added integration tests for the challenge/verify/JWT flow: challenge_returns_nonce_for_address, challenge_rejects_empty_address, verify_issues_jwt_when_signature_valid.

backend/api/src/resource_handlers.rs: Updated test_state() to set is_shutting_down and health_monitor_status so it matches the current AppState.

Build / fmt / clippy
backend/api/src/handlers.rs: Removed stray openapi-doc and main tokens and the duplicate get_trending_contracts stub that caused parse errors.

backend/shared/Cargo.toml: Removed invalid openapi-doc and main lines.

backend/Cargo.toml: Added workspace deps utoipa, utoipa-swagger-ui, and rust_decimal.

backend/api/Cargo.toml: Added rust_decimal, utoipa, utoipa-swagger-ui and an optional openapi feature.

backend/api/src/cache.rs: .bind(&id) → .bind(id) (clippy).

backend/api/src/resource_tracking.rs: Implemented Default for ResourceManager (clippy).

backend/shared/src/models.rs: Added utoipa::IntoParams to ContractSearchParams.

backend/api/src/handlers.rs: Added utoipa::IntoParams to GetContractQuery; fixed manual_clamp (use clamp).

backend/api/src/simulation/performance_analyzer.rs: Fixed needless refs in closures (clippy).

backend/api/src/simulation/wasm_validator.rs: Replaced if let Ok loops with .flatten() (clippy).

backend/api/src/validation/extractors.rs: .unwrap_or_else(|| "unknown") → .unwrap_or("unknown") (clippy).

Result
Auth endpoints are available: GET /api/auth/challenge, POST /api/auth/verify.
Resource endpoint is available: GET /api/contracts/:id/resources.
Admin routes still use the existing auth::require_admin middleware (unchanged).
cargo build -p api, cargo fmt --all, and cargo clippy -p api -- -D warnings succeed.

Testing
New tests in auth_handlers::tests cover the challenge/verify/JWT flow with a test AppState and ed25519 signing.
Existing resource_handlers tests were updated for the new AppState shape.