### PR TITLE
feat: Optimize memory usage in indexer by batching contract inserts a…

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "ed25519-dalek",
  "futures-util",
  "hex",
+ "hmac",
  "jsonwebtoken",
  "lazy_static",
  "lru",

--- a/backend/indexer/src/db.rs
+++ b/backend/indexer/src/db.rs
@@ -172,9 +172,9 @@ impl DatabaseWriter {
 
     /// Write multiple contracts in a single transaction.
     ///
-    /// Uses a multi-row INSERT via `QueryBuilder` wrapped in a transaction
-    /// for atomicity. Duplicates (by `contract_id + network`) are silently
-    /// skipped via `ON CONFLICT DO NOTHING`.
+    /// Deployments are processed in chunks of at most `BATCH_CHUNK_SIZE` rows
+    /// per INSERT to bound the size of each `QueryBuilder` SQL string. Duplicates
+    /// (by `contract_id + network`) are silently skipped via `ON CONFLICT DO NOTHING`.
     pub async fn write_contracts_batch(
         &self,
         deployments: &[ContractDeployment],
@@ -183,6 +183,10 @@ impl DatabaseWriter {
         if deployments.is_empty() {
             return Ok((0, 0));
         }
+
+        // Cap each INSERT to prevent the QueryBuilder SQL string from growing
+        // unboundedly when a ledger contains a large burst of deployments.
+        const BATCH_CHUNK_SIZE: usize = 50;
 
         let mut tx = self.pool.begin().await.map_err(|e| {
             error!("Failed to begin transaction: {}", e);
@@ -203,45 +207,59 @@ impl DatabaseWriter {
             publisher_map.insert(deployer, publisher_id);
         }
 
-        // 2. Batch insert contracts — ON CONFLICT DO NOTHING handles duplicates
-        let mut query_builder: QueryBuilder<sqlx::Postgres> = QueryBuilder::new(
-            "INSERT INTO contracts \
-             (id, contract_id, wasm_hash, name, slug, publisher_id, network, \
-              is_verified, created_at, updated_at, deployed_at) ",
-        );
+        let mut total_new = 0usize;
 
-        query_builder.push_values(deployments.iter(), |mut b, deployment| {
-            let publisher_id = publisher_map.get(deployment.deployer.as_str()).unwrap();
-            let wasm_hash = format!("{}_{}", deployment.contract_id, deployment.op_id);
-            let slug = shared::slugify(&deployment.contract_id);
-            b.push_bind(Uuid::new_v4())
-                .push_bind(&deployment.contract_id)
-                .push_bind(wasm_hash)
-                .push_bind(&deployment.contract_id)
-                .push_bind(slug)
-                .push_bind(publisher_id)
-                .push_bind(network_str)
-                .push_bind(false)
-                .push_bind(now)
-                .push_bind(now)
-                .push_bind(chrono::DateTime::parse_from_rfc3339(&deployment.deployed_at).map(|dt| dt.with_timezone(&chrono::Utc)).unwrap_or(now));
-        });
+        // 2. Batch insert contracts in bounded chunks to cap QueryBuilder memory usage.
+        for chunk in deployments.chunks(BATCH_CHUNK_SIZE) {
+            let mut query_builder: QueryBuilder<sqlx::Postgres> = QueryBuilder::new(
+                "INSERT INTO contracts \
+                 (id, contract_id, wasm_hash, name, slug, publisher_id, network, \
+                  is_verified, created_at, updated_at, deployed_at) ",
+            );
 
-        query_builder.push(" ON CONFLICT (contract_id, network) DO NOTHING RETURNING contract_id");
+            query_builder.push_values(chunk.iter(), |mut b, deployment| {
+                let publisher_id = publisher_map.get(deployment.deployer.as_str()).unwrap();
+                let wasm_hash = format!("{}_{}", deployment.contract_id, deployment.op_id);
+                let slug = shared::slugify(&deployment.contract_id);
+                b.push_bind(Uuid::new_v4())
+                    .push_bind(&deployment.contract_id)
+                    .push_bind(wasm_hash)
+                    .push_bind(&deployment.contract_id)
+                    .push_bind(slug)
+                    .push_bind(publisher_id)
+                    .push_bind(network_str)
+                    .push_bind(false)
+                    .push_bind(now)
+                    .push_bind(now)
+                    .push_bind(
+                        chrono::DateTime::parse_from_rfc3339(&deployment.deployed_at)
+                            .map(|dt| dt.with_timezone(&chrono::Utc))
+                            .unwrap_or(now),
+                    );
+            });
 
-        let query = query_builder.build();
-        let rows = query.fetch_all(&mut *tx).await.map_err(|e| {
-            error!("Failed to execute batch contract insert: {}", e);
-            DatabaseError::SqlError(e.to_string())
-        })?;
+            query_builder
+                .push(" ON CONFLICT (contract_id, network) DO NOTHING RETURNING contract_id");
 
-        let inserted_ids: std::collections::HashSet<String> = rows
-            .into_iter()
-            .map(|r| r.get::<String, _>("contract_id"))
-            .collect();
+            // Count returned rows directly — avoids collecting all IDs into a HashSet.
+            let chunk_new = query_builder
+                .build()
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(|e| {
+                    error!("Failed to execute batch contract insert: {}", e);
+                    DatabaseError::SqlError(e.to_string())
+                })?
+                .len();
 
-        let new_count = inserted_ids.len();
-        let duplicate_count = deployments.len() - new_count;
+            total_new += chunk_new;
+        }
+
+        // publisher_map is no longer needed; drop it before the commit so its
+        // heap allocation is released while the transaction is still open.
+        drop(publisher_map);
+
+        let duplicate_count = deployments.len() - total_new;
 
         tx.commit().await.map_err(|e| {
             error!("Failed to commit transaction: {}", e);
@@ -250,10 +268,10 @@ impl DatabaseWriter {
 
         info!(
             "Batch write complete: new={}, duplicates={}",
-            new_count, duplicate_count
+            total_new, duplicate_count
         );
 
-        Ok((new_count, duplicate_count))
+        Ok((total_new, duplicate_count))
     }
 
     /// Get or create a publisher record — transaction-scoped variant.

--- a/backend/indexer/src/main.rs
+++ b/backend/indexer/src/main.rs
@@ -263,9 +263,12 @@ impl IndexerService {
                         "Fetched ledger operations"
                     );
 
-                    // Detect contract deployments
+                    // Detect contract deployments, then immediately drop `operations` so
+                    // the Vec of serde_json::Value bodies does not linger for the rest of
+                    // the ledger-processing block.
                     let deployments =
                         detector::detect_contract_deployments(&operations, ledger_height, &ledger.timestamp);
+                    drop(operations);
 
                     if !deployments.is_empty() {
                         info!(

--- a/backend/indexer/src/rpc.rs
+++ b/backend/indexer/src/rpc.rs
@@ -79,6 +79,29 @@ struct OperationsResponse {
     records: Vec<OperationRecord>,
 }
 
+/// Typed response structures for the latest-ledger endpoint.
+/// Using concrete types (instead of serde_json::Value) avoids retaining the
+/// entire JSON tree in memory while only a handful of fields are needed.
+#[derive(Debug, Deserialize)]
+struct LatestLedgerResponse {
+    #[serde(rename = "_embedded")]
+    embedded: LatestLedgerEmbedded,
+}
+
+#[derive(Debug, Deserialize)]
+struct LatestLedgerEmbedded {
+    records: Vec<LedgerSummary>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LedgerSummary {
+    sequence: u64,
+    id: Option<String>,
+    hash: String,
+    prev_hash: Option<String>,
+    closed_at: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct OperationRecord {
     id: String,
@@ -233,73 +256,24 @@ impl StellarRpcClient {
             )));
         }
 
-        // Parse the response - it returns an array
-        let response_text = response
-            .text()
-            .await
-            .map_err(|e| RpcError::InvalidResponse(format!("Failed to read response: {}", e)))?;
-
-        let data: serde_json::Value = serde_json::from_str(&response_text).map_err(|e| {
-            error!("Invalid JSON in ledger response: {}", e);
-            RpcError::InvalidResponse(format!("Invalid JSON: {}", e))
+        // Deserialize directly into typed structs — avoids holding the full
+        // serde_json::Value tree in memory while extracting a handful of fields.
+        let data: LatestLedgerResponse = response.json().await.map_err(|e| {
+            error!("Invalid JSON in latest-ledger response: {}", e);
+            RpcError::InvalidResponse(format!("Failed to parse latest ledger response: {}", e))
         })?;
 
-        // Extract first ledger from _embedded records
-        let ledgers = data
-            .get("_embedded")
-            .and_then(|e| e.get("records"))
-            .and_then(|r| r.as_array())
-            .ok_or_else(|| {
-                error!("No records found in latest ledger response");
-                RpcError::InvalidResponse("No records in response".to_string())
-            })?;
-
-        let ledger = ledgers.first().ok_or_else(|| {
+        let ledger = data.embedded.records.into_iter().next().ok_or_else(|| {
             error!("Empty records array in latest ledger response");
             RpcError::InvalidResponse("Empty records array".to_string())
         })?;
 
-        let sequence = ledger
-            .get("sequence")
-            .and_then(|v| v.as_u64())
-            .ok_or_else(|| {
-                error!("Missing or invalid sequence in ledger: {:?}", ledger);
-                RpcError::InvalidResponse("Missing sequence".to_string())
-            })?;
-
-        let hash = ledger
-            .get("hash")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                error!("Missing hash in ledger");
-                RpcError::InvalidResponse("Missing hash".to_string())
-            })?;
-
-        let prev_hash = ledger
-            .get("prev_hash")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .unwrap_or_default();
-
-        let id = ledger
-            .get("id")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| hash.clone());
-
-        let timestamp = ledger
-            .get("closed_at")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .unwrap_or_default();
-
         Ok(Ledger {
-            sequence,
-            id,
-            hash,
-            prev_hash,
-            timestamp,
+            sequence: ledger.sequence,
+            id: ledger.id.unwrap_or_else(|| ledger.hash.clone()),
+            hash: ledger.hash.clone(),
+            prev_hash: ledger.prev_hash.unwrap_or_default(),
+            timestamp: ledger.closed_at.unwrap_or_default(),
         })
     }
 

--- a/backend/indexer/tests/integration_tests.rs
+++ b/backend/indexer/tests/integration_tests.rs
@@ -66,7 +66,7 @@ mod tests {
             }),
         }];
 
-        let deployments = detect_contract_deployments(&ops, 100);
+        let deployments = detect_contract_deployments(&ops, 100, "2023-10-27T10:00:00Z");
         assert_eq!(deployments.len(), 1);
         assert_eq!(deployments[0].contract_id, contract_id);
         assert_eq!(deployments[0].deployer, deployer);
@@ -92,7 +92,7 @@ mod tests {
             },
         ];
 
-        let deployments = detect_contract_deployments(&ops, 100);
+        let deployments = detect_contract_deployments(&ops, 100, "2023-10-27T10:00:00Z");
         assert_eq!(deployments.len(), 0);
     }
 
@@ -173,7 +173,7 @@ mod tests {
             },
         ];
 
-        let deployments = detect_contract_deployments(&ops, 100);
+        let deployments = detect_contract_deployments(&ops, 100, "2023-10-27T10:00:00Z");
         assert_eq!(deployments.len(), 2);
         assert_eq!(deployments[0].contract_id, c1);
         assert_eq!(deployments[1].contract_id, c2);
@@ -192,7 +192,7 @@ mod tests {
             }),
         }];
 
-        let deployments = detect_contract_deployments(&ops, 100);
+        let deployments = detect_contract_deployments(&ops, 100, "2023-10-27T10:00:00Z");
         assert_eq!(deployments.len(), 0);
     }
 


### PR DESCRIPTION
Summary
Drop operation bodies immediately after detection (main.rs): Vec<Operation> holds a serde_json::Value JSON tree for every operation in the ledger (up to 200 per fetch). Previously this Vec lived for the entire ledger-processing block. Now it is explicitly dropped right after detect_contract_deployments extracts what it needs, freeing the heap before the DB write begins.

Bound batch INSERT size (db.rs): write_contracts_batch now chunks deployments into groups of at most 50 rows per QueryBuilder SQL string. This caps the peak heap allocation of the query buffer during burst ledgers instead of building one unbounded SQL string for the entire batch.

Drop publisher_map before transaction commit (db.rs): The HashMap<&str, Uuid> used to resolve publisher IDs is no longer needed after push_values fills the query. It is now explicitly dropped before tx.commit() to release its allocation while the transaction is still in flight.

Typed deserialization in get_latest_ledger (rpc.rs): The previous implementation parsed the full HTTP response body into a serde_json::Value tree and then hand-walked the structure field by field. Replaced with concrete LatestLedgerResponse / LatestLedgerEmbedded / LedgerSummary structs so serde_json materialises only the fields we need and the rest of the response is never allocated.

Fix integration test compile failure (tests/integration_tests.rs): All four calls to detect_contract_deployments were missing the required deployed_at: &str argument, preventing the test suite from compiling.

Test plan
 cargo check -p indexer passes with no errors or warnings
 cargo test -p indexer — all unit and integration tests pass
 Deploy to staging and observe RSS/heap metrics over a 24-hour window — memory usage should remain flat across polling cycles
 Confirm no unbounded growth in any collection under normal operation and under a catch-up burst (large indexer_lag)
 
 closes #588 