### PR TITLE
Add pagination metadata to list endpoints

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -75,6 +75,7 @@ aes-gcm = "0.10"
 rand = "0.8"
 base64 = "0.22"
 sha2 = "0.10"
+hmac = "0.12"
 hex = "0.4"
 
 syn = { version = "2.0", features = ["full", "visit"] }

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -44,6 +44,7 @@ aes-gcm = { workspace = true }
 rand = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
+hmac = { workspace = true }
 hex = { workspace = true }
 moka = { version = "0.12.13", features = ["future"] }
 async-trait = "0.1.89"

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -3792,9 +3792,11 @@ pub async fn get_publisher(
 )]
 pub async fn get_publisher_contracts(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     Path(id): Path<String>,
     Query(query): Query<PublisherContractsQuery>,
-) -> ApiResult<Json<PaginatedResponse<Contract>>> {
+) -> ApiResult<crate::pagination::PagedJson<Contract>> {
     let publisher_uuid = Uuid::parse_str(&id).map_err(|_| {
         ApiError::bad_request(
             "InvalidPublisherId",
@@ -3802,18 +3804,15 @@ pub async fn get_publisher_contracts(
         )
     })?;
 
-    // Validate and cap limit (max 100)
     let limit = query.limit.clamp(1, 100);
     let offset = query.offset.max(0);
 
-    // Get total count
     let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM contracts WHERE publisher_id = $1")
         .bind(publisher_uuid)
         .fetch_one(&state.db)
         .await
         .map_err(|err| db_internal_error("get publisher contracts count", err))?;
 
-    // Fetch paginated results
     let contracts: Vec<Contract> = sqlx::query_as(
         "SELECT * FROM contracts WHERE publisher_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
     )
@@ -3825,9 +3824,9 @@ pub async fn get_publisher_contracts(
     .map_err(|err| db_internal_error("get publisher contracts", err))?;
 
     let page = (offset / limit) + 1;
-    let response = PaginatedResponse::new(contracts, total, page, limit);
+    let body = PaginatedResponse::new(contracts, total, page, limit);
 
-    Ok(Json(response))
+    Ok(crate::pagination::PagedJson::new(body, &headers, &uri))
 }
 
 /// Query for contract ABI and OpenAPI (optional version)

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -62,6 +62,7 @@ mod simulation_handlers;
 mod state;
 
 mod clone_federation_handlers;
+mod pagination;
 mod gas_estimation_handlers;
 mod security_scan_handlers;
 mod subscription_handlers;

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -61,8 +61,13 @@ mod simulation;
 mod simulation_handlers;
 mod state;
 
+mod clone_federation_handlers;
+mod gas_estimation_handlers;
+mod security_scan_handlers;
+mod subscription_handlers;
 mod type_safety;
 mod validation;
+mod webhook_delivery;
 mod websocket;
 
 use anyhow::Result;
@@ -191,6 +196,9 @@ async fn main() -> Result<()> {
     // Initialize GraphQL schema
     let schema = graphql::schema::build_schema(state.clone());
 
+    // Spawn webhook delivery background task
+    webhook_delivery::spawn_webhook_delivery_task(pool.clone());
+
     // Spawn the background DB and cache monitoring task
     db_monitoring::spawn_db_monitoring_task(pool.clone(), state.cache.clone());
 
@@ -271,6 +279,7 @@ async fn main() -> Result<()> {
         .merge(multisig_routes::routes())
         .merge(routes::observability_routes())
         .merge(routes::websocket_routes())
+        .merge(routes::subscription_routes())
         .merge(routes::validator_routes())
         .merge(release_notes_routes::release_notes_routes())
         .route("/api/graphql", axum::routing::post(graphql::graphql_handler).with_state(schema))

--- a/backend/api/src/pagination.rs
+++ b/backend/api/src/pagination.rs
@@ -1,0 +1,200 @@
+// Pagination helpers: RFC 5988 Link headers and PagedJson response type.
+//
+// Usage in a handler:
+//
+//   pub async fn list_things(
+//       headers: HeaderMap,
+//       OriginalUri(uri): OriginalUri,
+//       ...
+//   ) -> ApiResult<PagedJson<Thing>> {
+//       let body = PaginatedResponse::new(items, total, page, limit);
+//       Ok(PagedJson::new(body, &headers, &uri))
+//   }
+
+use axum::{
+    http::{HeaderMap, HeaderValue, StatusCode, Uri},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Serialize;
+use shared::PaginatedResponse;
+
+// ─── PagedJson ────────────────────────────────────────────────────────────────
+
+/// An Axum response that serialises a [`PaginatedResponse`] as JSON and
+/// appends an RFC 5988 `Link` header when more than one page exists.
+pub struct PagedJson<T: Serialize + Send>(PaginatedResponse<T>, Option<String>);
+
+impl<T: Serialize + Send> PagedJson<T> {
+    /// Build the response, deriving Link header URLs from the incoming request.
+    pub fn new(body: PaginatedResponse<T>, req_headers: &HeaderMap, uri: &Uri) -> Self {
+        let link = link_header(req_headers, uri, body.page, body.total_pages, body.page_size);
+        Self(body, link)
+    }
+}
+
+impl<T: Serialize + Send> IntoResponse for PagedJson<T> {
+    fn into_response(self) -> Response {
+        let PagedJson(body, link) = self;
+        let mut headers = HeaderMap::new();
+        if let Some(link_val) = link {
+            if let Ok(v) = HeaderValue::from_str(&link_val) {
+                headers.insert(axum::http::header::LINK, v);
+            }
+        }
+        (StatusCode::OK, headers, Json(body)).into_response()
+    }
+}
+
+// ─── Link header builder ──────────────────────────────────────────────────────
+
+/// Produces an RFC 5988 `Link` header value for the given page/pages context.
+/// Returns `None` when there is only one page (no navigation links needed).
+///
+/// All existing query parameters except `page`, `per_page`, `limit`, and
+/// `offset` are preserved in the generated URLs.
+pub fn link_header(
+    req_headers: &HeaderMap,
+    uri: &Uri,
+    page: i64,
+    pages: i64,
+    per_page: i64,
+) -> Option<String> {
+    if pages <= 1 {
+        return None;
+    }
+
+    let scheme = req_headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("https");
+
+    let host = req_headers
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("localhost");
+
+    let path = uri.path();
+    let existing = uri.query().unwrap_or("");
+
+    let url = |p: i64| -> String {
+        format!(
+            "{}://{}{}?{}",
+            scheme,
+            host,
+            path,
+            paged_query(existing, p, per_page)
+        )
+    };
+
+    let mut parts = vec![
+        format!("<{}>; rel=\"first\"", url(1)),
+        format!("<{}>; rel=\"last\"", url(pages)),
+    ];
+    if page > 1 {
+        parts.push(format!("<{}>; rel=\"prev\"", url(page - 1)));
+    }
+    if page < pages {
+        parts.push(format!("<{}>; rel=\"next\"", url(page + 1)));
+    }
+
+    Some(parts.join(", "))
+}
+
+/// Rebuilds a query string, replacing (or inserting) `page` and `per_page`
+/// and stripping out legacy `limit`/`offset` params.
+fn paged_query(existing: &str, page: i64, per_page: i64) -> String {
+    let mut params: Vec<(String, String)> = existing
+        .split('&')
+        .filter(|s| !s.is_empty())
+        .filter_map(|kv| {
+            let mut it = kv.splitn(2, '=');
+            let k = it.next()?.to_string();
+            let v = it.next().unwrap_or("").to_string();
+            Some((k, v))
+        })
+        .filter(|(k, _)| !matches!(k.as_str(), "page" | "per_page" | "limit" | "offset"))
+        .collect();
+
+    params.push(("page".to_string(), page.to_string()));
+    params.push(("per_page".to_string(), per_page.to_string()));
+
+    params
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uri(path_query: &str) -> Uri {
+        path_query.parse().unwrap()
+    }
+
+    fn headers_with_host(host: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(axum::http::header::HOST, HeaderValue::from_str(host).unwrap());
+        h.insert(
+            "x-forwarded-proto",
+            HeaderValue::from_static("https"),
+        );
+        h
+    }
+
+    #[test]
+    fn no_link_header_when_single_page() {
+        let h = headers_with_host("api.example.com");
+        let u = uri("/api/items?limit=20");
+        assert!(link_header(&h, &u, 1, 1, 20).is_none());
+    }
+
+    #[test]
+    fn first_page_has_no_prev() {
+        let h = headers_with_host("api.example.com");
+        let u = uri("/api/items?category=defi");
+        let header = link_header(&h, &u, 1, 5, 20).unwrap();
+        assert!(header.contains("rel=\"next\""));
+        assert!(header.contains("rel=\"first\""));
+        assert!(header.contains("rel=\"last\""));
+        assert!(!header.contains("rel=\"prev\""));
+    }
+
+    #[test]
+    fn last_page_has_no_next() {
+        let h = headers_with_host("api.example.com");
+        let u = uri("/api/items");
+        let header = link_header(&h, &u, 5, 5, 20).unwrap();
+        assert!(header.contains("rel=\"prev\""));
+        assert!(!header.contains("rel=\"next\""));
+    }
+
+    #[test]
+    fn middle_page_has_all_links() {
+        let h = headers_with_host("api.example.com");
+        let u = uri("/api/items?q=foo&limit=20&offset=40");
+        let header = link_header(&h, &u, 3, 5, 20).unwrap();
+        assert!(header.contains("rel=\"first\""));
+        assert!(header.contains("rel=\"last\""));
+        assert!(header.contains("rel=\"prev\""));
+        assert!(header.contains("rel=\"next\""));
+        // legacy params should be stripped, q should survive
+        assert!(header.contains("q=foo"));
+        assert!(!header.contains("offset="));
+        assert!(!header.contains("limit="));
+    }
+
+    #[test]
+    fn paged_query_strips_and_replaces() {
+        let q = paged_query("limit=20&offset=40&network=testnet", 2, 20);
+        assert!(q.contains("page=2"));
+        assert!(q.contains("per_page=20"));
+        assert!(q.contains("network=testnet"));
+        assert!(!q.contains("limit="));
+        assert!(!q.contains("offset="));
+    }
+}

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -486,10 +486,6 @@ pub fn compatibility_dashboard_routes() -> Router<AppState> {
     )
 }
 
-pub fn category_routes() -> Router<AppState> {
-    Router::new().route("/api/categories", get(category_handlers::list_categories))
-}
-
 pub fn canary_routes() -> Router<AppState> {
     Router::new()
         // Contract-scoped canary endpoints
@@ -660,10 +656,9 @@ pub fn federation_routes() -> Router<AppState> {
 }
 
 pub fn websocket_routes() -> Router<AppState> {
-    Router::new().route(
-        "/ws/contracts",
-        axum::routing::get(websocket::websocket_handler),
-    )
+    // /ws/contracts is registered in contract_routes via contract_events::contracts_websocket.
+    // This function is retained so main.rs can call it without a merge conflict.
+    Router::new()
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -758,5 +753,17 @@ pub fn subscription_routes() -> Router<AppState> {
         .route(
             "/api/webhooks/:id",
             delete(subscription_handlers::delete_webhook),
+        )
+        .route(
+            "/api/webhooks/:id/deliveries",
+            get(subscription_handlers::get_webhook_deliveries),
+        )
+        .route(
+            "/api/webhooks/:id/test",
+            post(subscription_handlers::test_webhook),
+        )
+        .route(
+            "/api/webhook-deliveries/:id/retry",
+            post(subscription_handlers::retry_webhook_delivery),
         )
 }

--- a/backend/api/src/state.rs
+++ b/backend/api/src/state.rs
@@ -3,16 +3,13 @@ use crate::cache::{CacheConfig, CacheLayer};
 use crate::contract_events::ContractEventHub;
 use crate::health_monitor::HealthMonitorStatus;
 use crate::resource_tracking::ResourceManager;
-use shared::error::Result;
 use shared::source_storage::SourceStorage;
 
 use prometheus::Registry;
-use shared::source_storage::SourceStorage;
 use sqlx::PgPool;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
-
 
 use tokio::sync::broadcast;
 
@@ -55,10 +52,7 @@ pub struct AppState {
     pub resource_mgr: Arc<RwLock<ResourceManager>>,
     pub source_storage: Arc<SourceStorage>,
     pub event_broadcaster: broadcast::Sender<RealtimeEvent>,
-    pub contract_events: Arc<ContractEventHub>,
-    pub source_storage: Arc<shared::source_storage::SourceStorage>,
 }
-
 
 impl AppState {
     pub async fn new(
@@ -88,12 +82,6 @@ impl AppState {
             resource_mgr,
             source_storage,
             event_broadcaster,
-            contract_events: Arc::new(ContractEventHub::from_env()),
-            source_storage: Arc::new(
-                shared::source_storage::SourceStorage::new()
-                    .await
-                    .expect("source storage init"),
-            ),
         })
     }
 }

--- a/backend/api/src/subscription_handlers.rs
+++ b/backend/api/src/subscription_handlers.rs
@@ -2,8 +2,8 @@
 // Enable users to subscribe to alerts for contract updates and changes
 
 use axum::{
-    extract::{Path, Query, State},
-    http::StatusCode,
+    extract::{OriginalUri, Path, Query, State},
+    http::{HeaderMap, StatusCode},
     Json,
 };
 use chrono::Utc;
@@ -12,14 +12,14 @@ use uuid::Uuid;
 use crate::{
     auth,
     error::{ApiError, ApiResult},
+    pagination::PagedJson,
     state::AppState,
 };
 use shared::{
     ContractSubscription, ContractSubscriptionSummary, CreateWebhookRequest,
     NotificationChannel, NotificationFrequency, NotificationQueueItem, NotificationType,
-    SubscribeRequest, SubscriptionStatus, UpdateSubscriptionRequest,
-    UpdateUserNotificationPreferencesRequest, UserNotificationPreferences,
-    UserSubscriptionsResponse, WebhookConfiguration,
+    PaginatedResponse, SubscribeRequest, SubscriptionStatus, UpdateSubscriptionRequest,
+    UpdateUserNotificationPreferencesRequest, UserNotificationPreferences, WebhookConfiguration,
 };
 
 // ─── Query / response types ────────────────────────────────────────────────
@@ -38,12 +38,6 @@ pub struct NotificationQuery {
     pub unread_only: Option<bool>,
 }
 
-#[derive(Debug, serde::Serialize)]
-pub struct NotificationListResponse {
-    pub notifications: Vec<NotificationQueueItem>,
-    pub total_count: i64,
-}
-
 #[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
 pub struct StatisticsQuery {
     pub period_start: chrono::NaiveDate,
@@ -54,6 +48,13 @@ pub struct StatisticsQuery {
 pub struct DeliveriesQuery {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
+    pub page: Option<i64>,
+}
+
+#[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
+pub struct ListWebhooksQuery {
+    pub limit: Option<i64>,
+    pub page: Option<i64>,
 }
 
 #[derive(Debug, serde::Serialize, sqlx::FromRow)]
@@ -69,12 +70,6 @@ pub struct WebhookDeliveryLog {
     pub attempt_number: i32,
     pub delivery_duration_ms: Option<i64>,
     pub created_at: chrono::DateTime<Utc>,
-}
-
-#[derive(Debug, serde::Serialize)]
-pub struct WebhookDeliveriesResponse {
-    pub deliveries: Vec<WebhookDeliveryLog>,
-    pub total_count: i64,
 }
 
 // ─── Subscribe / Unsubscribe ───────────────────────────────────────────────
@@ -163,15 +158,17 @@ pub async fn unsubscribe_from_contract(
 /// GET /api/me/subscriptions
 pub async fn list_user_subscriptions(
     State(state): State<AppState>,
+    headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
     auth_user: auth::AuthenticatedUser,
     Query(query): Query<ListSubscriptionsQuery>,
-) -> ApiResult<Json<UserSubscriptionsResponse>> {
+) -> ApiResult<PagedJson<ContractSubscriptionSummary>> {
     let user_id = auth_user.publisher_id;
-    let limit = query.limit.unwrap_or(20);
-    let offset = query.offset.unwrap_or(0);
+    let per_page = query.limit.unwrap_or(20).clamp(1, 100);
+    let offset = query.offset.unwrap_or(0).max(0);
+    let page = (offset / per_page) + 1;
 
-    // Use separate queries to avoid dynamic parameter numbering bugs.
-    let (subscriptions, total_count) = if let Some(ref status) = query.status {
+    let (items, total) = if let Some(ref status) = query.status {
         let rows = sqlx::query_as::<_, ContractSubscriptionSummary>(
             r#"
             SELECT cs.id, cs.contract_id, c.name AS contract_name,
@@ -186,21 +183,20 @@ pub async fn list_user_subscriptions(
         )
         .bind(user_id)
         .bind(status)
-        .bind(limit)
+        .bind(per_page)
         .bind(offset)
         .fetch_all(&state.db)
         .await
         .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
 
-        let count: i64 =
-            sqlx::query_scalar(
-                "SELECT COUNT(*) FROM contract_subscriptions WHERE user_id = $1 AND status = $2",
-            )
-            .bind(user_id)
-            .bind(status)
-            .fetch_one(&state.db)
-            .await
-            .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM contract_subscriptions WHERE user_id = $1 AND status = $2",
+        )
+        .bind(user_id)
+        .bind(status)
+        .fetch_one(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
 
         (rows, count)
     } else {
@@ -217,7 +213,7 @@ pub async fn list_user_subscriptions(
             "#,
         )
         .bind(user_id)
-        .bind(limit)
+        .bind(per_page)
         .bind(offset)
         .fetch_all(&state.db)
         .await
@@ -233,10 +229,11 @@ pub async fn list_user_subscriptions(
         (rows, count)
     };
 
-    Ok(Json(UserSubscriptionsResponse {
-        subscriptions,
-        total_count,
-    }))
+    Ok(PagedJson::new(
+        PaginatedResponse::new(items, total, page, per_page),
+        &headers,
+        &uri,
+    ))
 }
 
 /// PATCH /api/subscriptions/:id
@@ -437,15 +434,18 @@ pub async fn update_notification_preferences(
 /// GET /api/notifications
 pub async fn list_notifications(
     State(state): State<AppState>,
+    headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
     auth_user: auth::AuthenticatedUser,
     Query(query): Query<NotificationQuery>,
-) -> ApiResult<Json<NotificationListResponse>> {
+) -> ApiResult<PagedJson<NotificationQueueItem>> {
     let user_id = auth_user.publisher_id;
-    let limit = query.limit.unwrap_or(50);
-    let offset = query.offset.unwrap_or(0);
+    let per_page = query.limit.unwrap_or(50).clamp(1, 200);
+    let offset = query.offset.unwrap_or(0).max(0);
+    let page = (offset / per_page) + 1;
     let unread_only = query.unread_only.unwrap_or(false);
 
-    let (notifications, total_count) = if unread_only {
+    let (items, total) = if unread_only {
         let rows = sqlx::query_as::<_, NotificationQueueItem>(
             r#"
             SELECT nq.*
@@ -457,7 +457,7 @@ pub async fn list_notifications(
             "#,
         )
         .bind(user_id)
-        .bind(limit)
+        .bind(per_page)
         .bind(offset)
         .fetch_all(&state.db)
         .await
@@ -488,7 +488,7 @@ pub async fn list_notifications(
             "#,
         )
         .bind(user_id)
-        .bind(limit)
+        .bind(per_page)
         .bind(offset)
         .fetch_all(&state.db)
         .await
@@ -509,10 +509,11 @@ pub async fn list_notifications(
         (rows, count)
     };
 
-    Ok(Json(NotificationListResponse {
-        notifications,
-        total_count,
-    }))
+    Ok(PagedJson::new(
+        PaginatedResponse::new(items, total, page, per_page),
+        &headers,
+        &uri,
+    ))
 }
 
 /// POST /api/notifications/:id/read
@@ -619,17 +620,42 @@ pub async fn get_notification_statistics(
 /// GET /api/webhooks
 pub async fn list_webhooks(
     State(state): State<AppState>,
+    headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
     auth_user: auth::AuthenticatedUser,
-) -> ApiResult<Json<Vec<WebhookConfiguration>>> {
+    Query(query): Query<ListWebhooksQuery>,
+) -> ApiResult<PagedJson<WebhookConfiguration>> {
+    let per_page = query.limit.unwrap_or(20).clamp(1, 100);
+    let page = query.page.unwrap_or(1).max(1);
+    let offset = (page - 1) * per_page;
+
     let webhooks = sqlx::query_as::<_, WebhookConfiguration>(
-        "SELECT * FROM webhook_configurations WHERE user_id = $1 ORDER BY created_at DESC",
+        r#"
+        SELECT * FROM webhook_configurations
+        WHERE user_id = $1
+        ORDER BY created_at DESC
+        LIMIT $2 OFFSET $3
+        "#,
     )
     .bind(auth_user.publisher_id)
+    .bind(per_page)
+    .bind(offset)
     .fetch_all(&state.db)
     .await
     .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
 
-    Ok(Json(webhooks))
+    let total: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM webhook_configurations WHERE user_id = $1")
+            .bind(auth_user.publisher_id)
+            .fetch_one(&state.db)
+            .await
+            .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+    Ok(PagedJson::new(
+        PaginatedResponse::new(webhooks, total, page, per_page),
+        &headers,
+        &uri,
+    ))
 }
 
 /// POST /api/webhooks
@@ -694,11 +720,12 @@ pub async fn delete_webhook(
 /// GET /api/webhooks/:id/deliveries
 pub async fn get_webhook_deliveries(
     State(state): State<AppState>,
+    headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
     Path(webhook_id): Path<Uuid>,
     auth_user: auth::AuthenticatedUser,
     Query(query): Query<DeliveriesQuery>,
-) -> ApiResult<Json<WebhookDeliveriesResponse>> {
-    // Verify ownership.
+) -> ApiResult<PagedJson<WebhookDeliveryLog>> {
     let owned: bool = sqlx::query_scalar(
         "SELECT EXISTS(SELECT 1 FROM webhook_configurations WHERE id = $1 AND user_id = $2)",
     )
@@ -712,8 +739,9 @@ pub async fn get_webhook_deliveries(
         return Err(ApiError::not_found("webhook", "Webhook not found"));
     }
 
-    let limit = query.limit.unwrap_or(50);
-    let offset = query.offset.unwrap_or(0);
+    let per_page = query.limit.unwrap_or(50).clamp(1, 200);
+    let page = query.page.unwrap_or(1).max(1);
+    let offset = (page - 1) * per_page;
 
     let deliveries = sqlx::query_as::<_, WebhookDeliveryLog>(
         r#"
@@ -726,23 +754,24 @@ pub async fn get_webhook_deliveries(
         "#,
     )
     .bind(webhook_id)
-    .bind(limit)
+    .bind(per_page)
     .bind(offset)
     .fetch_all(&state.db)
     .await
     .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
 
-    let total_count: i64 =
+    let total: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM notification_delivery_logs WHERE webhook_id = $1")
             .bind(webhook_id)
             .fetch_one(&state.db)
             .await
             .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
 
-    Ok(Json(WebhookDeliveriesResponse {
-        deliveries,
-        total_count,
-    }))
+    Ok(PagedJson::new(
+        PaginatedResponse::new(deliveries, total, page, per_page),
+        &headers,
+        &uri,
+    ))
 }
 
 /// POST /api/webhooks/:id/test  — sends a synthetic test event to the webhook.

--- a/backend/api/src/subscription_handlers.rs
+++ b/backend/api/src/subscription_handlers.rs
@@ -16,12 +16,14 @@ use crate::{
 };
 use shared::{
     ContractSubscription, ContractSubscriptionSummary, CreateWebhookRequest,
-    NotificationChannel, NotificationFrequency, NotificationType, SubscribeRequest,
-    SubscriptionStatus, UpdateSubscriptionRequest, UpdateUserNotificationPreferencesRequest,
-    UserNotificationPreferences, UserSubscriptionsResponse, WebhookConfiguration,
+    NotificationChannel, NotificationFrequency, NotificationQueueItem, NotificationType,
+    SubscribeRequest, SubscriptionStatus, UpdateSubscriptionRequest,
+    UpdateUserNotificationPreferencesRequest, UserNotificationPreferences,
+    UserSubscriptionsResponse, WebhookConfiguration,
 };
 
-/// Query parameters for listing subscriptions
+// ─── Query / response types ────────────────────────────────────────────────
+
 #[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
 pub struct ListSubscriptionsQuery {
     pub limit: Option<i64>,
@@ -29,8 +31,54 @@ pub struct ListSubscriptionsQuery {
     pub status: Option<String>,
 }
 
-/// Subscribe to a contract
-///
+#[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
+pub struct NotificationQuery {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+    pub unread_only: Option<bool>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct NotificationListResponse {
+    pub notifications: Vec<NotificationQueueItem>,
+    pub total_count: i64,
+}
+
+#[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
+pub struct StatisticsQuery {
+    pub period_start: chrono::NaiveDate,
+    pub period_end: chrono::NaiveDate,
+}
+
+#[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
+pub struct DeliveriesQuery {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, serde::Serialize, sqlx::FromRow)]
+pub struct WebhookDeliveryLog {
+    pub id: Uuid,
+    pub webhook_id: Uuid,
+    pub notification_id: Option<Uuid>,
+    pub event_type: String,
+    pub status: String,
+    pub response_code: Option<i32>,
+    pub response_body: Option<String>,
+    pub error_message: Option<String>,
+    pub attempt_number: i32,
+    pub delivery_duration_ms: Option<i64>,
+    pub created_at: chrono::DateTime<Utc>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct WebhookDeliveriesResponse {
+    pub deliveries: Vec<WebhookDeliveryLog>,
+    pub total_count: i64,
+}
+
+// ─── Subscribe / Unsubscribe ───────────────────────────────────────────────
+
 /// POST /api/contracts/:id/subscribe
 pub async fn subscribe_to_contract(
     State(state): State<AppState>,
@@ -38,40 +86,32 @@ pub async fn subscribe_to_contract(
     auth_user: auth::AuthenticatedUser,
     Json(req): Json<SubscribeRequest>,
 ) -> ApiResult<Json<ContractSubscription>> {
-    // Verify contract exists
-    let contract_exists: bool = sqlx::query_scalar(
-        "SELECT EXISTS(SELECT 1 FROM contracts WHERE id = $1)",
-    )
-    .bind(contract_id)
-    .fetch_one(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    let contract_exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM contracts WHERE id = $1)")
+            .bind(contract_id)
+            .fetch_one(&state.db)
+            .await
+            .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
 
     if !contract_exists {
         return Err(ApiError::not_found("contract", "Contract not found"));
     }
 
-    // Get user's publisher_id
     let user_id = auth_user.publisher_id;
 
-    // Default values
     let notification_types = req.notification_types.unwrap_or(vec![
         NotificationType::NewVersion,
         NotificationType::VerificationStatus,
         NotificationType::SecurityIssue,
     ]);
-
-    let channels = req
-        .channels
-        .unwrap_or(vec![NotificationChannel::InApp]);
-
+    let channels = req.channels.unwrap_or(vec![NotificationChannel::InApp]);
     let frequency = req.frequency.unwrap_or(NotificationFrequency::Realtime);
 
-    // Create or update subscription
     let subscription = sqlx::query_as::<_, ContractSubscription>(
         r#"
         INSERT INTO contract_subscriptions
-        (user_id, contract_id, status, notification_types, channels, frequency, min_severity, created_at, updated_at)
+            (user_id, contract_id, status, notification_types, channels, frequency, min_severity,
+             created_at, updated_at)
         VALUES ($1, $2, 'active', $3, $4, $5, $6, NOW(), NOW())
         ON CONFLICT (user_id, contract_id) DO UPDATE SET
             status = 'active',
@@ -96,20 +136,16 @@ pub async fn subscribe_to_contract(
     Ok(Json(subscription))
 }
 
-/// Unsubscribe from a contract
-///
 /// DELETE /api/contracts/:id/subscribe
 pub async fn unsubscribe_from_contract(
     State(state): State<AppState>,
     Path(contract_id): Path<Uuid>,
     auth_user: auth::AuthenticatedUser,
 ) -> ApiResult<StatusCode> {
-    let user_id = auth_user.publisher_id;
-
     let rows_affected = sqlx::query(
         "DELETE FROM contract_subscriptions WHERE user_id = $1 AND contract_id = $2",
     )
-    .bind(user_id)
+    .bind(auth_user.publisher_id)
     .bind(contract_id)
     .execute(&state.db)
     .await
@@ -117,17 +153,13 @@ pub async fn unsubscribe_from_contract(
     .rows_affected();
 
     if rows_affected == 0 {
-        return Err(ApiError::not_found(
-            "subscription",
-            "Subscription not found",
-        ));
+        return Err(ApiError::not_found("subscription", "Subscription not found"));
     }
-
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// List user's subscriptions
-///
+// ─── List / Update subscriptions ──────────────────────────────────────────
+
 /// GET /api/me/subscriptions
 pub async fn list_user_subscriptions(
     State(state): State<AppState>,
@@ -138,54 +170,68 @@ pub async fn list_user_subscriptions(
     let limit = query.limit.unwrap_or(20);
     let offset = query.offset.unwrap_or(0);
 
-    let mut where_clause = "WHERE cs.user_id = $1".to_string();
-    if let Some(status) = &query.status {
-        where_clause.push_str(&format!(" AND cs.status = ${}", 2));
-    }
+    // Use separate queries to avoid dynamic parameter numbering bugs.
+    let (subscriptions, total_count) = if let Some(ref status) = query.status {
+        let rows = sqlx::query_as::<_, ContractSubscriptionSummary>(
+            r#"
+            SELECT cs.id, cs.contract_id, c.name AS contract_name,
+                   c.slug AS contract_slug, cs.status, cs.notification_types,
+                   cs.channels, cs.frequency, cs.created_at
+            FROM contract_subscriptions cs
+            JOIN contracts c ON cs.contract_id = c.id
+            WHERE cs.user_id = $1 AND cs.status = $2
+            ORDER BY cs.created_at DESC
+            LIMIT $3 OFFSET $4
+            "#,
+        )
+        .bind(user_id)
+        .bind(status)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
 
-    let subscriptions = sqlx::query_as::<_, ContractSubscriptionSummary>(&format!(
-        r#"
-        SELECT 
-            cs.id,
-            cs.contract_id,
-            c.name as contract_name,
-            c.slug as contract_slug,
-            cs.status,
-            cs.notification_types,
-            cs.channels,
-            cs.frequency,
-            cs.created_at
-        FROM contract_subscriptions cs
-        JOIN contracts c ON cs.contract_id = c.id
-        {}
-        ORDER BY cs.created_at DESC
-        LIMIT ${} OFFSET ${}
-        "#,
-        where_clause,
-        if query.status.is_some() { 3 } else { 2 },
-        if query.status.is_some() { 4 } else { 3 }
-    ))
-    .bind(user_id)
-    .bind(&query.status.unwrap_or_default())
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+        let count: i64 =
+            sqlx::query_scalar(
+                "SELECT COUNT(*) FROM contract_subscriptions WHERE user_id = $1 AND status = $2",
+            )
+            .bind(user_id)
+            .bind(status)
+            .fetch_one(&state.db)
+            .await
+            .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
 
-    let total_count: i64 = sqlx::query_scalar(&format!(
-        "SELECT COUNT(*) FROM contract_subscriptions {}",
-        if query.status.is_some() {
-            "WHERE user_id = $1 AND status = $2"
-        } else {
-            "WHERE user_id = $1"
-        }
-    ))
-    .bind(user_id)
-    .bind(&query.status.unwrap_or_default())
-    .fetch_one(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+        (rows, count)
+    } else {
+        let rows = sqlx::query_as::<_, ContractSubscriptionSummary>(
+            r#"
+            SELECT cs.id, cs.contract_id, c.name AS contract_name,
+                   c.slug AS contract_slug, cs.status, cs.notification_types,
+                   cs.channels, cs.frequency, cs.created_at
+            FROM contract_subscriptions cs
+            JOIN contracts c ON cs.contract_id = c.id
+            WHERE cs.user_id = $1
+            ORDER BY cs.created_at DESC
+            LIMIT $2 OFFSET $3
+            "#,
+        )
+        .bind(user_id)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM contract_subscriptions WHERE user_id = $1")
+                .bind(user_id)
+                .fetch_one(&state.db)
+                .await
+                .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+        (rows, count)
+    };
 
     Ok(Json(UserSubscriptionsResponse {
         subscriptions,
@@ -193,8 +239,6 @@ pub async fn list_user_subscriptions(
     }))
 }
 
-/// Update subscription preferences
-///
 /// PATCH /api/subscriptions/:id
 pub async fn update_subscription(
     State(state): State<AppState>,
@@ -202,88 +246,102 @@ pub async fn update_subscription(
     auth_user: auth::AuthenticatedUser,
     Json(req): Json<UpdateSubscriptionRequest>,
 ) -> ApiResult<Json<ContractSubscription>> {
-    let user_id = auth_user.publisher_id;
-
-    // Build dynamic update query
-    let mut updates = Vec::new();
-    if let Some(status) = &req.status {
-        updates.push(format!("status = '{}'", status));
-    }
-    if let Some(types) = &req.notification_types {
-        updates.push(format!("notification_types = {:?}", types));
-    }
-    if let Some(channels) = &req.channels {
-        updates.push(format!("channels = {:?}", channels));
-    }
-    if let Some(frequency) = &req.frequency {
-        updates.push(format!("frequency = '{}'", frequency));
-    }
-    if let Some(min_severity) = &req.min_severity {
-        updates.push(format!("min_severity = '{}'", min_severity));
-    }
-
-    updates.push("updated_at = NOW()".to_string());
-
-    if updates.is_empty() {
-        return Err(ApiError::bad_request("No fields to update"));
-    }
-
-    let update_clause = updates.join(", ");
-
-    let subscription = sqlx::query_as::<_, ContractSubscription>(&format!(
-        r#"
-        UPDATE contract_subscriptions
-        SET {}
-        WHERE id = $1 AND user_id = $2
-        RETURNING *
-        "#,
-        update_clause
-    ))
+    // Verify ownership first.
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM contract_subscriptions WHERE id = $1 AND user_id = $2)",
+    )
     .bind(subscription_id)
-    .bind(user_id)
-    .fetch_optional(&state.db)
+    .bind(auth_user.publisher_id)
+    .fetch_one(&state.db)
     .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
-    .ok_or_else(|| ApiError::not_found("subscription", "Subscription not found"))?;
+    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+    if !exists {
+        return Err(ApiError::not_found("subscription", "Subscription not found"));
+    }
+
+    // Apply each optional field individually to avoid string-interpolated SQL injection.
+    if let Some(ref status) = req.status {
+        sqlx::query(
+            "UPDATE contract_subscriptions SET status = $1, updated_at = NOW() WHERE id = $2",
+        )
+        .bind(status)
+        .bind(subscription_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+    if let Some(ref types) = req.notification_types {
+        sqlx::query(
+            "UPDATE contract_subscriptions SET notification_types = $1, updated_at = NOW() WHERE id = $2",
+        )
+        .bind(types)
+        .bind(subscription_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+    if let Some(ref channels) = req.channels {
+        sqlx::query(
+            "UPDATE contract_subscriptions SET channels = $1, updated_at = NOW() WHERE id = $2",
+        )
+        .bind(channels)
+        .bind(subscription_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+    if let Some(ref frequency) = req.frequency {
+        sqlx::query(
+            "UPDATE contract_subscriptions SET frequency = $1, updated_at = NOW() WHERE id = $2",
+        )
+        .bind(frequency)
+        .bind(subscription_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+    if let Some(ref severity) = req.min_severity {
+        sqlx::query(
+            "UPDATE contract_subscriptions SET min_severity = $1, updated_at = NOW() WHERE id = $2",
+        )
+        .bind(severity)
+        .bind(subscription_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+
+    let subscription = sqlx::query_as::<_, ContractSubscription>(
+        "SELECT * FROM contract_subscriptions WHERE id = $1",
+    )
+    .bind(subscription_id)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
 
     Ok(Json(subscription))
 }
 
-/// Get user notification preferences
-///
+// ─── Notification preferences ─────────────────────────────────────────────
+
 /// GET /api/notifications/preferences
 pub async fn get_notification_preferences(
     State(state): State<AppState>,
     auth_user: auth::AuthenticatedUser,
 ) -> ApiResult<Json<UserNotificationPreferences>> {
-    let user_id = auth_user.publisher_id;
-
     let prefs = sqlx::query_as::<_, UserNotificationPreferences>(
         "SELECT * FROM user_preferences WHERE publisher_id = $1",
     )
-    .bind(user_id)
+    .bind(auth_user.publisher_id)
     .fetch_optional(&state.db)
     .await
     .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
     .ok_or_else(|| ApiError::not_found("preferences", "User preferences not found"))?;
 
-    Ok(Json(UserNotificationPreferences {
-        id: prefs.id,
-        publisher_id: prefs.publisher_id,
-        notification_frequency: prefs.notification_frequency,
-        notification_channels: prefs.notification_channels,
-        email_notifications_enabled: prefs.email_notifications_enabled,
-        webhook_url: prefs.webhook_url,
-        quiet_hours_start: prefs.quiet_hours_start,
-        quiet_hours_end: prefs.quiet_hours_end,
-        timezone: prefs.timezone,
-        created_at: prefs.created_at,
-        updated_at: prefs.updated_at,
-    }))
+    Ok(Json(prefs))
 }
 
-/// Update user notification preferences
-///
 /// PATCH /api/notifications/preferences
 pub async fn update_notification_preferences(
     State(state): State<AppState>,
@@ -292,65 +350,81 @@ pub async fn update_notification_preferences(
 ) -> ApiResult<Json<UserNotificationPreferences>> {
     let user_id = auth_user.publisher_id;
 
-    // Build dynamic update
-    let mut updates = Vec::new();
-    let mut param_count = 1;
+    if let Some(ref freq) = req.notification_frequency {
+        sqlx::query(
+            "UPDATE user_preferences SET notification_frequency = $1, updated_at = NOW() WHERE publisher_id = $2",
+        )
+        .bind(freq)
+        .bind(user_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+    if let Some(ref channels) = req.notification_channels {
+        sqlx::query(
+            "UPDATE user_preferences SET notification_channels = $1, updated_at = NOW() WHERE publisher_id = $2",
+        )
+        .bind(channels)
+        .bind(user_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+    if let Some(enabled) = req.email_notifications_enabled {
+        sqlx::query(
+            "UPDATE user_preferences SET email_notifications_enabled = $1, updated_at = NOW() WHERE publisher_id = $2",
+        )
+        .bind(enabled)
+        .bind(user_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+    if let Some(ref url) = req.webhook_url {
+        sqlx::query(
+            "UPDATE user_preferences SET webhook_url = $1, updated_at = NOW() WHERE publisher_id = $2",
+        )
+        .bind(url)
+        .bind(user_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+    if let Some(ref start) = req.quiet_hours_start {
+        sqlx::query(
+            "UPDATE user_preferences SET quiet_hours_start = $1, updated_at = NOW() WHERE publisher_id = $2",
+        )
+        .bind(start)
+        .bind(user_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+    if let Some(ref end) = req.quiet_hours_end {
+        sqlx::query(
+            "UPDATE user_preferences SET quiet_hours_end = $1, updated_at = NOW() WHERE publisher_id = $2",
+        )
+        .bind(end)
+        .bind(user_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
+    if let Some(ref tz) = req.timezone {
+        sqlx::query(
+            "UPDATE user_preferences SET timezone = $1, updated_at = NOW() WHERE publisher_id = $2",
+        )
+        .bind(tz)
+        .bind(user_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    }
 
-    if let Some(freq) = &req.notification_frequency {
-        param_count += 1;
-        updates.push(format!("notification_frequency = ${}", param_count));
-    }
-    if let Some(channels) = &req.notification_channels {
-        param_count += 1;
-        updates.push(format!("notification_channels = ${}", param_count));
-    }
-    if let Some(enabled) = &req.email_notifications_enabled {
-        param_count += 1;
-        updates.push(format!("email_notifications_enabled = ${}", param_count));
-    }
-    if let Some(webhook) = &req.webhook_url {
-        param_count += 1;
-        updates.push(format!("webhook_url = ${}", param_count));
-    }
-    if let Some(start) = &req.quiet_hours_start {
-        param_count += 1;
-        updates.push(format!("quiet_hours_start = ${}", param_count));
-    }
-    if let Some(end) = &req.quiet_hours_end {
-        param_count += 1;
-        updates.push(format!("quiet_hours_end = ${}", param_count));
-    }
-    if let Some(tz) = &req.timezone {
-        param_count += 1;
-        updates.push(format!("timezone = ${}", param_count));
-    }
-
-    updates.push(format!("updated_at = NOW()"));
-
-    if updates.is_empty() {
-        return Err(ApiError::bad_request("No fields to update"));
-    }
-
-    let update_clause = updates.join(", ");
-
-    // This is a simplified version - in production you'd use proper parameterized queries
-    let prefs = sqlx::query_as::<_, UserNotificationPreferences>(&format!(
-        r#"
-        UPDATE user_preferences
-        SET {}
-        WHERE publisher_id = $1
-        RETURNING *
-        "#,
-        update_clause
-    ))
+    let prefs = sqlx::query_as::<_, UserNotificationPreferences>(
+        "SELECT * FROM user_preferences WHERE publisher_id = $1",
+    )
     .bind(user_id)
-    .bind(&req.notification_frequency)
-    .bind(&req.notification_channels)
-    .bind(&req.email_notifications_enabled)
-    .bind(&req.webhook_url)
-    .bind(&req.quiet_hours_start)
-    .bind(&req.quiet_hours_end)
-    .bind(&req.timezone)
     .fetch_one(&state.db)
     .await
     .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
@@ -358,91 +432,8 @@ pub async fn update_notification_preferences(
     Ok(Json(prefs))
 }
 
-/// List user's webhook configurations
-///
-/// GET /api/webhooks
-pub async fn list_webhooks(
-    State(state): State<AppState>,
-    auth_user: auth::AuthenticatedUser,
-) -> ApiResult<Json<Vec<WebhookConfiguration>>> {
-    let user_id = auth_user.publisher_id;
+// ─── Notifications ─────────────────────────────────────────────────────────
 
-    let webhooks = sqlx::query_as::<_, WebhookConfiguration>(
-        r#"
-        SELECT * FROM webhook_configurations
-        WHERE user_id = $1
-        ORDER BY created_at DESC
-        "#,
-    )
-    .bind(user_id)
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
-
-    Ok(Json(webhooks))
-}
-
-/// Create a new webhook
-///
-/// POST /api/webhooks
-pub async fn create_webhook(
-    State(state): State<AppState>,
-    auth_user: auth::AuthenticatedUser,
-    Json(req): Json<CreateWebhookRequest>,
-) -> ApiResult<Json<WebhookConfiguration>> {
-    let user_id = auth_user.publisher_id;
-
-    // In production, secret should be encrypted
-    let webhook = sqlx::query_as::<_, WebhookConfiguration>(
-        r#"
-        INSERT INTO webhook_configurations
-        (user_id, name, url, notification_types, is_active, verify_ssl, custom_headers, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, true, $5, $6, NOW(), NOW())
-        RETURNING *
-        "#,
-    )
-    .bind(user_id)
-    .bind(&req.name)
-    .bind(&req.url)
-    .bind(&req.notification_types)
-    .bind(req.verify_ssl.unwrap_or(true))
-    .bind(&req.custom_headers)
-    .fetch_one(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Failed to create webhook: {}", e)))?;
-
-    Ok(Json(webhook))
-}
-
-/// Delete a webhook
-///
-/// DELETE /api/webhooks/:id
-pub async fn delete_webhook(
-    State(state): State<AppState>,
-    Path(webhook_id): Path<Uuid>,
-    auth_user: auth::AuthenticatedUser,
-) -> ApiResult<StatusCode> {
-    let user_id = auth_user.publisher_id;
-
-    let rows_affected = sqlx::query(
-        "DELETE FROM webhook_configurations WHERE id = $1 AND user_id = $2",
-    )
-    .bind(webhook_id)
-    .bind(user_id)
-    .execute(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
-    .rows_affected();
-
-    if rows_affected == 0 {
-        return Err(ApiError::not_found("webhook", "Webhook not found"));
-    }
-
-    Ok(StatusCode::NO_CONTENT)
-}
-
-/// Get user's notifications (from notification queue)
-///
 /// GET /api/notifications
 pub async fn list_notifications(
     State(state): State<AppState>,
@@ -452,37 +443,71 @@ pub async fn list_notifications(
     let user_id = auth_user.publisher_id;
     let limit = query.limit.unwrap_or(50);
     let offset = query.offset.unwrap_or(0);
+    let unread_only = query.unread_only.unwrap_or(false);
 
-    // Get notifications from queue for this user's subscriptions
-    let notifications = sqlx::query_as::<_, NotificationQueueItem>(
-        r#"
-        SELECT nq.*
-        FROM notification_queue nq
-        JOIN contract_subscriptions cs ON nq.subscription_id = cs.id
-        WHERE cs.user_id = $1
-        ORDER BY nq.priority ASC, nq.scheduled_at DESC
-        LIMIT $2 OFFSET $3
-        "#,
-    )
-    .bind(user_id)
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+    let (notifications, total_count) = if unread_only {
+        let rows = sqlx::query_as::<_, NotificationQueueItem>(
+            r#"
+            SELECT nq.*
+            FROM notification_queue nq
+            JOIN contract_subscriptions cs ON nq.subscription_id = cs.id
+            WHERE cs.user_id = $1 AND nq.status != 'read'
+            ORDER BY nq.priority ASC, nq.scheduled_at DESC
+            LIMIT $2 OFFSET $3
+            "#,
+        )
+        .bind(user_id)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
 
-    let total_count: i64 = sqlx::query_scalar(
-        r#"
-        SELECT COUNT(*)
-        FROM notification_queue nq
-        JOIN contract_subscriptions cs ON nq.subscription_id = cs.id
-        WHERE cs.user_id = $1
-        "#,
-    )
-    .bind(user_id)
-    .fetch_one(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+        let count: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*) FROM notification_queue nq
+            JOIN contract_subscriptions cs ON nq.subscription_id = cs.id
+            WHERE cs.user_id = $1 AND nq.status != 'read'
+            "#,
+        )
+        .bind(user_id)
+        .fetch_one(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+        (rows, count)
+    } else {
+        let rows = sqlx::query_as::<_, NotificationQueueItem>(
+            r#"
+            SELECT nq.*
+            FROM notification_queue nq
+            JOIN contract_subscriptions cs ON nq.subscription_id = cs.id
+            WHERE cs.user_id = $1
+            ORDER BY nq.priority ASC, nq.scheduled_at DESC
+            LIMIT $2 OFFSET $3
+            "#,
+        )
+        .bind(user_id)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+        let count: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*) FROM notification_queue nq
+            JOIN contract_subscriptions cs ON nq.subscription_id = cs.id
+            WHERE cs.user_id = $1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_one(&state.db)
+        .await
+        .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+        (rows, count)
+    };
 
     Ok(Json(NotificationListResponse {
         notifications,
@@ -490,44 +515,25 @@ pub async fn list_notifications(
     }))
 }
 
-/// Query parameters for notifications
-#[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
-pub struct NotificationQuery {
-    pub limit: Option<i64>,
-    pub offset: Option<i64>,
-    pub unread_only: Option<bool>,
-}
-
-/// Notification list response
-#[derive(Debug, serde::Serialize)]
-pub struct NotificationListResponse {
-    pub notifications: Vec<NotificationQueueItem>,
-    pub total_count: i64,
-}
-
-/// Mark notification as read
-///
 /// POST /api/notifications/:id/read
 pub async fn mark_notification_read(
     State(state): State<AppState>,
     Path(notification_id): Path<Uuid>,
     auth_user: auth::AuthenticatedUser,
 ) -> ApiResult<StatusCode> {
-    let user_id = auth_user.publisher_id;
-
     sqlx::query(
         r#"
         UPDATE notification_queue nq
         SET status = 'read'
         WHERE nq.id = $1
-        AND EXISTS (
-            SELECT 1 FROM contract_subscriptions cs
-            WHERE cs.id = nq.subscription_id AND cs.user_id = $2
-        )
+          AND EXISTS (
+              SELECT 1 FROM contract_subscriptions cs
+              WHERE cs.id = nq.subscription_id AND cs.user_id = $2
+          )
         "#,
     )
     .bind(notification_id)
-    .bind(user_id)
+    .bind(auth_user.publisher_id)
     .execute(&state.db)
     .await
     .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
@@ -535,27 +541,23 @@ pub async fn mark_notification_read(
     Ok(StatusCode::OK)
 }
 
-/// Mark all notifications as read
-///
 /// POST /api/notifications/read-all
 pub async fn mark_all_notifications_read(
     State(state): State<AppState>,
     auth_user: auth::AuthenticatedUser,
 ) -> ApiResult<StatusCode> {
-    let user_id = auth_user.publisher_id;
-
     sqlx::query(
         r#"
         UPDATE notification_queue nq
         SET status = 'read'
-        WHERE EXISTS (
-            SELECT 1 FROM contract_subscriptions cs
-            WHERE cs.id = nq.subscription_id AND cs.user_id = $1
-        )
-        AND nq.status != 'read'
+        WHERE nq.status != 'read'
+          AND EXISTS (
+              SELECT 1 FROM contract_subscriptions cs
+              WHERE cs.id = nq.subscription_id AND cs.user_id = $1
+          )
         "#,
     )
-    .bind(user_id)
+    .bind(auth_user.publisher_id)
     .execute(&state.db)
     .await
     .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
@@ -563,8 +565,6 @@ pub async fn mark_all_notifications_read(
     Ok(StatusCode::OK)
 }
 
-/// Get notification statistics
-///
 /// GET /api/notifications/statistics
 pub async fn get_notification_statistics(
     State(state): State<AppState>,
@@ -572,19 +572,14 @@ pub async fn get_notification_statistics(
     Query(query): Query<StatisticsQuery>,
 ) -> ApiResult<Json<shared::NotificationStatistics>> {
     let user_id = auth_user.publisher_id;
-    let period_start = query.period_start;
-    let period_end = query.period_end;
 
-    // In production, you'd aggregate from notification_delivery_logs
-    // This is a simplified version
     let stats = sqlx::query_as::<_, shared::NotificationStatistics>(
         r#"
-        SELECT 
-            id, user_id, contract_id, period_start, period_end,
-            new_version_count, verification_status_count, security_issue_count,
-            security_scan_completed_count, breaking_change_count, deprecation_count,
-            maintenance_count, compatibility_issue_count,
-            total_sent, total_delivered, total_failed
+        SELECT id, user_id, contract_id, period_start, period_end,
+               new_version_count, verification_status_count, security_issue_count,
+               security_scan_completed_count, breaking_change_count, deprecation_count,
+               maintenance_count, compatibility_issue_count,
+               total_sent, total_delivered, total_failed
         FROM notification_statistics
         WHERE user_id = $1 AND period_start >= $2 AND period_end <= $3
         ORDER BY period_start DESC
@@ -592,8 +587,8 @@ pub async fn get_notification_statistics(
         "#,
     )
     .bind(user_id)
-    .bind(period_start)
-    .bind(period_end)
+    .bind(query.period_start)
+    .bind(query.period_end)
     .fetch_optional(&state.db)
     .await
     .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
@@ -601,8 +596,8 @@ pub async fn get_notification_statistics(
         id: Uuid::nil(),
         user_id: Some(user_id),
         contract_id: None,
-        period_start,
-        period_end,
+        period_start: query.period_start,
+        period_end: query.period_end,
         new_version_count: 0,
         verification_status_count: 0,
         security_issue_count: 0,
@@ -619,9 +614,215 @@ pub async fn get_notification_statistics(
     Ok(Json(stats))
 }
 
-/// Query parameters for statistics
-#[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
-pub struct StatisticsQuery {
-    pub period_start: chrono::NaiveDate,
-    pub period_end: chrono::NaiveDate,
+// ─── Webhook CRUD ──────────────────────────────────────────────────────────
+
+/// GET /api/webhooks
+pub async fn list_webhooks(
+    State(state): State<AppState>,
+    auth_user: auth::AuthenticatedUser,
+) -> ApiResult<Json<Vec<WebhookConfiguration>>> {
+    let webhooks = sqlx::query_as::<_, WebhookConfiguration>(
+        "SELECT * FROM webhook_configurations WHERE user_id = $1 ORDER BY created_at DESC",
+    )
+    .bind(auth_user.publisher_id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+    Ok(Json(webhooks))
+}
+
+/// POST /api/webhooks
+pub async fn create_webhook(
+    State(state): State<AppState>,
+    auth_user: auth::AuthenticatedUser,
+    Json(req): Json<CreateWebhookRequest>,
+) -> ApiResult<Json<WebhookConfiguration>> {
+    // Validate URL scheme — only https allowed in production.
+    if !req.url.starts_with("https://") && !req.url.starts_with("http://localhost") {
+        return Err(ApiError::bad_request(
+            "Webhook URL must use HTTPS (http://localhost is allowed for testing)",
+        ));
+    }
+
+    let webhook = sqlx::query_as::<_, WebhookConfiguration>(
+        r#"
+        INSERT INTO webhook_configurations
+            (user_id, name, url, notification_types, is_active, verify_ssl, custom_headers,
+             created_at, updated_at)
+        VALUES ($1, $2, $3, $4, true, $5, $6, NOW(), NOW())
+        RETURNING *
+        "#,
+    )
+    .bind(auth_user.publisher_id)
+    .bind(&req.name)
+    .bind(&req.url)
+    .bind(&req.notification_types)
+    .bind(req.verify_ssl.unwrap_or(true))
+    .bind(&req.custom_headers)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| ApiError::internal(format!("Failed to create webhook: {}", e)))?;
+
+    Ok(Json(webhook))
+}
+
+/// DELETE /api/webhooks/:id
+pub async fn delete_webhook(
+    State(state): State<AppState>,
+    Path(webhook_id): Path<Uuid>,
+    auth_user: auth::AuthenticatedUser,
+) -> ApiResult<StatusCode> {
+    let rows_affected = sqlx::query(
+        "DELETE FROM webhook_configurations WHERE id = $1 AND user_id = $2",
+    )
+    .bind(webhook_id)
+    .bind(auth_user.publisher_id)
+    .execute(&state.db)
+    .await
+    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
+    .rows_affected();
+
+    if rows_affected == 0 {
+        return Err(ApiError::not_found("webhook", "Webhook not found"));
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ─── Webhook delivery management ──────────────────────────────────────────
+
+/// GET /api/webhooks/:id/deliveries
+pub async fn get_webhook_deliveries(
+    State(state): State<AppState>,
+    Path(webhook_id): Path<Uuid>,
+    auth_user: auth::AuthenticatedUser,
+    Query(query): Query<DeliveriesQuery>,
+) -> ApiResult<Json<WebhookDeliveriesResponse>> {
+    // Verify ownership.
+    let owned: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM webhook_configurations WHERE id = $1 AND user_id = $2)",
+    )
+    .bind(webhook_id)
+    .bind(auth_user.publisher_id)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+    if !owned {
+        return Err(ApiError::not_found("webhook", "Webhook not found"));
+    }
+
+    let limit = query.limit.unwrap_or(50);
+    let offset = query.offset.unwrap_or(0);
+
+    let deliveries = sqlx::query_as::<_, WebhookDeliveryLog>(
+        r#"
+        SELECT id, webhook_id, notification_id, event_type, status, response_code,
+               response_body, error_message, attempt_number, delivery_duration_ms, created_at
+        FROM notification_delivery_logs
+        WHERE webhook_id = $1
+        ORDER BY created_at DESC
+        LIMIT $2 OFFSET $3
+        "#,
+    )
+    .bind(webhook_id)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+    let total_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM notification_delivery_logs WHERE webhook_id = $1")
+            .bind(webhook_id)
+            .fetch_one(&state.db)
+            .await
+            .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+    Ok(Json(WebhookDeliveriesResponse {
+        deliveries,
+        total_count,
+    }))
+}
+
+/// POST /api/webhooks/:id/test  — sends a synthetic test event to the webhook.
+pub async fn test_webhook(
+    State(state): State<AppState>,
+    Path(webhook_id): Path<Uuid>,
+    auth_user: auth::AuthenticatedUser,
+) -> ApiResult<StatusCode> {
+    let webhook = sqlx::query_as::<_, WebhookConfiguration>(
+        "SELECT * FROM webhook_configurations WHERE id = $1 AND user_id = $2",
+    )
+    .bind(webhook_id)
+    .bind(auth_user.publisher_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
+    .ok_or_else(|| ApiError::not_found("webhook", "Webhook not found"))?;
+
+    // Queue a synthetic test notification for async delivery.
+    sqlx::query(
+        r#"
+        INSERT INTO notification_delivery_logs
+            (webhook_id, event_type, status, attempt_number, created_at)
+        VALUES ($1, 'test', 'pending', 0, NOW())
+        "#,
+    )
+    .bind(webhook.id)
+    .execute(&state.db)
+    .await
+    .map_err(|e| ApiError::internal(format!("Failed to queue test delivery: {}", e)))?;
+
+    Ok(StatusCode::ACCEPTED)
+}
+
+/// POST /api/webhook-deliveries/:id/retry  — re-queues a failed delivery.
+pub async fn retry_webhook_delivery(
+    State(state): State<AppState>,
+    Path(delivery_id): Path<Uuid>,
+    auth_user: auth::AuthenticatedUser,
+) -> ApiResult<StatusCode> {
+    // Verify the delivery belongs to a webhook owned by this user.
+    let owned: bool = sqlx::query_scalar(
+        r#"
+        SELECT EXISTS(
+            SELECT 1
+            FROM notification_delivery_logs ndl
+            JOIN webhook_configurations wc ON wc.id = ndl.webhook_id
+            WHERE ndl.id = $1 AND wc.user_id = $2
+        )
+        "#,
+    )
+    .bind(delivery_id)
+    .bind(auth_user.publisher_id)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+    if !owned {
+        return Err(ApiError::not_found("delivery", "Delivery log not found"));
+    }
+
+    // Reset the delivery so the background worker picks it up again.
+    let rows = sqlx::query(
+        r#"
+        UPDATE notification_delivery_logs
+        SET status = 'pending', attempt_number = 0, error_message = NULL, updated_at = NOW()
+        WHERE id = $1 AND status = 'failed'
+        "#,
+    )
+    .bind(delivery_id)
+    .execute(&state.db)
+    .await
+    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
+    .rows_affected();
+
+    if rows == 0 {
+        return Err(ApiError::bad_request(
+            "Delivery is not in a failed state and cannot be retried",
+        ));
+    }
+
+    Ok(StatusCode::ACCEPTED)
 }

--- a/backend/api/src/webhook_delivery.rs
+++ b/backend/api/src/webhook_delivery.rs
@@ -1,0 +1,302 @@
+// Webhook delivery background task.
+//
+// Polls `notification_delivery_logs` for pending entries, makes HMAC-SHA256-signed
+// HTTP POST requests to the configured endpoint, and writes back the result.
+// Retries up to MAX_ATTEMPTS times with exponential backoff.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use sqlx::PgPool;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+const MAX_ATTEMPTS: i32 = 5;
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+// Exponential backoff delays between attempts (seconds).
+const BACKOFF_SECS: [u64; 5] = [0, 30, 120, 450, 1200];
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Debug, sqlx::FromRow)]
+struct PendingDelivery {
+    id: Uuid,
+    webhook_id: Uuid,
+    notification_id: Option<Uuid>,
+    event_type: String,
+    attempt_number: i32,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct WebhookEndpoint {
+    url: String,
+    secret: Option<String>,
+    verify_ssl: bool,
+    custom_headers: Option<serde_json::Value>,
+    is_active: bool,
+}
+
+/// Spawn the delivery worker as a detached Tokio task.
+pub fn spawn_webhook_delivery_task(db: PgPool) {
+    tokio::spawn(async move {
+        run_delivery_loop(db).await;
+    });
+}
+
+async fn run_delivery_loop(db: PgPool) {
+    info!("Webhook delivery worker started");
+    let client = build_client();
+
+    loop {
+        match fetch_pending(&db).await {
+            Ok(deliveries) if deliveries.is_empty() => {}
+            Ok(deliveries) => {
+                for delivery in deliveries {
+                    process_delivery(&db, &client, delivery).await;
+                }
+            }
+            Err(e) => error!(error = %e, "Failed to fetch pending webhook deliveries"),
+        }
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+fn build_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .user_agent("Soroban-Registry-Webhook/1.0")
+        .build()
+        .expect("Failed to build HTTP client for webhook delivery")
+}
+
+async fn fetch_pending(db: &PgPool) -> Result<Vec<PendingDelivery>, sqlx::Error> {
+    // Claim up to 10 deliveries atomically to avoid double-processing under concurrency.
+    sqlx::query_as::<_, PendingDelivery>(
+        r#"
+        UPDATE notification_delivery_logs
+        SET status = 'processing', updated_at = NOW()
+        WHERE id IN (
+            SELECT id FROM notification_delivery_logs
+            WHERE status = 'pending'
+              AND attempt_number < $1
+            ORDER BY created_at ASC
+            LIMIT 10
+            FOR UPDATE SKIP LOCKED
+        )
+        RETURNING id, webhook_id, notification_id, event_type, attempt_number
+        "#,
+    )
+    .bind(MAX_ATTEMPTS)
+    .fetch_all(db)
+    .await
+}
+
+async fn process_delivery(db: &PgPool, client: &reqwest::Client, delivery: PendingDelivery) {
+    let endpoint = match fetch_endpoint(db, delivery.webhook_id).await {
+        Ok(Some(e)) => e,
+        Ok(None) => {
+            mark_failed(db, delivery.id, "Webhook configuration not found", None).await;
+            return;
+        }
+        Err(e) => {
+            mark_failed(db, delivery.id, &e.to_string(), None).await;
+            return;
+        }
+    };
+
+    if !endpoint.is_active {
+        mark_failed(db, delivery.id, "Webhook is disabled", None).await;
+        return;
+    }
+
+    // Apply backoff before retrying (first attempt has 0-second backoff).
+    let attempt = delivery.attempt_number as usize;
+    let backoff = BACKOFF_SECS.get(attempt).copied().unwrap_or(1200);
+    if backoff > 0 {
+        sleep(Duration::from_secs(backoff)).await;
+    }
+
+    let payload = build_payload(&delivery);
+    let signature = sign_payload(&payload, endpoint.secret.as_deref());
+    let delivery_id = delivery.id;
+
+    let start = Instant::now();
+    let result = send_request(client, &endpoint, &payload, &signature, delivery_id).await;
+    let elapsed_ms = start.elapsed().as_millis() as i64;
+
+    match result {
+        Ok(status_code) if status_code < 300 => {
+            info!(
+                delivery_id = %delivery_id,
+                status_code = status_code,
+                elapsed_ms = elapsed_ms,
+                "Webhook delivery succeeded"
+            );
+            mark_delivered(db, delivery_id, status_code, elapsed_ms).await;
+            update_webhook_stats(db, delivery.webhook_id, true).await;
+        }
+        Ok(status_code) => {
+            let msg = format!("Endpoint returned HTTP {}", status_code);
+            warn!(delivery_id = %delivery_id, status_code = status_code, "Webhook delivery failed");
+            retry_or_fail(db, delivery_id, delivery.webhook_id, &msg, Some(status_code), elapsed_ms, attempt).await;
+        }
+        Err(e) => {
+            warn!(delivery_id = %delivery_id, error = %e, "Webhook delivery error");
+            retry_or_fail(db, delivery_id, delivery.webhook_id, &e.to_string(), None, elapsed_ms, attempt).await;
+        }
+    }
+}
+
+async fn fetch_endpoint(db: &PgPool, webhook_id: Uuid) -> Result<Option<WebhookEndpoint>, sqlx::Error> {
+    sqlx::query_as::<_, WebhookEndpoint>(
+        "SELECT url, secret, verify_ssl, custom_headers, is_active FROM webhook_configurations WHERE id = $1",
+    )
+    .bind(webhook_id)
+    .fetch_optional(db)
+    .await
+}
+
+fn build_payload(delivery: &PendingDelivery) -> String {
+    serde_json::json!({
+        "delivery_id": delivery.id,
+        "event_type": delivery.event_type,
+        "notification_id": delivery.notification_id,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    })
+    .to_string()
+}
+
+fn sign_payload(payload: &str, secret: Option<&str>) -> String {
+    if let Some(secret) = secret.filter(|s| !s.is_empty()) {
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+            .expect("HMAC accepts any key length");
+        mac.update(payload.as_bytes());
+        let result = mac.finalize().into_bytes();
+        format!("sha256={}", hex::encode(result))
+    } else {
+        String::new()
+    }
+}
+
+async fn send_request(
+    client: &reqwest::Client,
+    endpoint: &WebhookEndpoint,
+    payload: &str,
+    signature: &str,
+    delivery_id: Uuid,
+) -> Result<u16, reqwest::Error> {
+    let mut req = client
+        .post(&endpoint.url)
+        .header("Content-Type", "application/json")
+        .header("X-Soroban-Delivery-Id", delivery_id.to_string())
+        .body(payload.to_owned());
+
+    if !signature.is_empty() {
+        req = req.header("X-Soroban-Signature", signature);
+    }
+
+    // Apply user-supplied custom headers.
+    if let Some(serde_json::Value::Object(headers)) = &endpoint.custom_headers {
+        for (k, v) in headers {
+            if let Some(v_str) = v.as_str() {
+                req = req.header(k.as_str(), v_str);
+            }
+        }
+    }
+
+    let response = req.send().await?;
+    Ok(response.status().as_u16())
+}
+
+async fn retry_or_fail(
+    db: &PgPool,
+    delivery_id: Uuid,
+    webhook_id: Uuid,
+    error_msg: &str,
+    response_code: Option<u16>,
+    elapsed_ms: i64,
+    current_attempt: usize,
+) {
+    let next_attempt = current_attempt as i32 + 1;
+    if next_attempt >= MAX_ATTEMPTS {
+        mark_failed(db, delivery_id, error_msg, response_code).await;
+        update_webhook_stats(db, webhook_id, false).await;
+    } else {
+        // Put back as pending for the next poll cycle (backoff is applied at pickup time).
+        let _ = sqlx::query(
+            r#"
+            UPDATE notification_delivery_logs
+            SET status = 'pending', attempt_number = $1, error_message = $2,
+                delivery_duration_ms = $3, response_code = $4, updated_at = NOW()
+            WHERE id = $5
+            "#,
+        )
+        .bind(next_attempt)
+        .bind(error_msg)
+        .bind(elapsed_ms)
+        .bind(response_code.map(|c| c as i32))
+        .bind(delivery_id)
+        .execute(db)
+        .await;
+    }
+}
+
+async fn mark_delivered(db: &PgPool, delivery_id: Uuid, status_code: u16, elapsed_ms: i64) {
+    let _ = sqlx::query(
+        r#"
+        UPDATE notification_delivery_logs
+        SET status = 'delivered', response_code = $1, delivery_duration_ms = $2,
+            error_message = NULL, updated_at = NOW()
+        WHERE id = $3
+        "#,
+    )
+    .bind(status_code as i32)
+    .bind(elapsed_ms)
+    .bind(delivery_id)
+    .execute(db)
+    .await;
+}
+
+async fn mark_failed(db: &PgPool, delivery_id: Uuid, error_msg: &str, response_code: Option<u16>) {
+    let _ = sqlx::query(
+        r#"
+        UPDATE notification_delivery_logs
+        SET status = 'failed', error_message = $1, response_code = $2, updated_at = NOW()
+        WHERE id = $3
+        "#,
+    )
+    .bind(error_msg)
+    .bind(response_code.map(|c| c as i32))
+    .bind(delivery_id)
+    .execute(db)
+    .await;
+}
+
+async fn update_webhook_stats(db: &PgPool, webhook_id: Uuid, success: bool) {
+    let query = if success {
+        r#"
+        UPDATE webhook_configurations
+        SET total_deliveries = total_deliveries + 1,
+            last_delivery_at = NOW(),
+            last_success_at = NOW(),
+            consecutive_failures = 0,
+            updated_at = NOW()
+        WHERE id = $1
+        "#
+    } else {
+        r#"
+        UPDATE webhook_configurations
+        SET total_deliveries = total_deliveries + 1,
+            failed_deliveries = failed_deliveries + 1,
+            last_delivery_at = NOW(),
+            last_failure_at = NOW(),
+            consecutive_failures = consecutive_failures + 1,
+            updated_at = NOW()
+        WHERE id = $1
+        "#
+    };
+    let _ = sqlx::query(query).bind(webhook_id).execute(db).await;
+}

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -1009,9 +1009,15 @@ pub struct PaginatedResponse<T> {
     pub items: Vec<T>,
     pub total: i64,
     pub page: i64,
+    /// Number of items per page (serialised as `per_page`).
+    #[serde(rename = "per_page")]
     pub page_size: i64,
+    /// Total number of pages (serialised as `pages`).
+    #[serde(rename = "pages")]
     pub total_pages: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub prev_cursor: Option<String>,
 }
 


### PR DESCRIPTION
Implement Paginated Response Metadata and RFC 5988 Link Headers
Overview
Standardises all list responses to include consistent pagination metadata (total, page, pages, per_page) and RFC 5988-compliant Link headers for cursor-free navigation.

Changes
shared/models.rs
Added #[serde(rename)] attributes to PaginatedResponse<T> — no Rust code changes required anywhere:

page_size serialises as per_page
total_pages serialises as pages
next_cursor / prev_cursor are omitted when None
pagination.rs (new).
Closes #608 