### PR TITLE
fix: Add wasm_hash validation to contract metadata submission

### DIFF
--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -1123,9 +1123,6 @@ pub async fn publish_contract(
     headers: HeaderMap,
     ValidatedJson(req): ValidatedJson<PublishRequest>,
 ) -> ApiResult<Json<Contract>> {
-    crate::validation::validate_contract_id(&req.contract_id)
-        .map_err(|e| ApiError::bad_request("InvalidContractId", e))?;
-
     let publisher: Publisher = sqlx::query_as(
         "INSERT INTO publishers (stellar_address) VALUES ($1)
          ON CONFLICT (stellar_address) DO UPDATE SET stellar_address = EXCLUDED.stellar_address

--- a/backend/api/src/validation/requests.rs
+++ b/backend/api/src/validation/requests.rs
@@ -55,6 +55,7 @@ const MAX_DEPENDENCIES_COUNT: usize = 50;
 impl Validatable for PublishRequest {
     fn sanitize(&mut self) {
         self.contract_id = normalize_contract_id(&self.contract_id);
+        self.wasm_hash = trim(&self.wasm_hash);
         self.name = sanitize_name(&self.name);
         sanitize_description_optional(&mut self.description);
         self.publisher_address = normalize_stellar_address(&self.publisher_address);
@@ -78,6 +79,8 @@ impl Validatable for PublishRequest {
         let mut builder = ValidationBuilder::new();
 
         builder.check("contract_id", || validate_contract_id(&self.contract_id));
+
+        builder.check("wasm_hash", || validate_wasm_hash(&self.wasm_hash));
 
         builder.check("name", || {
             if self.name.is_empty() {
@@ -549,6 +552,27 @@ mod tests {
     }
 
     #[test]
+    fn test_publish_request_invalid_wasm_hash() {
+        let req = PublishRequest {
+            contract_id: valid_contract_id(),
+            wasm_hash: "invalid".to_string(),
+            name: "My Contract".to_string(),
+            description: None,
+            network: Network::Testnet,
+            category: None,
+            tags: vec![],
+            source_url: None,
+            publisher_address: valid_stellar_address(),
+            dependencies: vec![],
+        };
+
+        let result = req.validate();
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.field == "wasm_hash"));
+    }
+
+    #[test]
     fn test_publish_request_sanitization() {
         let mut req = PublishRequest {
             contract_id: "  cdlzfc3syjydzt7k67vz75hpjvieuvnixf47zg2fb2rmqqvu2hhgcysc  ".to_string(),
@@ -567,7 +591,7 @@ mod tests {
         req.sanitize();
 
         assert_eq!(req.contract_id, valid_contract_id());
-        assert_eq!(req.wasm_hash.trim(), "a".repeat(64));
+        assert_eq!(req.wasm_hash, "a".repeat(64));
         assert_eq!(req.name, "My Contract");
         assert_eq!(req.description, Some("alert('xss')Description".to_string()));
         assert_eq!(req.publisher_address, valid_stellar_address());


### PR DESCRIPTION
Closes #410

## Summary

- Add missing `wasm_hash` field validation (64-char hex SHA-256) to `PublishRequest`
- Add `wasm_hash` sanitization (trim whitespace) before validation
- Remove redundant `validate_contract_id` call in `publish_contract` handler
- Add test case for invalid wasm_hash validation

## Test plan

- [x] Existing tests pass
- [x] New test `test_publish_request_invalid_wasm_hash` validates wasm_hash field errors
- [x] Formatting check passes (`cargo fmt --check`)


