### PR TITLE
feat: add loading skeletons for contract list

### DIFF
--- a/frontend/app/contracts/contracts-content.tsx
+++ b/frontend/app/contracts/contracts-content.tsx
@@ -665,14 +665,24 @@ export function ContractsContent() {
           {/* Results grid */}
           <div className="flex-1 min-w-0">
             {isLoading ? (
-              <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 mb-8">
-                {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                role="status"
+                aria-label="Loading contracts"
+                aria-live="polite"
+                className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 mb-8"
+              >
+                {Array.from({ length: DEFAULT_PAGE_SIZE }).map((_, i) => (
                   <ContractCardSkeleton key={i} />
                 ))}
+                <span className="sr-only">Loading contracts, please wait…</span>
               </div>
             ) : effectiveData && effectiveData.items.length > 0 ? (
               <>
-                <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 mb-8">
+                <div
+                  aria-live="polite"
+                  aria-atomic="true"
+                  className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 mb-8 animate-in fade-in duration-300"
+                >
                   {effectiveData.items.map((contract: Contract) => (
                     <ContractCard key={contract.id} contract={contract} />
                   ))}

--- a/frontend/components/ContractCardSkeleton.tsx
+++ b/frontend/components/ContractCardSkeleton.tsx
@@ -2,11 +2,16 @@ import LoadingSkeleton from "./LoadingSkeleton";
 
 export default function ContractCardSkeleton() {
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-border bg-card p-6 glow-border h-full">
+    <div
+      className="relative overflow-hidden rounded-2xl border border-border bg-card p-6 glow-border h-full"
+      role="status"
+      aria-busy="true"
+      aria-label="Loading contract"
+    >
       <div className="relative h-full flex flex-col">
-        {/* Header */}
+        {/* Header: name + network badge */}
         <div className="flex items-start justify-between mb-3">
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
               <LoadingSkeleton width="60%" height="1.5rem" />
             </div>
@@ -15,21 +20,14 @@ export default function ContractCardSkeleton() {
           <LoadingSkeleton
             width="5rem"
             height="1.75rem"
-            className="rounded-full"
+            className="rounded-full ml-3 shrink-0"
           />
         </div>
 
+        {/* Category + verified badge row */}
         <div className="flex items-center justify-between gap-2 mb-4">
-          <LoadingSkeleton
-            width="6rem"
-            height="1.75rem"
-            className="rounded-lg"
-          />
-          <LoadingSkeleton
-            width="4.5rem"
-            height="1.25rem"
-            className="rounded-full"
-          />
+          <LoadingSkeleton width="6rem" height="1.75rem" className="rounded-lg" />
+          <LoadingSkeleton width="4.5rem" height="1.25rem" className="rounded-full" />
         </div>
 
         {/* Description */}
@@ -38,32 +36,28 @@ export default function ContractCardSkeleton() {
           <LoadingSkeleton width="85%" height="0.875rem" />
         </div>
 
+        {/* Stats row */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
           <LoadingSkeleton width="100%" height="0.875rem" />
           <LoadingSkeleton width="100%" height="0.875rem" />
         </div>
 
+        {/* Address line */}
         <LoadingSkeleton width="55%" height="0.875rem" className="mb-4" />
 
-        {/* Health Widget */}
+        {/* Health widget */}
         <div className="mb-4">
           <LoadingSkeleton width="100%" height="3rem" className="rounded-lg" />
         </div>
 
-        {/* Footer */}
-        <div className="flex items-center gap-2 pt-4 mt-auto border-t border-border">
-          <LoadingSkeleton
-            width="6.5rem"
-            height="1.75rem"
-            className="rounded-md"
-          />
-          <LoadingSkeleton
-            width="7.5rem"
-            height="1.75rem"
-            className="rounded-md"
-          />
+        {/* Action buttons */}
+        <div className="flex flex-wrap items-center gap-2 pt-4 mt-auto border-t border-border">
+          <LoadingSkeleton width="6.5rem" height="1.75rem" className="rounded-md" />
+          <LoadingSkeleton width="7.5rem" height="1.75rem" className="rounded-md" />
+          <LoadingSkeleton width="7rem"   height="1.75rem" className="rounded-md" />
         </div>
       </div>
+      <span className="sr-only">Loading contract card</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Adds skeleton screens while contract listings are loading for a smoother, more polished user experience with no layout shift.

## Changes
- Updated `ContractCardSkeleton.tsx` with accessibility attributes (`role="status"`, `aria-busy="true"`, `aria-label="Loading contract"`) and matched skeleton buttons to real card layout
- Updated `contracts-content.tsx`:
  - Skeleton count changed to match `DEFAULT_PAGE_SIZE` (12) to prevent layout shift
  - Skeleton grid has `role="status"`, `aria-label="Loading contracts"`, `aria-live="polite"`
  - Real content grid fades in with `animate-in fade-in duration-300` transition
  - Screen readers notified when contracts finish loading via `aria-live="polite"`

Closes #631