### PR TITLE
fix(examples): replace hardcoded storage keys with DataKey enum and document collision anti-pattern

### DIFF
--- a/soroban-registry/examples/token_with_issues.rs
+++ b/soroban-registry/examples/token_with_issues.rs
@@ -64,7 +64,7 @@ impl TokenWithIssues {
 ///
 /// - Panics if `amount` is 0
 /// - Panics if `amount` exceeds `MAX_MINT_ITERATIONS`
-       pub fn mint(env: Env, amount: u64) {
+    pub fn mint(env: Env, amount: u64) {
         // Parameter validation
         if amount == 0 {
             panic!("amount must be greater than zero");


### PR DESCRIPTION
## Summary

- Adds `token_fixed.rs` companion example demonstrating the correct typed-key approach using an exhaustive `DataKey` enum, with per-account scoping for `Balance` and `Allowance` entries
- Documents the hardcoded storage key collision anti-pattern in `token_with_issues.rs` with `//!` module-level warnings, per-function docstrings, and two test cases that prove both `set_balance` and `set_allowance` silently overwrite the same storage slot
- Fixes indentation of the `mint` function in `token_with_issues.rs`

## Test plan

- [ ] `hardcoded_keys_collide_and_overwrite_balance` — sets balance to 100, then sets allowance to 7; asserts both `get_balance` and `get_allowance` return 7 (collision confirmed)
- [ ] `hardcoded_keys_collide_and_overwrite_allowance` — sets allowance to 55, then balance to 12; asserts both return 12 (collision confirmed)
- [ ] `typed_keys_prevent_balance_allowance_collision` in `token_fixed.rs` — sets balance to 100 and allowance to 7 for distinct keys; asserts each read returns its own value without interference

Closes #219