### PR TITLE
Add distributed tracing across backend services

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2171,6 +2171,9 @@ dependencies = [
  "chrono",
  "clap",
  "dotenv",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "reqwest",
  "serde",
  "serde_json",
@@ -2179,6 +2182,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,12 +20,13 @@ COPY soroban-registry/crates/ soroban-registry/crates/
 # Copy full source
 COPY backend/ backend/
 
-RUN cd backend && cargo build --release --bin api
+RUN cd backend && cargo build --release --bin api --bin indexer
 
 # ── Runtime ────────────────────────────────────────────────────────────────
 FROM gcr.io/distroless/cc-debian12:nonroot
 
 COPY --from=builder --chown=nonroot:nonroot /app/backend/target/release/api /app/api
+COPY --from=builder --chown=nonroot:nonroot /app/backend/target/release/indexer /app/indexer
 
 USER nonroot:nonroot
 EXPOSE 3001

--- a/backend/api/src/clone_federation_handlers.rs
+++ b/backend/api/src/clone_federation_handlers.rs
@@ -775,7 +775,9 @@ async fn perform_federation_sync(
     let sync_url = format!("{}/api/contracts?limit={}", base_url.trim_end_matches('/'), batch_size);
     
     let result = async {
-        let response = client.get(&sync_url).send().await?;
+        let mut headers = reqwest::header::HeaderMap::new();
+        crate::request_tracing::inject_current_trace_context(&mut headers);
+        let response = client.get(&sync_url).headers(headers).send().await?;
         if !response.status().is_success() {
             return Err(format!("Failed to fetch contracts: {}", response.status()));
         }

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -433,7 +433,12 @@ fn derive_network_status(
 }
 
 async fn probe_network_health(client: &reqwest::Client, health_url: &str) -> bool {
-    match client.get(health_url).send().await {
+    let mut request = client.get(health_url);
+    let mut headers = reqwest::header::HeaderMap::new();
+    crate::request_tracing::inject_current_trace_context(&mut headers);
+    request = request.headers(headers);
+
+    match request.send().await {
         Ok(response) => response.status().is_success(),
         Err(_) => false,
     }

--- a/backend/api/src/onchain_verification.rs
+++ b/backend/api/src/onchain_verification.rs
@@ -410,10 +410,13 @@ impl OnChainVerifier {
 
         let mut delay_ms = 200_u64;
         for attempt in 0..config.max_retries {
+            let mut headers = reqwest::header::HeaderMap::new();
+            crate::request_tracing::inject_current_trace_context(&mut headers);
             let response = self
                 .client
                 .post(&config.rpc_endpoint)
                 .timeout(config.timeout)
+                .headers(headers)
                 .json(&payload)
                 .send()
                 .await;

--- a/backend/api/src/request_tracing.rs
+++ b/backend/api/src/request_tracing.rs
@@ -16,9 +16,17 @@ use axum::{
     middleware::Next,
     response::Response,
 };
+use opentelemetry::global;
+use opentelemetry::propagation::{Extractor, Injector};
+use opentelemetry::trace::TraceContextExt;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::Resource;
 use std::net::SocketAddr;
 use std::time::Instant;
 use tracing::Instrument;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
 /// Paths that should never be logged (health checks, readiness probes, etc.)
@@ -48,6 +56,7 @@ pub async fn tracing_middleware(
     req.extensions_mut().insert(RequestId(request_id.clone()));
 
     let start = Instant::now();
+    let parent_context = extract_remote_context(req.headers());
     let span = tracing::info_span!(
         "http_request",
         request_id = %request_id,
@@ -55,6 +64,7 @@ pub async fn tracing_middleware(
         path = %path,
         user_ip = %user_ip
     );
+    span.set_parent(parent_context);
     let mut response = CURRENT_REQUEST_ID
         .scope(request_id.clone(), next.run(req).instrument(span.clone()))
         .await;
@@ -127,6 +137,44 @@ pub fn attach_request_id_headers(headers: &mut HeaderMap, request_id: &str) {
     }
 }
 
+pub fn inject_current_trace_context(headers: &mut reqwest::header::HeaderMap) {
+    let context = opentelemetry::Context::current();
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&context, &mut ReqwestHeaderInjector(headers));
+    });
+}
+
+fn extract_remote_context(headers: &HeaderMap) -> opentelemetry::Context {
+    global::get_text_map_propagator(|propagator| {
+        propagator.extract(&AxumHeaderExtractor(headers))
+    })
+}
+
+struct AxumHeaderExtractor<'a>(&'a HeaderMap);
+
+impl Extractor for AxumHeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|value| value.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|key| key.as_str()).collect()
+    }
+}
+
+struct ReqwestHeaderInjector<'a>(&'a mut reqwest::header::HeaderMap);
+
+impl Injector for ReqwestHeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let (Ok(header_name), Ok(header_value)) = (
+            reqwest::header::HeaderName::from_bytes(key.as_bytes()),
+            reqwest::header::HeaderValue::from_str(&value),
+        ) {
+            self.0.insert(header_name, header_value);
+        }
+    }
+}
+
 // ── Request ID extractor ──────────────────────────────────────────────────────
 
 /// A newtype wrapper stored in request extensions so downstream code can
@@ -156,16 +204,48 @@ impl RequestId {
 pub fn init_json_tracing() {
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+    let service_name = std::env::var("OTEL_SERVICE_NAME")
+        .unwrap_or_else(|_| "soroban-registry-api".to_string());
+    let otlp_endpoint = std::env::var("OTLP_ENDPOINT")
+        .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT"))
+        .ok();
+
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "api=info,tower_http=info".into());
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_current_span(true);
+
+    if let Some(endpoint) = otlp_endpoint {
+        let trace_config = opentelemetry_sdk::trace::Config::default().with_resource(
+            Resource::new(vec![KeyValue::new("service.name", service_name)]),
+        );
+
+        match opentelemetry_otlp::new_pipeline()
+            .tracing()
+            .with_trace_config(trace_config)
+            .with_exporter(opentelemetry_otlp::new_exporter().tonic().with_endpoint(endpoint))
+            .install_batch(opentelemetry_sdk::runtime::Tokio)
+        {
+            Ok(tracer) => {
+                tracing_subscriber::registry()
+                    .with(env_filter)
+                    .with(fmt_layer)
+                    .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                    .init();
+                return;
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "Failed to initialize OTLP exporter; falling back to log-only tracing");
+            }
+        }
+    }
+
     tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "api=info,tower_http=info".into()),
-        )
-        .with(
-            tracing_subscriber::fmt::layer()
-                .json()
-                .with_current_span(true),
-        )
+        .with(env_filter)
+        .with(fmt_layer)
         .init();
 }
 

--- a/backend/indexer/Cargo.toml
+++ b/backend/indexer/Cargo.toml
@@ -21,6 +21,10 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
 dotenv = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }

--- a/backend/indexer/src/main.rs
+++ b/backend/indexer/src/main.rs
@@ -19,6 +19,7 @@ mod detector;
 mod reorg;
 mod rpc;
 mod state;
+mod telemetry;
 
 use anyhow::Result;
 use config::{DatabaseConfig, ServiceConfig};
@@ -29,8 +30,6 @@ use state::{IndexerState, StateManager};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tracing::{error, info, warn};
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
 
 struct IndexerService {
     config: ServiceConfig,
@@ -349,14 +348,8 @@ impl IndexerService {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize tracing/logging
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "indexer=info".into()),
-        )
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stdout))
-        .init();
+    // Initialize tracing/logging with optional OTLP export.
+    telemetry::init_tracing("soroban-registry-indexer");
 
     info!("Stellar Blockchain Indexer Service starting...");
 

--- a/backend/indexer/src/rpc.rs
+++ b/backend/indexer/src/rpc.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use thiserror::Error;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, instrument, warn};
 
 #[derive(Error, Debug)]
 pub enum RpcError {
@@ -104,14 +104,19 @@ impl StellarRpcClient {
     }
 
     /// Fetch ledger by sequence number
+    #[instrument(skip(self), fields(rpc.endpoint = %self.endpoint, ledger.sequence = sequence))]
     pub async fn get_ledger(&self, sequence: u64) -> Result<Ledger, RpcError> {
         let url = format!("{}/ledgers/{}", self.endpoint, sequence);
         debug!("Fetching ledger from {}", url);
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        crate::telemetry::inject_current_trace_context(&mut headers);
 
         let response = self
             .client
             .get(&url)
             .timeout(self.request_timeout)
+            .headers(headers)
             .send()
             .await
             .map_err(|e| {
@@ -144,6 +149,7 @@ impl StellarRpcClient {
     }
 
     /// Fetch operations for a ledger
+    #[instrument(skip(self), fields(rpc.endpoint = %self.endpoint, ledger.sequence = sequence))]
     pub async fn get_ledger_operations(&self, sequence: u64) -> Result<Vec<Operation>, RpcError> {
         let url = format!(
             "{}/ledgers/{}/operations?order=asc&limit=200",
@@ -151,10 +157,14 @@ impl StellarRpcClient {
         );
         debug!("Fetching operations for ledger {} from {}", sequence, url);
 
+        let mut headers = reqwest::header::HeaderMap::new();
+        crate::telemetry::inject_current_trace_context(&mut headers);
+
         let response = self
             .client
             .get(&url)
             .timeout(self.request_timeout)
+            .headers(headers)
             .send()
             .await
             .map_err(|e| {
@@ -191,14 +201,19 @@ impl StellarRpcClient {
     }
 
     /// Get the latest ledger
+    #[instrument(skip(self), fields(rpc.endpoint = %self.endpoint))]
     pub async fn get_latest_ledger(&self) -> Result<Ledger, RpcError> {
         let url = format!("{}/ledgers?order=desc&limit=1", self.endpoint);
         debug!("Fetching latest ledger from {}", url);
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        crate::telemetry::inject_current_trace_context(&mut headers);
 
         let response = self
             .client
             .get(&url)
             .timeout(self.request_timeout)
+            .headers(headers)
             .send()
             .await
             .map_err(|e| {

--- a/backend/indexer/src/telemetry.rs
+++ b/backend/indexer/src/telemetry.rs
@@ -1,0 +1,72 @@
+use opentelemetry::global;
+use opentelemetry::propagation::Injector;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::Resource;
+
+pub fn init_tracing(service_name: &str) {
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "indexer=info".into());
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stdout);
+
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let otlp_endpoint = std::env::var("OTLP_ENDPOINT")
+        .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT"))
+        .ok();
+    let service_name = std::env::var("OTEL_SERVICE_NAME")
+        .unwrap_or_else(|_| service_name.to_string());
+
+    if let Some(endpoint) = otlp_endpoint {
+        let trace_config = opentelemetry_sdk::trace::Config::default().with_resource(
+            Resource::new(vec![KeyValue::new("service.name", service_name)]),
+        );
+
+        match opentelemetry_otlp::new_pipeline()
+            .tracing()
+            .with_trace_config(trace_config)
+            .with_exporter(opentelemetry_otlp::new_exporter().tonic().with_endpoint(endpoint))
+            .install_batch(opentelemetry_sdk::runtime::Tokio)
+        {
+            Ok(tracer) => {
+                tracing_subscriber::registry()
+                    .with(env_filter)
+                    .with(fmt_layer)
+                    .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                    .init();
+                return;
+            }
+            Err(err) => {
+                eprintln!("Failed to initialize OTLP tracing: {err}");
+            }
+        }
+    }
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt_layer)
+        .init();
+}
+
+pub fn inject_current_trace_context(headers: &mut reqwest::header::HeaderMap) {
+    let context = opentelemetry::Context::current();
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&context, &mut ReqwestHeaderInjector(headers));
+    });
+}
+
+struct ReqwestHeaderInjector<'a>(&'a mut reqwest::header::HeaderMap);
+
+impl Injector for ReqwestHeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let (Ok(header_name), Ok(header_value)) = (
+            reqwest::header::HeaderName::from_bytes(key.as_bytes()),
+            reqwest::header::HeaderValue::from_str(&value),
+        ) {
+            self.0.insert(header_name, header_value);
+        }
+    }
+}

--- a/backend/verifier/src/lib.rs
+++ b/backend/verifier/src/lib.rs
@@ -8,6 +8,7 @@ use shared::RegistryError;
 use std::{fs, process::Stdio, time::Duration};
 use tempfile::TempDir;
 use tokio::{process::Command, time::timeout};
+use tracing::instrument;
 
 const DEFAULT_SOROBAN_SDK_VERSION: &str = "21.7.7";
 const BUILD_TIMEOUT: Duration = Duration::from_secs(120);
@@ -20,6 +21,7 @@ pub struct VerificationResult {
     pub message: Option<String>,
 }
 
+#[instrument(skip(source_code, build_params), fields(component = "verifier", deployed_wasm_hash = %deployed_wasm_hash))]
 pub async fn verify_contract(
     source_code: &str,
     deployed_wasm_hash: &str,
@@ -68,6 +70,7 @@ pub async fn verify_contract(
 /// Supports two source modes:
 /// - raw Rust contract source (compiled with cargo)
 /// - `wasm_base64:<...>` for precompiled test payloads
+#[instrument(skip(source_code, build_params), fields(component = "verifier"))]
 pub async fn compile_contract(
     source_code: &str,
     compiler_version: Option<&str>,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?err}@postgres:5432/${POSTGRES_DB:-soroban_registry}
       RUST_LOG: ${RUST_LOG:-info}
       OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_SERVICE_NAME: soroban-registry-api
     ports:
       - "3001:3001"
     depends_on:
@@ -41,6 +42,25 @@ services:
     volumes:
       - ./backend:/app
       - cargo_cache:/usr/local/cargo/registry
+
+  indexer:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    container_name: soroban-registry-indexer
+    command: ["/app/indexer"]
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?err}@postgres:5432/${POSTGRES_DB:-soroban_registry}
+      RUST_LOG: ${INDEXER_RUST_LOG:-indexer=info}
+      STELLAR_NETWORK: ${STELLAR_NETWORK:-testnet}
+      OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_SERVICE_NAME: soroban-registry-indexer
+    depends_on:
+      postgres:
+        condition: service_healthy
+      jaeger:
+        condition: service_started
+    restart: unless-stopped
 
   frontend:
     build:

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -334,7 +334,11 @@ duration_ms: >500 AND path: /api/contracts/search
 
 ### Overview
 
-All HTTP requests and async operations are traced using OpenTelemetry → Jaeger.
+Distributed traces are exported via OTLP to Jaeger from backend services:
+- `soroban-registry-api`
+- `soroban-registry-indexer`
+
+Verification flows are instrumented under the verifier component spans so they are visible in request traces.
 
 ### Trace Context Propagation
 
@@ -357,12 +361,17 @@ Access Jaeger UI at: `http://localhost:16686`
    - Min Duration: `500ms`
 
 2. **Trace errors:**
-   - Service: `soroban-api`
+  - Service: `soroban-registry-api`
    - Tags: `error=true`
 
-3. **Database query spans:**
-   - Service: `soroban-api`
-   - Tags: `db.system=postgresql`
+3. **Indexer polling traces:**
+  - Service: `soroban-registry-indexer`
+  - Operation contains: `get_latest_ledger` or `get_ledger_operations`
+
+### Dependency Graph
+
+In Jaeger UI, open **Monitor > Dependencies** to view service interaction topology generated from spans.
+Trace context propagation uses W3C headers so downstream HTTP calls stay correlated in a single trace.
 
 ### Correlation IDs
 


### PR DESCRIPTION
This PR adds end-to-end tracing so requests are easier to debug across services.

# What’s included
- Connected API and indexer to Jaeger using OTLP
- Added trace context propagation for incoming and outgoing HTTP calls
- Added tracing spans in verifier flows
- Added indexer service to docker-compose for full trace visibility
- Updated observability docs

# Result
- Full request traces can be seen in Jaeger
- Service relationships/dependencies are visible in Jaeger’s dependency view

closes #601 