### PR TITLE
feat: Added build interactive cli dashboard with contract monitoring

### DIFF
--- a/cli/dashboard/README.md
+++ b/cli/dashboard/README.md
@@ -1,0 +1,66 @@
+# Soroban Registry Dashboard (Terminal UI)
+
+This folder contains the Node.js/TypeScript implementation of the interactive terminal dashboard (blessed + ws).
+
+The main Soroban-Registry CLI is Rust. The Rust subcommand `soroban-registry dashboard` launches this Node dashboard by running `node dist/index.js ...`.
+
+## Setup
+
+From the repo root:
+
+```bash
+cd cli/dashboard
+npm install
+npm run build
+```
+
+## Run (with mock data)
+
+Terminal 1:
+
+```bash
+cd cli/dashboard
+npm run mock:server
+```
+
+Terminal 2 (Rust CLI wrapper):
+
+```bash
+cd cli
+cargo run --bin soroban-registry -- dashboard --refresh-rate 100 --network testnet --category dex
+```
+
+## Run the Node dashboard directly
+
+```bash
+cd cli/dashboard
+SOROBAN_REGISTRY_WS_URL=ws://127.0.0.1:8787 node dist/index.js dashboard --refresh-rate 100
+```
+
+## Environment variables
+
+- `SOROBAN_REGISTRY_WS_URL`: WebSocket URL the dashboard connects to (default: `ws://127.0.0.1:8787`)
+- `SOROBAN_REGISTRY_DASHBOARD_ENTRY`: Optional override for the Rust wrapper to locate the built entrypoint
+
+## WebSocket event schema
+
+The dashboard expects JSON messages like:
+
+```json
+{ "type": "deployment_created", "payload": { "id": "uuid", "contractId": "C...", "network": "testnet", "category": "dex", "publisher": "G...", "timestamp": "2026-03-27T00:00:00.000Z" } }
+```
+
+```json
+{ "type": "contract_interaction", "payload": { "id": "uuid", "contractId": "C...", "network": "testnet", "timestamp": "2026-03-27T00:00:00.000Z" } }
+```
+
+```json
+{ "type": "network_status", "payload": { "network": "testnet", "status": "connected", "latencyMs": 42, "timestamp": "2026-03-27T00:00:00.000Z" } }
+```
+
+The mock server supports basic client messages:
+
+- `{"type":"subscribe","payload":{"filters":{...}}}`
+- `{"type":"set_filters","payload":{"filters":{...}}}`
+- `{"type":"refresh","payload":{}}`
+

--- a/cli/dashboard/package.json
+++ b/cli/dashboard/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "soroban-registry-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Interactive terminal dashboard for Soroban-Registry (blessed + ws).",
+  "license": "Apache-2.0",
+  "scripts": {
+    "dev": "tsx src/index.ts dashboard",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js dashboard",
+    "mock:server": "tsx scripts/mock-ws-server.ts"
+  },
+  "dependencies": {
+    "blessed": "^0.1.81",
+    "commander": "^14.0.0",
+    "ws": "^8.18.3"
+  },
+  "devDependencies": {
+    "@types/blessed": "^0.1.25",
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.18.1",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/cli/dashboard/scripts/mock-ws-server.ts
+++ b/cli/dashboard/scripts/mock-ws-server.ts
@@ -1,0 +1,175 @@
+import { WebSocketServer } from "ws";
+import { randomUUID } from "node:crypto";
+
+type ClientFilters = {
+  network?: string;
+  category?: string;
+  query?: string;
+};
+
+type ClientState = {
+  filters: ClientFilters;
+};
+
+const PORT = Number.parseInt(process.env.MOCK_WS_PORT ?? "8787", 10);
+const wss = new WebSocketServer({ port: PORT });
+
+const clients = new Map<any, ClientState>();
+
+const NETWORKS = ["mainnet", "testnet", "futurenet"] as const;
+const CATEGORIES = ["dex", "nft", "token", "oracle", "lending"] as const;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function randomFrom<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function makeContractId(): string {
+  const suffix = Math.random().toString(16).slice(2, 10);
+  return `C${suffix}`.toUpperCase();
+}
+
+function passesFilters(ev: { network: string; category?: string; contractId: string }, filters: ClientFilters): boolean {
+  if (filters.network && ev.network !== filters.network) return false;
+  if (filters.category && ev.category !== filters.category) return false;
+  if (filters.query) {
+    const q = filters.query.toLowerCase();
+    if (!ev.contractId.toLowerCase().includes(q)) return false;
+  }
+  return true;
+}
+
+wss.on("connection", (ws) => {
+  clients.set(ws, { filters: {} });
+
+  ws.on("message", (data) => {
+    const msg = safeJson(data.toString());
+    if (!msg || typeof msg.type !== "string") return;
+
+    if (msg.type === "subscribe" && msg.payload && typeof msg.payload === "object") {
+      const next = (msg.payload as any).filters;
+      if (next && typeof next === "object") {
+        clients.set(ws, { filters: sanitizeFilters(next) });
+      }
+      return;
+    }
+
+    if (msg.type === "set_filters" && msg.payload && typeof msg.payload === "object") {
+      const next = (msg.payload as any).filters;
+      if (next && typeof next === "object") {
+        clients.set(ws, { filters: sanitizeFilters(next) });
+      }
+      return;
+    }
+
+    if (msg.type === "refresh") {
+      for (let i = 0; i < 5; i++) emitInteraction(ws);
+      emitDeployment(ws);
+      return;
+    }
+  });
+
+  ws.on("close", () => {
+    clients.delete(ws);
+  });
+});
+
+setInterval(() => {
+  for (const ws of wss.clients) {
+    if (ws.readyState !== ws.OPEN) continue;
+    emitNetworkStatus(ws);
+  }
+}, 3_000);
+
+setInterval(() => {
+  for (const ws of wss.clients) {
+    if (ws.readyState !== ws.OPEN) continue;
+    emitInteraction(ws);
+    if (Math.random() < 0.15) emitDeployment(ws);
+  }
+}, 1_000);
+
+process.stdout.write(`Mock WS server running at ws://127.0.0.1:${PORT}\n`);
+
+function emitDeployment(ws: any): void {
+  const filters = clients.get(ws)?.filters ?? {};
+  const network = randomFrom(NETWORKS);
+  const category = randomFrom(CATEGORIES);
+  const contractId = makeContractId();
+
+  const ev = { network, category, contractId };
+  if (!passesFilters(ev, filters)) return;
+
+  ws.send(
+    JSON.stringify({
+      type: "deployment_created",
+      payload: {
+        id: randomUUID(),
+        contractId,
+        network,
+        category,
+        publisher: `G${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
+        timestamp: nowIso()
+      }
+    })
+  );
+}
+
+function emitInteraction(ws: any): void {
+  const filters = clients.get(ws)?.filters ?? {};
+  const network = randomFrom(NETWORKS);
+  const contractId = makeContractId();
+
+  const ev = { network, contractId };
+  if (!passesFilters(ev, filters)) return;
+
+  ws.send(
+    JSON.stringify({
+      type: "contract_interaction",
+      payload: {
+        id: randomUUID(),
+        contractId,
+        network,
+        timestamp: nowIso()
+      }
+    })
+  );
+}
+
+function emitNetworkStatus(ws: any): void {
+  const filters = clients.get(ws)?.filters ?? {};
+  const network = filters.network ?? randomFrom(NETWORKS);
+  const latencyMs = Math.floor(20 + Math.random() * 180);
+
+  ws.send(
+    JSON.stringify({
+      type: "network_status",
+      payload: {
+        network,
+        status: "connected",
+        latencyMs,
+        timestamp: nowIso()
+      }
+    })
+  );
+}
+
+function safeJson(text: string): any | undefined {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function sanitizeFilters(input: any): ClientFilters {
+  const out: ClientFilters = {};
+  if (typeof input.network === "string") out.network = input.network || undefined;
+  if (typeof input.category === "string") out.category = input.category || undefined;
+  if (typeof input.query === "string") out.query = input.query || undefined;
+  return out;
+}
+

--- a/cli/dashboard/src/dashboard/render/render_scheduler.ts
+++ b/cli/dashboard/src/dashboard/render/render_scheduler.ts
@@ -1,0 +1,32 @@
+export class RenderScheduler {
+  private timer: NodeJS.Timeout | undefined;
+  private pending = false;
+  private lastRenderAt = 0;
+
+  constructor(
+    private readonly minIntervalMs: number,
+    private readonly render: () => void
+  ) {}
+
+  // Throttles terminal re-renders so high-frequency WS events don't cause lag.
+  request(): void {
+    this.pending = true;
+    if (this.timer) return;
+
+    const now = Date.now();
+    const dueIn = Math.max(0, this.minIntervalMs - (now - this.lastRenderAt));
+    this.timer = setTimeout(() => this.flush(), dueIn);
+  }
+
+  flush(): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = undefined;
+
+    if (!this.pending) return;
+    this.pending = false;
+
+    this.lastRenderAt = Date.now();
+    this.render();
+  }
+}
+

--- a/cli/dashboard/src/dashboard/render/sparkline.ts
+++ b/cli/dashboard/src/dashboard/render/sparkline.ts
@@ -1,0 +1,39 @@
+const TICKS = "▁▂▃▄▅▆▇█";
+
+export function sparkline(values: number[], params?: { width?: number; min?: number; max?: number }): string {
+  const width = Math.max(1, params?.width ?? values.length);
+  if (values.length === 0) return "".padEnd(width, " ");
+
+  const sampled = sampleToWidth(values, width);
+  const min = params?.min ?? Math.min(...sampled);
+  const max = params?.max ?? Math.max(...sampled);
+
+  if (max <= min) return TICKS[0].repeat(width);
+
+  return sampled
+    .map((v) => {
+      const t = (v - min) / (max - min);
+      const idx = Math.max(0, Math.min(TICKS.length - 1, Math.round(t * (TICKS.length - 1))));
+      return TICKS[idx];
+    })
+    .join("");
+}
+
+function sampleToWidth(values: number[], width: number): number[] {
+  if (values.length === width) return values.slice();
+  if (values.length < width) {
+    const pad = new Array(width - values.length).fill(0);
+    return [...pad, ...values];
+  }
+
+  const out: number[] = [];
+  for (let i = 0; i < width; i++) {
+    const start = Math.floor((i * values.length) / width);
+    const end = Math.floor(((i + 1) * values.length) / width);
+    const slice = values.slice(start, Math.max(start + 1, end));
+    const sum = slice.reduce((a, b) => a + b, 0);
+    out.push(sum);
+  }
+  return out;
+}
+

--- a/cli/dashboard/src/dashboard/run.ts
+++ b/cli/dashboard/src/dashboard/run.ts
@@ -1,0 +1,125 @@
+import type { DashboardFilters } from "./types";
+import { DashboardStore } from "./state/store";
+import { RenderScheduler } from "./render/render_scheduler";
+import { RegistryWsClient } from "./ws/client";
+import { DashboardApp } from "./ui/dashboard_app";
+
+export async function runDashboard(params: { refreshRateMs: number; network?: string; category?: string }): Promise<void> {
+  const wsUrl = process.env.SOROBAN_REGISTRY_WS_URL ?? "ws://127.0.0.1:8787";
+
+  const initialFilters: DashboardFilters = {
+    network: params.network,
+    category: params.category
+  };
+
+  const store = new DashboardStore({ wsUrl, filters: initialFilters });
+  const ws = new RegistryWsClient(wsUrl);
+
+  let shuttingDown = false;
+  let tickTimer: NodeJS.Timeout | undefined;
+  let resolveDone: (() => void) | undefined;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+
+  const app = new DashboardApp({
+    getState: () => store.getState(),
+    onQuit: () => {
+      shuttingDown = true;
+      resolveDone?.();
+    },
+    onRefresh: () => {
+      ws.sendJson({ type: "refresh", payload: {} });
+      scheduler.request();
+    },
+    onSetFilters: (filters) => {
+      store.setFilters(filters, "filters_changed");
+      ws.sendJson({ type: "set_filters", payload: { filters } });
+      scheduler.request();
+    },
+    requestRender: () => scheduler.request()
+  });
+
+  const scheduler = new RenderScheduler(params.refreshRateMs, () => {
+    app.renderFromState(store.getState());
+    app.render();
+  });
+
+  const cleanup = () => {
+    shuttingDown = true;
+    if (tickTimer) clearInterval(tickTimer);
+    ws.close();
+    app.destroy();
+  };
+
+  store.subscribe(() => scheduler.request());
+
+  ws.on("open", () => {
+    store.setConnection({ status: "connected", wsUrl, connectedAt: Date.now() }, "ws_open");
+  });
+
+  ws.on("latency", (latencyMs) => {
+    const current = store.getState().connection;
+    if (current.status === "connected") {
+      store.setConnection({ ...current, latencyMs }, "latency");
+    }
+  });
+
+  ws.on("event", (ev) => {
+    if (ev.type === "deployment_created") {
+      store.addDeployment({
+        id: ev.payload.id,
+        contractId: ev.payload.contractId,
+        network: ev.payload.network,
+        category: ev.payload.category,
+        publisher: ev.payload.publisher,
+        ts: Date.parse(ev.payload.timestamp) || Date.now()
+      });
+      return;
+    }
+
+    if (ev.type === "contract_interaction") {
+      store.addInteraction({
+        id: ev.payload.id,
+        contractId: ev.payload.contractId,
+        network: ev.payload.network,
+        ts: Date.parse(ev.payload.timestamp) || Date.now()
+      });
+      return;
+    }
+
+    if (ev.type === "network_status") {
+      const conn = store.getState().connection;
+      if (conn.status === "connected") {
+        store.setConnection({ ...conn, latencyMs: ev.payload.latencyMs }, "network_status");
+      }
+    }
+  });
+
+  ws.on("error", ({ message }) => {
+    const conn = store.getState().connection;
+    if (conn.status === "connected") {
+      store.setConnection({ status: "disconnected", wsUrl, lastConnectedAt: conn.connectedAt, lastError: message }, "ws_error");
+    } else {
+      store.setConnection({ ...conn, status: "disconnected", lastError: message }, "ws_error");
+    }
+  });
+
+  ws.on("close", ({ code, reason }) => {
+    if (shuttingDown) return;
+    const lastError = reason || `closed (${code})`;
+    const conn = store.getState().connection;
+    const lastConnectedAt = conn.status === "connected" ? conn.connectedAt : conn.lastConnectedAt;
+    const { attempt, nextRetryAt } = ws.scheduleReconnect({ filters: store.getState().filters, lastError });
+    store.setConnection({ status: "reconnecting", wsUrl, attempt, nextRetryAt, lastError, lastConnectedAt }, "ws_close");
+  });
+
+  ws.connect(store.getState().filters);
+
+  tickTimer = setInterval(() => store.tickNow(Date.now()), 1_000);
+  scheduler.request();
+
+  await done;
+  cleanup();
+}
+

--- a/cli/dashboard/src/dashboard/state/selectors.ts
+++ b/cli/dashboard/src/dashboard/state/selectors.ts
@@ -1,0 +1,41 @@
+import type { DashboardState, Deployment } from "../types";
+
+export function selectFilteredDeployments(state: DashboardState): Deployment[] {
+  const { network, category, query } = state.filters;
+  const q = query?.trim().toLowerCase();
+
+  return state.deployments.filter((d) => {
+    if (network && d.network !== network) return false;
+    if (category && d.category !== category) return false;
+    if (q && !d.contractId.toLowerCase().includes(q) && !(d.publisher ?? "").toLowerCase().includes(q)) return false;
+    return true;
+  });
+}
+
+export function selectTrendingContracts(
+  state: DashboardState,
+  params: { windowMs: number; limit: number }
+): Array<{ contractId: string; network: string; count: number; lastTs: number }> {
+  const cutoff = state.nowTs - params.windowMs;
+  const { network, query } = state.filters;
+  const q = query?.trim().toLowerCase();
+
+  const counts = new Map<string, { contractId: string; network: string; count: number; lastTs: number }>();
+
+  for (const i of state.interactions) {
+    if (i.ts < cutoff) continue;
+    if (network && i.network !== network) continue;
+
+    const key = `${i.network}:${i.contractId}`;
+    const prev = counts.get(key);
+    const next = prev
+      ? { ...prev, count: prev.count + 1, lastTs: Math.max(prev.lastTs, i.ts) }
+      : { contractId: i.contractId, network: i.network, count: 1, lastTs: i.ts };
+    counts.set(key, next);
+  }
+
+  const items = Array.from(counts.values()).sort((a, b) => b.count - a.count || b.lastTs - a.lastTs);
+  const filtered = q ? items.filter((x) => x.contractId.toLowerCase().includes(q)) : items;
+  return filtered.slice(0, params.limit);
+}
+

--- a/cli/dashboard/src/dashboard/state/store.ts
+++ b/cli/dashboard/src/dashboard/state/store.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from "node:events";
+import type { ActivityBucket, ConnectionState, DashboardFilters, DashboardState, Deployment, Interaction } from "../types";
+
+export type StoreChange = {
+  state: DashboardState;
+  reason: string;
+};
+
+const MAX_DEPLOYMENTS = 200;
+const MAX_INTERACTIONS = 1000;
+
+export class DashboardStore {
+  private readonly emitter = new EventEmitter();
+  private state: DashboardState;
+
+  constructor(params: { wsUrl: string; filters: DashboardFilters }) {
+    const connection: ConnectionState = { status: "disconnected", wsUrl: params.wsUrl };
+    this.state = {
+      connection,
+      filters: params.filters,
+      deployments: [],
+      interactions: [],
+      activity: [],
+      nowTs: Date.now()
+    };
+  }
+
+  // Central in-memory store; UI subscribes to "change" events.
+  getState(): DashboardState {
+    return this.state;
+  }
+
+  subscribe(listener: (change: StoreChange) => void): () => void {
+    this.emitter.on("change", listener);
+    return () => this.emitter.off("change", listener);
+  }
+
+  setConnection(next: ConnectionState, reason: string): void {
+    this.state = { ...this.state, connection: next };
+    this.emit(reason);
+  }
+
+  setFilters(next: DashboardFilters, reason: string): void {
+    this.state = { ...this.state, filters: next };
+    this.emit(reason);
+  }
+
+  tickNow(nowTs: number): void {
+    this.state = { ...this.state, nowTs };
+    this.emit("tick");
+  }
+
+  addDeployment(dep: Deployment): void {
+    const deployments = [dep, ...this.state.deployments].slice(0, MAX_DEPLOYMENTS);
+    this.state = { ...this.state, deployments };
+    this.bumpActivity(dep.ts, { deployments: 1, interactions: 0 });
+    this.emit("deployment_created");
+  }
+
+  addInteraction(intx: Interaction): void {
+    const interactions = [intx, ...this.state.interactions].slice(0, MAX_INTERACTIONS);
+    this.state = { ...this.state, interactions };
+    this.bumpActivity(intx.ts, { deployments: 0, interactions: 1 });
+    this.emit("contract_interaction");
+  }
+
+  private bumpActivity(ts: number, delta: { deployments: number; interactions: number }): void {
+    const bucketMs = 60_000;
+    const startTs = Math.floor(ts / bucketMs) * bucketMs;
+
+    const activity = this.state.activity.slice();
+    const last = activity[activity.length - 1];
+    if (!last || last.startTs !== startTs) {
+      activity.push({ startTs, deployments: 0, interactions: 0 });
+    }
+
+    const idx = activity.length - 1;
+    const updated: ActivityBucket = {
+      ...activity[idx],
+      deployments: activity[idx].deployments + delta.deployments,
+      interactions: activity[idx].interactions + delta.interactions
+    };
+
+    activity[idx] = updated;
+
+    const maxBuckets = 120;
+    const trimmed = activity.slice(Math.max(0, activity.length - maxBuckets));
+    this.state = { ...this.state, activity: trimmed };
+  }
+
+  private emit(reason: string): void {
+    this.emitter.emit("change", { state: this.state, reason } satisfies StoreChange);
+  }
+}
+

--- a/cli/dashboard/src/dashboard/types.ts
+++ b/cli/dashboard/src/dashboard/types.ts
@@ -1,0 +1,96 @@
+export type NetworkName = string;
+export type CategoryName = string;
+
+export type DeploymentCreatedEvent = {
+  type: "deployment_created";
+  payload: {
+    id: string;
+    contractId: string;
+    network: NetworkName;
+    category?: CategoryName;
+    publisher?: string;
+    timestamp: string;
+  };
+};
+
+export type ContractInteractionEvent = {
+  type: "contract_interaction";
+  payload: {
+    id: string;
+    contractId: string;
+    network: NetworkName;
+    timestamp: string;
+  };
+};
+
+export type NetworkStatusEvent = {
+  type: "network_status";
+  payload: {
+    network: NetworkName;
+    status: "connected" | "degraded" | "disconnected";
+    latencyMs?: number;
+    timestamp: string;
+  };
+};
+
+export type RegistryEvent = DeploymentCreatedEvent | ContractInteractionEvent | NetworkStatusEvent;
+
+export type ConnectionState =
+  | {
+      status: "disconnected";
+      wsUrl: string;
+      lastError?: string;
+      lastConnectedAt?: number;
+    }
+  | {
+      status: "connected";
+      wsUrl: string;
+      connectedAt: number;
+      latencyMs?: number;
+    }
+  | {
+      status: "reconnecting";
+      wsUrl: string;
+      attempt: number;
+      nextRetryAt: number;
+      lastError?: string;
+      lastConnectedAt?: number;
+    };
+
+export type DashboardFilters = {
+  network?: NetworkName;
+  category?: CategoryName;
+  query?: string;
+};
+
+export type Deployment = {
+  id: string;
+  contractId: string;
+  network: NetworkName;
+  category?: CategoryName;
+  publisher?: string;
+  ts: number;
+};
+
+export type Interaction = {
+  id: string;
+  contractId: string;
+  network: NetworkName;
+  ts: number;
+};
+
+export type ActivityBucket = {
+  startTs: number;
+  deployments: number;
+  interactions: number;
+};
+
+export type DashboardState = {
+  connection: ConnectionState;
+  filters: DashboardFilters;
+  deployments: Deployment[];
+  interactions: Interaction[];
+  activity: ActivityBucket[];
+  nowTs: number;
+};
+

--- a/cli/dashboard/src/dashboard/ui/dashboard_app.ts
+++ b/cli/dashboard/src/dashboard/ui/dashboard_app.ts
@@ -1,0 +1,306 @@
+import blessed from "blessed";
+import type { DashboardFilters, DashboardState } from "../types";
+import { selectFilteredDeployments, selectTrendingContracts } from "../state/selectors";
+import { sparkline } from "../render/sparkline";
+import { clampStr, formatSince } from "../util/format";
+import { parseKeyValueFilters, promptLine } from "./modals";
+
+type FocusedPanel = "deployments" | "trending";
+
+export class DashboardApp {
+  private readonly screen: blessed.Widgets.Screen;
+  private readonly header: blessed.Widgets.BoxElement;
+  private readonly deploymentsList: blessed.Widgets.ListElement;
+  private readonly trendingList: blessed.Widgets.ListElement;
+  private readonly activityBox: blessed.Widgets.BoxElement;
+
+  private focused: FocusedPanel = "deployments";
+  private modalActive = false;
+
+  private lastHeader = "";
+  private lastDeploymentsKey = "";
+  private lastTrendingKey = "";
+  private lastActivityKey = "";
+
+  constructor(
+    private readonly params: {
+      getState: () => DashboardState;
+      onQuit: () => void;
+      onRefresh: () => void;
+      onSetFilters: (filters: DashboardFilters) => void;
+      requestRender: () => void;
+    }
+  ) {
+    this.screen = blessed.screen({
+      smartCSR: true,
+      fullUnicode: true,
+      title: "Soroban Registry Dashboard",
+      dockBorders: true
+    });
+
+    this.screen.key(["C-c", "q"], () => this.params.onQuit());
+    this.screen.key(["r"], () => this.params.onRefresh());
+    this.screen.key(["left", "right", "tab"], () => this.toggleFocus());
+    this.screen.key(["up"], () => this.onArrow("up"));
+    this.screen.key(["down"], () => this.onArrow("down"));
+    this.screen.key(["f"], () => void this.openFilterModal());
+    this.screen.key(["/"], () => void this.openSearchModal());
+
+    this.header = blessed.box({
+      parent: this.screen,
+      top: 0,
+      left: 0,
+      right: 0,
+      height: 3,
+      border: "line",
+      style: { border: { fg: "cyan" } }
+    });
+
+    const midTop = 3;
+    const bottomHeight = 9;
+    const midHeight = `100%-${midTop + bottomHeight}`;
+
+    this.deploymentsList = blessed.list({
+      parent: this.screen,
+      label: " Recent deployments ",
+      top: midTop,
+      left: 0,
+      width: "50%",
+      height: midHeight,
+      border: "line",
+      keys: false,
+      mouse: false,
+      tags: false,
+      style: {
+        border: { fg: "gray" },
+        selected: { bg: "blue" }
+      },
+      scrollbar: {
+        ch: " ",
+        track: { bg: "gray" },
+        style: { bg: "yellow" }
+      }
+    });
+
+    this.trendingList = blessed.list({
+      parent: this.screen,
+      label: " Trending contracts ",
+      top: midTop,
+      left: "50%",
+      width: "50%",
+      height: midHeight,
+      border: "line",
+      keys: false,
+      mouse: false,
+      tags: false,
+      style: {
+        border: { fg: "gray" },
+        selected: { bg: "blue" }
+      },
+      scrollbar: {
+        ch: " ",
+        track: { bg: "gray" },
+        style: { bg: "yellow" }
+      }
+    });
+
+    this.activityBox = blessed.box({
+      parent: this.screen,
+      label: " Activity (last 120 minutes) ",
+      left: 0,
+      right: 0,
+      bottom: 0,
+      height: bottomHeight,
+      border: "line",
+      style: { border: { fg: "gray" } }
+    });
+
+    this.applyFocusStyles();
+    this.renderFromState(this.params.getState());
+    this.render();
+
+    this.screen.on("resize", () => this.params.requestRender());
+  }
+
+  destroy(): void {
+    this.screen.destroy();
+  }
+
+  render(): void {
+    this.screen.render();
+  }
+
+  renderFromState(state: DashboardState): void {
+    this.renderHeader(state);
+    this.renderDeployments(state);
+    this.renderTrending(state);
+    this.renderActivity(state);
+  }
+
+  private renderHeader(state: DashboardState): void {
+    const conn = state.connection;
+    const filters = state.filters;
+
+    let status = "DISCONNECTED";
+    let statusColor: "red" | "green" | "yellow" = "red";
+    let details = "";
+
+    if (conn.status === "connected") {
+      status = "CONNECTED";
+      statusColor = "green";
+      details = conn.latencyMs !== undefined ? `latency ${conn.latencyMs}ms` : "latency --";
+    } else if (conn.status === "reconnecting") {
+      status = "RECONNECTING";
+      statusColor = "yellow";
+      const inSec = Math.max(0, Math.ceil((conn.nextRetryAt - Date.now()) / 1000));
+      details = `retry in ${inSec}s (attempt ${conn.attempt})`;
+    } else {
+      details = conn.lastError ? `error: ${conn.lastError}` : "waiting for connection";
+    }
+
+    const f = `network=${filters.network ?? "*"} category=${filters.category ?? "*"} query=${filters.query ?? ""}`;
+
+    const content = [
+      ` {bold}Network:{/bold} ${filters.network ?? "all"}   {bold}WS:{/bold} ${conn.wsUrl}`,
+      ` {bold}Status:{/bold} {${statusColor}-fg}${status}{/${statusColor}-fg}   ${details}`,
+      ` {bold}Keys:{/bold} q quit · r refresh · f filters · / search · ←/→ switch panel · ↑/↓ scroll   ${f}`
+    ].join("\n");
+
+    if (content !== this.lastHeader) {
+      this.lastHeader = content;
+      this.header.setContent(content);
+      this.header.setTags(true);
+    }
+    this.header.style.border = { fg: statusColor };
+  }
+
+  private renderDeployments(state: DashboardState): void {
+    const items = selectFilteredDeployments(state).slice(0, 100);
+    const width = Math.max(10, Math.floor((this.deploymentsList.width as number) ?? 40) - 4);
+
+    const key = `${items.length}:${items[0]?.id ?? ""}:${state.nowTs}`;
+    if (key === this.lastDeploymentsKey) return;
+    this.lastDeploymentsKey = key;
+
+    const lines = items.map((d) => {
+      const age = formatSince(d.ts, state.nowTs).padStart(3, " ");
+      const net = clampStr(d.network, 10).padEnd(10, " ");
+      const cat = clampStr(d.category ?? "-", 8).padEnd(8, " ");
+      const id = clampStr(d.contractId, 40);
+      const line = `${age}  ${net}  ${cat}  ${id}`;
+      return clampStr(line, width);
+    });
+
+    this.deploymentsList.setItems(lines.length ? lines : ["(no deployments)"]);
+  }
+
+  private renderTrending(state: DashboardState): void {
+    const items = selectTrendingContracts(state, { windowMs: 10 * 60_000, limit: 100 });
+    const width = Math.max(10, Math.floor((this.trendingList.width as number) ?? 40) - 4);
+
+    const key = `${items.length}:${items[0]?.contractId ?? ""}:${state.nowTs}`;
+    if (key === this.lastTrendingKey) return;
+    this.lastTrendingKey = key;
+
+    const lines = items.map((t) => {
+      const age = formatSince(t.lastTs, state.nowTs).padStart(3, " ");
+      const net = clampStr(t.network, 10).padEnd(10, " ");
+      const count = String(t.count).padStart(5, " ");
+      const id = clampStr(t.contractId, 40);
+      const line = `${age}  ${net}  ${count}  ${id}`;
+      return clampStr(line, width);
+    });
+
+    this.trendingList.setItems(lines.length ? lines : ["(no interactions)"]);
+  }
+
+  private renderActivity(state: DashboardState): void {
+    const width = Math.max(20, (this.activityBox.width as number) - 4);
+    const buckets = state.activity.slice(-120);
+    const deployments = buckets.map((b) => b.deployments);
+    const interactions = buckets.map((b) => b.interactions);
+
+    const key = `${width}:${buckets.length}:${buckets[buckets.length - 1]?.startTs ?? 0}`;
+    if (key === this.lastActivityKey) return;
+    this.lastActivityKey = key;
+
+    const dLine = sparkline(deployments, { width });
+    const iLine = sparkline(interactions, { width });
+
+    const dMax = deployments.length ? Math.max(...deployments) : 0;
+    const iMax = interactions.length ? Math.max(...interactions) : 0;
+
+    this.activityBox.setContent(
+      [
+        `Deployments: ${dLine}  max ${dMax}`,
+        `Interactions: ${iLine}  max ${iMax}`,
+        "",
+        "Tip: use f to filter (network/category), / to search by contract id."
+      ].join("\n")
+    );
+  }
+
+  private toggleFocus(): void {
+    if (this.modalActive) return;
+    this.focused = this.focused === "deployments" ? "trending" : "deployments";
+    this.applyFocusStyles();
+    this.params.requestRender();
+  }
+
+  private applyFocusStyles(): void {
+    const depFocused = this.focused === "deployments";
+    this.deploymentsList.style.border = { fg: depFocused ? "yellow" : "gray" };
+    this.trendingList.style.border = { fg: depFocused ? "gray" : "yellow" };
+  }
+
+  private onArrow(dir: "up" | "down"): void {
+    if (this.modalActive) return;
+    const list = this.focused === "deployments" ? this.deploymentsList : this.trendingList;
+    if (dir === "up") list.up(1);
+    else list.down(1);
+    this.params.requestRender();
+  }
+
+  private async openFilterModal(): Promise<void> {
+    if (this.modalActive) return;
+    this.modalActive = true;
+    try {
+      const current = this.params.getState();
+      const line = await promptLine({
+        screen: this.screen,
+        title: "Filters",
+        hint: "Enter: network=<name> category=<type>. Use empty value to clear, e.g. network= category=.\nExample: network=testnet category=dex",
+        initial: `network=${current.filters.network ?? ""} category=${current.filters.category ?? ""}`
+      });
+      if (line === undefined) return;
+
+      const parsed = parseKeyValueFilters(line);
+      const next: DashboardFilters = { ...current.filters, ...parsed, query: current.filters.query };
+      this.params.onSetFilters(next);
+    } finally {
+      this.modalActive = false;
+      this.params.requestRender();
+    }
+  }
+
+  private async openSearchModal(): Promise<void> {
+    if (this.modalActive) return;
+    this.modalActive = true;
+    try {
+      const current = this.params.getState();
+      const line = await promptLine({
+        screen: this.screen,
+        title: "Search",
+        hint: "Enter a substring to match contract id/publisher. Empty clears search.",
+        initial: current.filters.query ?? ""
+      });
+      if (line === undefined) return;
+      const next: DashboardFilters = { ...current.filters, query: line.trim() ? line.trim() : undefined };
+      this.params.onSetFilters(next);
+    } finally {
+      this.modalActive = false;
+      this.params.requestRender();
+    }
+  }
+}
+

--- a/cli/dashboard/src/dashboard/ui/modals.ts
+++ b/cli/dashboard/src/dashboard/ui/modals.ts
@@ -1,0 +1,85 @@
+import blessed from "blessed";
+
+// Lightweight, non-blocking modal input (doesn't stop WS event processing).
+export async function promptLine(params: {
+  screen: blessed.Widgets.Screen;
+  title: string;
+  hint: string;
+  initial?: string;
+}): Promise<string | undefined> {
+  const overlay = blessed.box({
+    parent: params.screen,
+    top: "center",
+    left: "center",
+    width: "80%",
+    height: 7,
+    border: "line",
+    label: ` ${params.title} `,
+    style: { border: { fg: "cyan" } }
+  });
+
+  blessed.text({
+    parent: overlay,
+    top: 1,
+    left: 2,
+    right: 2,
+    height: 2,
+    content: params.hint,
+    style: { fg: "white" }
+  });
+
+  const input = blessed.textbox({
+    parent: overlay,
+    top: 3,
+    left: 2,
+    right: 2,
+    height: 1,
+    inputOnFocus: true,
+    value: params.initial ?? "",
+    border: "line",
+    style: {
+      border: { fg: "gray" },
+      focus: { border: { fg: "yellow" } }
+    }
+  });
+
+  blessed.text({
+    parent: overlay,
+    top: 5,
+    left: 2,
+    right: 2,
+    height: 1,
+    content: "Enter: apply   Esc: cancel",
+    style: { fg: "gray" }
+  });
+
+  params.screen.render();
+  input.focus();
+
+  return await new Promise<string | undefined>((resolve) => {
+    const cleanup = (result: string | undefined) => {
+      input.removeAllListeners();
+      overlay.detach();
+      params.screen.render();
+      resolve(result);
+    };
+
+    input.key(["escape"], () => cleanup(undefined));
+    input.on("submit", (value) => cleanup(String(value ?? "")));
+    input.readInput();
+  });
+}
+
+export function parseKeyValueFilters(line: string): { network?: string; category?: string; query?: string } {
+  const out: { network?: string; category?: string; query?: string } = {};
+  for (const token of line.split(/\s+/).filter(Boolean)) {
+    const [k, ...rest] = token.split("=");
+    const v = rest.join("=").trim();
+    if (!k) continue;
+    if (k === "network") out.network = v || undefined;
+    if (k === "category") out.category = v || undefined;
+    if (k === "query") out.query = v || undefined;
+  }
+  return out;
+}
+

--- a/cli/dashboard/src/dashboard/util/format.ts
+++ b/cli/dashboard/src/dashboard/util/format.ts
@@ -1,0 +1,15 @@
+export function formatSince(ts: number, nowTs: number): string {
+  const deltaSec = Math.max(0, Math.floor((nowTs - ts) / 1000));
+  if (deltaSec < 60) return `${deltaSec}s`;
+  const min = Math.floor(deltaSec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  return `${hr}h`;
+}
+
+export function clampStr(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  if (maxLen <= 1) return s.slice(0, maxLen);
+  return `${s.slice(0, maxLen - 1)}…`;
+}
+

--- a/cli/dashboard/src/dashboard/ws/client.ts
+++ b/cli/dashboard/src/dashboard/ws/client.ts
@@ -1,0 +1,153 @@
+import WebSocket from "ws";
+import type { DashboardFilters, RegistryEvent } from "../types";
+import { parseRegistryEvent } from "./protocol";
+
+export type WsClientEvents = {
+  open: () => void;
+  close: (params: { code: number; reason: string }) => void;
+  error: (params: { message: string }) => void;
+  event: (ev: RegistryEvent) => void;
+  latency: (latencyMs: number) => void;
+};
+
+export class RegistryWsClient {
+  private ws: WebSocket | undefined;
+  private pingTimer: NodeJS.Timeout | undefined;
+  private reconnectTimer: NodeJS.Timeout | undefined;
+  private listeners: { [K in keyof WsClientEvents]?: Array<WsClientEvents[K]> } = {};
+  private attempt = 0;
+  private lastPingAt: number | undefined;
+
+  constructor(private readonly wsUrl: string) {}
+
+  on<K extends keyof WsClientEvents>(event: K, listener: WsClientEvents[K]): () => void {
+    const arr = (this.listeners[event] ??= []);
+    arr.push(listener);
+    return () => {
+      const next = (this.listeners[event] ?? []).filter((l) => l !== listener);
+      this.listeners[event] = next;
+    };
+  }
+
+  connect(filters: DashboardFilters): void {
+    this.clearReconnect();
+    this.attempt = 0;
+    this.open(filters);
+  }
+
+  close(): void {
+    this.clearReconnect();
+    this.clearPing();
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.close(1000, "client_exit");
+    } else {
+      this.ws?.terminate();
+    }
+    this.ws = undefined;
+  }
+
+  sendJson(payload: unknown): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    try {
+      this.ws.send(JSON.stringify(payload));
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit("error", { message });
+    }
+  }
+
+  private open(filters: DashboardFilters): void {
+    this.attempt += 1;
+    const ws = new WebSocket(this.wsUrl);
+    this.ws = ws;
+
+    ws.on("open", () => {
+      this.attempt = 0;
+      this.emit("open", undefined);
+      // Send current filters so servers can do server-side filtering when available.
+      this.sendJson({ type: "subscribe", payload: { filters } });
+      this.startPing();
+    });
+
+    ws.on("message", (data) => {
+      const parsed = tryParseJson(data);
+      const ev = parseRegistryEvent(parsed);
+      if (ev) this.emit("event", ev);
+    });
+
+    ws.on("pong", () => {
+      if (this.lastPingAt === undefined) return;
+      const latencyMs = Date.now() - this.lastPingAt;
+      this.emit("latency", latencyMs);
+      this.lastPingAt = undefined;
+    });
+
+    ws.on("close", (code, reason) => {
+      this.clearPing();
+      this.emit("close", { code, reason: reason.toString() });
+    });
+
+    ws.on("error", (err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit("error", { message });
+    });
+  }
+
+  scheduleReconnect(params: { filters: DashboardFilters; lastError?: string }): { attempt: number; nextRetryAt: number } {
+    this.clearReconnect();
+    const attempt = Math.max(1, this.attempt + 1);
+    const delay = computeBackoffDelayMs(attempt);
+    const nextRetryAt = Date.now() + delay;
+    this.reconnectTimer = setTimeout(() => this.open(params.filters), delay);
+    return { attempt, nextRetryAt };
+  }
+
+  private startPing(): void {
+    this.clearPing();
+    this.pingTimer = setInterval(() => {
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+      try {
+        this.lastPingAt = Date.now();
+        this.ws.ping();
+      } catch {
+        this.lastPingAt = undefined;
+      }
+    }, 5_000);
+  }
+
+  private clearPing(): void {
+    if (this.pingTimer) clearInterval(this.pingTimer);
+    this.pingTimer = undefined;
+    this.lastPingAt = undefined;
+  }
+
+  private clearReconnect(): void {
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = undefined;
+  }
+
+  private emit<K extends keyof WsClientEvents>(event: K, payload: Parameters<WsClientEvents[K]>[0] | undefined): void {
+    const list = this.listeners[event] ?? [];
+    for (const l of list) {
+      (l as any)(payload);
+    }
+  }
+}
+
+function computeBackoffDelayMs(attempt: number): number {
+  const base = 500;
+  const max = 30_000;
+  const exp = Math.min(max, base * 2 ** Math.min(10, attempt));
+  const jitter = Math.floor(Math.random() * 250);
+  return Math.min(max, exp + jitter);
+}
+
+function tryParseJson(data: WebSocket.RawData): unknown {
+  try {
+    const text = typeof data === "string" ? data : data.toString("utf8");
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+

--- a/cli/dashboard/src/dashboard/ws/protocol.ts
+++ b/cli/dashboard/src/dashboard/ws/protocol.ts
@@ -1,0 +1,42 @@
+import type { RegistryEvent } from "../types";
+
+// Parses and validates incoming WebSocket messages (defensive against bad payloads).
+export function parseRegistryEvent(message: unknown): RegistryEvent | undefined {
+  if (!isRecord(message)) return undefined;
+  const type = message.type;
+  const payload = message.payload;
+  if (typeof type !== "string" || !isRecord(payload)) return undefined;
+
+  if (type === "deployment_created") {
+    if (typeof payload.id !== "string") return undefined;
+    if (typeof payload.contractId !== "string") return undefined;
+    if (typeof payload.network !== "string") return undefined;
+    if (typeof payload.timestamp !== "string") return undefined;
+    if (payload.category !== undefined && typeof payload.category !== "string") return undefined;
+    if (payload.publisher !== undefined && typeof payload.publisher !== "string") return undefined;
+    return message as RegistryEvent;
+  }
+
+  if (type === "contract_interaction") {
+    if (typeof payload.id !== "string") return undefined;
+    if (typeof payload.contractId !== "string") return undefined;
+    if (typeof payload.network !== "string") return undefined;
+    if (typeof payload.timestamp !== "string") return undefined;
+    return message as RegistryEvent;
+  }
+
+  if (type === "network_status") {
+    if (typeof payload.network !== "string") return undefined;
+    if (payload.status !== "connected" && payload.status !== "degraded" && payload.status !== "disconnected") return undefined;
+    if (typeof payload.timestamp !== "string") return undefined;
+    if (payload.latencyMs !== undefined && typeof payload.latencyMs !== "number") return undefined;
+    return message as RegistryEvent;
+  }
+
+  return undefined;
+}
+
+function isRecord(v: unknown): v is Record<string, any> {
+  return typeof v === "object" && v !== null;
+}
+

--- a/cli/dashboard/src/index.ts
+++ b/cli/dashboard/src/index.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import { runDashboard } from "./dashboard/run";
+
+type DashboardOptions = {
+  refreshRate?: string;
+  network?: string;
+  category?: string;
+};
+
+const program = new Command();
+
+program.name("soroban-registry").description("Soroban-Registry CLI dashboard").version("0.1.0");
+
+program
+  .command("dashboard")
+  .description("Launch an interactive, real-time terminal dashboard")
+  .option("--refresh-rate <ms>", "Minimum interval between UI renders", "100")
+  .option("--network <name>", "Network filter (e.g. testnet, mainnet)")
+  .option("--category <type>", "Contract category filter (e.g. dex, nft)")
+  .action(async (opts: DashboardOptions) => {
+    const refreshRateMs = Number.parseInt(opts.refreshRate ?? "100", 10);
+    if (!Number.isFinite(refreshRateMs) || refreshRateMs <= 0) {
+      process.stderr.write("--refresh-rate must be a positive integer (ms)\n");
+      process.exitCode = 1;
+      return;
+    }
+
+    await runDashboard({
+      refreshRateMs,
+      network: opts.network,
+      category: opts.category
+    });
+  });
+
+program.parseAsync(process.argv).catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});
+

--- a/cli/dashboard/tsconfig.json
+++ b/cli/dashboard/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "lib": ["ES2022"],
+    "moduleResolution": "Node",
+    "types": ["node"],
+    "rootDir": ".",
+    "outDir": "dist",
+    "declaration": false,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "preserveShebang": true
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.ts"]
+}
+

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -611,14 +611,13 @@ pub async fn migrate(
     dry_run: bool,
 ) -> Result<()> {
     use sha2::{Digest, Sha256};
-    use std::fs;
     use tokio::process::Command;
 
     println!("\n{}", "Migration Tool".bold().cyan());
     println!("{}", "=".repeat(80).cyan());
 
     // 1. Read WASM file
-    let wasm_bytes = fs::read(wasm_path)
+    let wasm_bytes = std::fs::read(wasm_path)
         .with_context(|| format!("Failed to read WASM file at {}", wasm_path))?;
 
     // 2. Compute Hash
@@ -627,7 +626,13 @@ pub async fn migrate(
     let wasm_hash = hex::encode(hasher.finalize());
 
     println!("Contract ID: {}", contract_id.green());
-@@ -298,51 +309,51 @@ pub async fn migrate(
+    println!("WASM Hash: {}", wasm_hash.bright_black());
+
+    if dry_run {
+        println!("\n{}", "Dry run enabled: not contacting the registry API.".yellow());
+        println!("{}", "✓ Migration simulation complete (dry-run).".green().bold());
+        return Ok(());
+    }
 
     // 3. Create Migration Record (Pending)
     let client = reqwest::Client::new();
@@ -654,7 +659,6 @@ pub async fn migrate(
 
     let migration: serde_json::Value = response.json().await?;
     let migration_id = extract_migration_id(&migration)?;
-    let migration_id = crate::conversions::as_str(&migration["id"], "id")?;
     println!("{}", "OK".green());
     println!("Migration ID: {}", migration_id);
 
@@ -680,87 +684,6 @@ pub async fn migrate(
             println!("{}", "Simulating SUCCESS...".green());
             (
                 shared::models::MigrationStatus::Success,
-@@ -626,51 +637,54 @@ pub fn doc(contract_path: &str, output_dir: &str) -> Result<()> {
-    println!("{} Documentation generated at {:?}", "✓".green(), out_path);
-    Ok(())
-}
-
-pub async fn profile(
-    contract_path: &str,
-    method: Option<&str>,
-    output: Option<&str>,
-    flamegraph: Option<&str>,
-    compare: Option<&str>,
-    show_recommendations: bool,
-) -> Result<()> {
-    let path = Path::new(contract_path);
-    if !path.exists() {
-        anyhow::bail!("Contract file not found: {}", contract_path);
-    }
-
-    println!("\n{}", "Profiling contract...".bold().cyan());
-    println!("{}", "=".repeat(80).cyan());
-
-    let mut profiler = profiler::Profiler::new();
-    profiler::simulate_execution(path, method, &mut profiler)?;
-    let profile_data = profiler.finish(contract_path.to_string(), method.map(|s| s.to_string()));
-
-    println!("\n{}", "Profile Results:".bold().green());
-    println!(
-        "Total Duration: {:.2}ms",
-        profile_data.total_duration.as_secs_f64() * 1000.0
-    );
-    println!("Overhead: {:.2}%", profile_data.overhead_percent);
-    println!("Functions Profiled: {}", profile_data.functions.len());
-
-    let mut sorted_functions: Vec<_> = profile_data.functions.values().collect();
-    sorted_functions.sort_by(|a, b| b.total_time.cmp(&a.total_time));
-
-    println!("\n{}", "Top Functions:".bold());
-    for (i, func) in sorted_functions.iter().take(10).enumerate() {
-        println!(
-            "{}. {} - {:.2}ms ({} calls, avg: {:.2}μs)",
-            i + 1,
-            func.name.bold(),
-            func.total_time.as_secs_f64() * 1000.0,
-            func.call_count,
-            func.avg_time.as_secs_f64() * 1_000_000.0
-        );
-    }
-
-    if let Some(output_path) = output {
-        let json = serde_json::to_string_pretty(&profile_data)?;
-        std::fs::write(output_path, json)
-            .with_context(|| format!("Failed to write profile to: {}", output_path))?;
-        println!("\n{} Profile exported to: {}", "✓".green(), output_path);
-    }
-
-@@ -687,202 +701,254 @@ pub async fn profile(
-        let comparisons = profiler::compare_profiles(&baseline, &profile_data);
-
-        println!("\n{}", "Comparison Results:".bold().yellow());
-        for comp in comparisons.iter().take(10) {
-            let sign = if comp.time_diff_ns > 0 { "+" } else { "" };
-            println!(
-                "{}: {} ({}{:.2}%, {:.2}ms → {:.2}ms)",
-                comp.function.bold(),
-                comp.status,
-                sign,
-                comp.time_diff_percent,
-                comp.baseline_time.as_secs_f64() * 1000.0,
-                comp.current_time.as_secs_f64() * 1000.0
-            );
-        }
-    }
-
-    if show_recommendations {
-        let recommendations = profiler::generate_recommendations(&profile_data);
-        println!("\n{}", "Recommendations:".bold().magenta());
-        for (i, rec) in recommendations.iter().enumerate() {
-            println!("{}. {}", i + 1, rec);
-        }
-    }
-
                 "Simulation: Migration succeeded.".to_string(),
             )
         }

--- a/cli/src/dashboard.rs
+++ b/cli/src/dashboard.rs
@@ -1,0 +1,73 @@
+use anyhow::{anyhow, Context, Result};
+use std::path::PathBuf;
+use tokio::process::Command;
+
+pub struct DashboardParams {
+    pub refresh_rate_ms: u64,
+    pub network: Option<String>,
+    pub category: Option<String>,
+    pub ws_url: Option<String>,
+}
+
+pub async fn run_dashboard(params: DashboardParams) -> Result<()> {
+    let entry = dashboard_entrypoint().context("Unable to locate dashboard Node entrypoint")?;
+
+    let mut cmd = Command::new("node");
+    cmd.current_dir(cli_dir());
+    cmd.arg(entry);
+    cmd.arg("dashboard");
+    cmd.arg("--refresh-rate");
+    cmd.arg(params.refresh_rate_ms.to_string());
+
+    if let Some(network) = params.network.as_deref() {
+        cmd.arg("--network");
+        cmd.arg(network);
+    }
+
+    if let Some(category) = params.category.as_deref() {
+        cmd.arg("--category");
+        cmd.arg(category);
+    }
+
+    if let Some(ws_url) = params.ws_url.as_deref() {
+        cmd.env("SOROBAN_REGISTRY_WS_URL", ws_url);
+    }
+
+    cmd.stdin(std::process::Stdio::inherit());
+    cmd.stdout(std::process::Stdio::inherit());
+    cmd.stderr(std::process::Stdio::inherit());
+
+    let status = cmd.status().await.context("Failed to execute Node dashboard process")?;
+    if !status.success() {
+        return Err(anyhow!("Dashboard exited with status: {status}"));
+    }
+
+    Ok(())
+}
+
+fn cli_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn dashboard_entrypoint() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("SOROBAN_REGISTRY_DASHBOARD_ENTRY") {
+        let path = PathBuf::from(p);
+        if path.exists() {
+            return Ok(path);
+        }
+        return Err(anyhow!(
+            "SOROBAN_REGISTRY_DASHBOARD_ENTRY points to a missing path: {}",
+            path.display()
+        ));
+    }
+
+    let path = cli_dir().join("dashboard").join("dist").join("index.js");
+    if path.exists() {
+        return Ok(path);
+    }
+
+    Err(anyhow!(
+        "Dashboard entrypoint not found. Build it first: cd cli/dashboard && npm install && npm run build"
+    ))
+}
+

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@ mod commands;
 mod config;
 mod conversions;
 mod coverage;
+mod dashboard;
 mod events;
 mod export;
 mod formal_verification;
@@ -124,6 +125,19 @@ pub enum Commands {
         /// Output results as machine-readable JSON
         #[arg(long)]
         json: bool,
+    },
+
+    /// Launch an interactive, real-time terminal dashboard
+    Dashboard {
+        /// Minimum interval between UI renders (milliseconds)
+        #[arg(long, default_value = "100")]
+        refresh_rate: u64,
+        /// Filter by contract category
+        #[arg(long)]
+        category: Option<String>,
+        /// WebSocket URL (or set SOROBAN_REGISTRY_WS_URL)
+        #[arg(long, env = "SOROBAN_REGISTRY_WS_URL")]
+        ws_url: Option<String>,
     },
 
     /// Detect breaking changes between contract versions
@@ -974,6 +988,25 @@ async fn main() -> Result<()> {
         Commands::List { limit, json } => {
             log::debug!("Command: list | limit={}", limit);
             commands::list(&cli.api_url, limit, network, json).await?;
+        }
+        Commands::Dashboard {
+            refresh_rate,
+            category,
+            ws_url,
+        } => {
+            log::debug!(
+                "Command: dashboard | refresh_rate={} network={:?} category={:?}",
+                refresh_rate,
+                cli.network,
+                category
+            );
+            dashboard::run_dashboard(dashboard::DashboardParams {
+                refresh_rate_ms: refresh_rate,
+                network: cli.network.clone(),
+                category,
+                ws_url,
+            })
+            .await?;
         }
         Commands::BreakingChanges { old_id, new_id, json } => {
             log::debug!("Command: breaking-changes | old={} new={}", old_id, new_id);


### PR DESCRIPTION
Closes #440 

## Summary
Adds a new interactive terminal dashboard command to the Soroban-Registry CLI:

- `soroban-registry dashboard`

The dashboard renders a full-screen TUI (header + panels + activity chart) and updates in real-time from a WebSocket event stream.

## What’s Included
- New Rust CLI subcommand: `dashboard` (options: `--refresh-rate`, `--category`, plus global `--network`)
- Node/TypeScript dashboard implementation located under `cli/dashboard/` using:
  - commander (CLI)
  - blessed (terminal UI)
  - ws (WebSocket client)
  - ASCII sparkline chart rendering
- Keyboard controls:
  - `q` quit
  - `r` refresh
  - `f` filter modal (network/category)
  - `/` search modal
  - arrow keys + tab to navigate panels
- Robust WebSocket handling:
  - defensive event parsing
  - latency measurement via ping/pong
  - auto-reconnect with backoff
- Mock WebSocket server for local testing when backend stream isn’t available


## How To Test (Local)
1. Build the dashboard:
   - `cd cli/dashboard`
   - `npm install`
   - `npm run build`

2. Run mock event stream:
   - `npm run mock:server`

3. Launch dashboard via Rust CLI:
   - `cd cli`
   - `cargo run --bin soroban-registry -- dashboard --refresh-rate 100 --network testnet --category dex`

## Notes
- WebSocket URL can be provided via `SOROBAN_REGISTRY_WS_URL` (default: `ws://127.0.0.1:8787`).
- Rust wrapper locates the Node entrypoint at `cli/dashboard/dist/index.js` (override via `SOROBAN_REGISTRY_DASHBOARD_ENTRY` if needed).