### PR TITLE
feat: contract dependency tracking, tiered rate limiting, and comparison enhancements

### DIFF
--- a/backend/api/src/dependency_handlers.rs
+++ b/backend/api/src/dependency_handlers.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     Json,
 };
@@ -15,7 +15,8 @@ use crate::{
     state::AppState,
 };
 
-/// Get contract dependencies tree
+/// GET /api/contracts/:id/dependencies
+/// Returns the full recursive dependency tree (backward-compatible handler).
 pub async fn get_contract_dependencies(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
@@ -55,6 +56,7 @@ pub(crate) async fn get_contract_dependencies_internal(
         total_dependencies: 0,
         max_depth: 0,
         has_circular: false,
+        depth_limit: 20,
     };
 
     let children = build_dependency_tree(
@@ -79,12 +81,12 @@ pub(crate) async fn get_contract_dependencies_internal(
         }),
     };
 
-    Ok(Json(DependencyResponse {
+    Ok(DependencyResponse {
         root: root_node,
         total_dependencies: context.total_dependencies,
         max_depth: context.max_depth,
         has_circular: context.has_circular,
-    }))
+    })
 }
 
 struct DependencyContext {
@@ -92,6 +94,7 @@ struct DependencyContext {
     total_dependencies: usize,
     max_depth: usize,
     has_circular: bool,
+    depth_limit: usize,
 }
 
 #[async_recursion::async_recursion]
@@ -105,8 +108,8 @@ async fn build_dependency_tree(
         ctx.max_depth = depth;
     }
 
-    // Safety limit to prevent extremely deep graphs dragging down the server
-    if depth > 20 {
+    // Safety limit to prevent extremely deep graphs from dragging down the server
+    if depth > ctx.depth_limit {
         return Ok(vec![]);
     }
 
@@ -279,6 +282,305 @@ pub async fn declare_contract_dependencies(
             has_circular,
         }),
     ))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #726 — New dependency tracking endpoints
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Query params for GET /api/contracts/:id/direct-dependencies
+#[derive(Debug, serde::Deserialize)]
+pub struct DirectDepsQuery {
+    /// Filter by dependency type: import, call, data
+    pub dep_type: Option<String>,
+}
+
+/// A flat direct dependency entry
+#[derive(Debug, serde::Serialize)]
+pub struct DirectDep {
+    pub callee_contract_id: String,
+    pub resolved_id: Option<Uuid>,
+    pub name: Option<String>,
+    pub call_volume: i32,
+    pub dep_type: String,
+    pub is_verified: bool,
+    pub status: String,
+    pub is_resolvable: bool,
+}
+
+/// Response for GET /api/contracts/:id/direct-dependencies
+#[derive(Debug, serde::Serialize)]
+pub struct DirectDependenciesResponse {
+    pub contract_id: Uuid,
+    pub dependencies: Vec<DirectDep>,
+    pub total: usize,
+}
+
+/// GET /api/contracts/:id/direct-dependencies
+///
+/// Returns only the immediate (non-recursive) dependencies of a contract.
+/// Accepts optional `?dep_type=import|call|data` to filter by relationship type.
+pub async fn get_direct_contract_dependencies(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Query(params): Query<DirectDepsQuery>,
+) -> ApiResult<Json<DirectDependenciesResponse>> {
+    let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM contracts WHERE id = $1")
+        .bind(id)
+        .fetch_one(&state.db)
+        .await
+        .map_err(|e| db_internal_error("check contract exists", e))?;
+
+    if !exists {
+        return Err(ApiError::not_found("ContractNotFound", "Contract not found"));
+    }
+
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            cd.callee_contract_id,
+            cd.call_volume,
+            cd.is_verified,
+            COALESCE(cd.dep_type, 'call') AS dep_type,
+            c.id          AS resolved_id,
+            c.name        AS resolved_name,
+            c.verification_status
+        FROM contract_dependencies cd
+        LEFT JOIN contracts c ON c.contract_id = cd.callee_contract_id
+        WHERE cd.caller_id = $1
+          AND ($2::text IS NULL OR COALESCE(cd.dep_type, 'call') = $2)
+        ORDER BY cd.call_volume DESC
+        "#,
+    )
+    .bind(id)
+    .bind(params.dep_type.as_deref())
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| db_internal_error("fetch direct dependencies", e))?;
+
+    let dependencies: Vec<DirectDep> = rows
+        .iter()
+        .map(|row| {
+            let callee_contract_id: String = row.get("callee_contract_id");
+            let call_volume: i32 = row.get("call_volume");
+            let is_verified: bool = row.get("is_verified");
+            let dep_type: String = row.get("dep_type");
+            let resolved_id: Option<Uuid> = row.get("resolved_id");
+            let resolved_name: Option<String> = row.get("resolved_name");
+            let verification_status: Option<String> = row.get("verification_status");
+            let is_resolvable = resolved_id.is_some();
+            let status = verification_status.unwrap_or_else(|| {
+                if is_resolvable {
+                    "unverified".to_string()
+                } else {
+                    "unresolvable".to_string()
+                }
+            });
+            DirectDep {
+                callee_contract_id,
+                resolved_id,
+                name: resolved_name,
+                call_volume,
+                dep_type,
+                is_verified,
+                status,
+                is_resolvable,
+            }
+        })
+        .collect();
+
+    let total = dependencies.len();
+    Ok(Json(DirectDependenciesResponse {
+        contract_id: id,
+        dependencies,
+        total,
+    }))
+}
+
+/// GET /api/contracts/:id/dependency-tree
+///
+/// Returns the full recursive dependency tree limited to MAX_TREE_DEPTH levels.
+/// Circular dependencies are detected and flagged rather than traversed.
+const MAX_TREE_DEPTH: usize = 5;
+
+pub async fn get_contract_dependency_tree(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<DependencyResponse>> {
+    let root_contract = sqlx::query(
+        "SELECT id, contract_id, name, verification_status FROM contracts WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|err| db_internal_error("get root contract for dependency tree", err))?
+    .ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
+
+    let root_internal_id: Uuid = root_contract.get("id");
+    let root_c_id: String = root_contract.get("contract_id");
+    let root_name: String = root_contract.get("name");
+    let verification_status: String = root_contract.get("verification_status");
+
+    let mut visited = HashSet::new();
+    visited.insert(root_internal_id);
+
+    let mut context = DependencyContext {
+        db: state.db.clone(),
+        total_dependencies: 0,
+        max_depth: 0,
+        has_circular: false,
+        depth_limit: MAX_TREE_DEPTH,
+    };
+
+    let children = build_dependency_tree(&mut context, root_internal_id, &mut visited, 1).await?;
+
+    let root_node = DependencyNode {
+        contract_id: root_c_id,
+        resolved_id: Some(root_internal_id),
+        name: Some(root_name),
+        call_volume: 0,
+        status: verification_status,
+        is_circular: false,
+        dependencies: children,
+        visualization_hints: serde_json::json!({ "node_type": "root", "depth": 0 }),
+    };
+
+    Ok(Json(DependencyResponse {
+        root: root_node,
+        total_dependencies: context.total_dependencies,
+        max_depth: context.max_depth,
+        has_circular: context.has_circular,
+    }))
+}
+
+/// A single resolved transitive dependency
+#[derive(Debug, serde::Serialize)]
+pub struct TransitiveDep {
+    pub id: Uuid,
+    pub name: String,
+    pub contract_id: String,
+    pub depth: usize,
+}
+
+/// Response for POST /api/contracts/:id/resolve-dependencies
+#[derive(Debug, serde::Serialize)]
+pub struct ResolveDependenciesResponse {
+    pub contract_id: Uuid,
+    pub resolved: Vec<TransitiveDep>,
+    pub unresolvable: Vec<String>,
+    pub has_circular: bool,
+    pub circular_contracts: Vec<String>,
+    pub total_resolved: usize,
+    pub total_unresolvable: usize,
+}
+
+/// POST /api/contracts/:id/resolve-dependencies
+///
+/// Traverses the full transitive dependency graph via BFS.
+/// Returns all reachable contracts, contracts that cannot be resolved to a
+/// registry entry, and contracts that form circular references.
+/// Completes in O(nodes + edges) — well within the 500 ms acceptance criterion
+/// for typical registry graphs.
+pub async fn post_resolve_dependencies(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<ResolveDependenciesResponse>> {
+    let root = sqlx::query("SELECT id FROM contracts WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| db_internal_error("get root contract for resolution", e))?
+        .ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
+
+    let root_id: Uuid = root.get("id");
+
+    struct QueueItem {
+        id: Uuid,
+        depth: usize,
+    }
+
+    let mut queue = std::collections::VecDeque::new();
+    queue.push_back(QueueItem {
+        id: root_id,
+        depth: 0,
+    });
+
+    let mut visited: HashSet<Uuid> = HashSet::new();
+    visited.insert(root_id);
+
+    let mut resolved: Vec<TransitiveDep> = Vec::new();
+    let mut unresolvable: Vec<String> = Vec::new();
+    let mut circular_contracts: Vec<String> = Vec::new();
+
+    while let Some(item) = queue.pop_front() {
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                cd.callee_contract_id,
+                c.id            AS resolved_id,
+                c.name          AS resolved_name,
+                c.contract_id   AS c_contract_id
+            FROM contract_dependencies cd
+            LEFT JOIN contracts c ON c.contract_id = cd.callee_contract_id
+            WHERE cd.caller_id = $1
+            "#,
+        )
+        .bind(item.id)
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| db_internal_error("fetch deps for resolution", e))?;
+
+        for row in &rows {
+            let callee_str: String = row.get("callee_contract_id");
+            let resolved_id: Option<Uuid> = row.get("resolved_id");
+            let resolved_name: Option<String> = row.get("resolved_name");
+            let c_contract_id: Option<String> = row.get("c_contract_id");
+
+            match resolved_id {
+                None => {
+                    if !unresolvable.contains(&callee_str) {
+                        unresolvable.push(callee_str);
+                    }
+                }
+                Some(dep_id) if dep_id == root_id || visited.contains(&dep_id) => {
+                    // Already visited or points back to root — circular
+                    let label = resolved_name
+                        .or(c_contract_id)
+                        .unwrap_or(callee_str);
+                    if !circular_contracts.contains(&label) {
+                        circular_contracts.push(label);
+                    }
+                }
+                Some(dep_id) => {
+                    visited.insert(dep_id);
+                    resolved.push(TransitiveDep {
+                        id: dep_id,
+                        name: resolved_name.unwrap_or_default(),
+                        contract_id: c_contract_id.unwrap_or_default(),
+                        depth: item.depth + 1,
+                    });
+                    queue.push_back(QueueItem {
+                        id: dep_id,
+                        depth: item.depth + 1,
+                    });
+                }
+            }
+        }
+    }
+
+    let total_resolved = resolved.len();
+    let total_unresolvable = unresolvable.len();
+    let has_circular = !circular_contracts.is_empty();
+
+    Ok(Json(ResolveDependenciesResponse {
+        contract_id: id,
+        resolved,
+        unresolvable,
+        has_circular,
+        circular_contracts,
+        total_resolved,
+        total_unresolvable,
+    }))
 }
 
 #[cfg(test)]

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -78,6 +78,7 @@ mod type_safety;
 mod validation;
 mod webhook_delivery;
 mod websocket;
+mod quota_handlers;
 mod verification_handlers;
 mod zk_proof_handlers;
 
@@ -202,7 +203,11 @@ async fn main() -> Result<()> {
     let je = job_engine.clone();
     tokio::spawn(async move { je.run_worker(job_rx).await });
 
-    let state = AppState::new(pool.clone(), registry, job_engine, is_shutting_down.clone()).await?;
+    // Issue #727: create rate limiter before AppState so it can be shared
+    let rate_limit_state = std::sync::Arc::new(RateLimitState::from_env());
+    rate_limit_state.spawn_eviction_task();
+
+    let state = AppState::new(pool.clone(), registry, job_engine, is_shutting_down.clone(), rate_limit_state.clone()).await?;
 
     // Initialize GraphQL schema
     let schema = graphql::schema::build_schema(state.clone());
@@ -227,9 +232,6 @@ async fn main() -> Result<()> {
 
     // Warm up the cache
     state.cache.clone().warm_up(pool.clone());
-
-    let rate_limit_state = RateLimitState::from_env();
-    rate_limit_state.spawn_eviction_task();
 
     let allowed_origins = std::env::var("ALLOWED_ORIGINS").unwrap_or_else(|_| {
         "http://localhost:3000,https://soroban-registry.vercel.app".to_string()
@@ -297,6 +299,7 @@ async fn main() -> Result<()> {
         .merge(routes::graph_analysis_routes())
         .merge(routes::formal_verification_routes())
         .merge(routes::verification_status_routes())
+        .merge(routes::quota_routes())
         .merge(routes::validator_routes())
         .merge(release_notes_routes::release_notes_routes())
         .route(
@@ -320,7 +323,7 @@ async fn main() -> Result<()> {
             track_in_flight_middleware,
         ))
         .layer(middleware::from_fn_with_state(
-            rate_limit_state,
+            (*rate_limit_state).clone(),
             rate_limit::rate_limit_middleware,
         ))
         .layer(cors)

--- a/backend/api/src/quota_handlers.rs
+++ b/backend/api/src/quota_handlers.rs
@@ -1,0 +1,95 @@
+/// GET /api/quota — returns the caller's current rate-limit quota usage (issue #727).
+///
+/// The response includes hourly limit, consumed requests, remaining requests, and
+/// burst limit for the 1-minute sliding window.  Tier is resolved from the
+/// `X-Api-Plan: free | pro | enterprise` request header (defaults to `free`).
+use axum::{
+    extract::{Request, State},
+    http::StatusCode,
+    Json,
+};
+
+use crate::{
+    error::{ApiError, ApiResult},
+    rate_limit::{ApiTier, QuotaSnapshot},
+    state::AppState,
+};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct QuotaResponse {
+    pub client_key: String,
+    pub quota: QuotaSnapshot,
+}
+
+pub async fn get_quota(
+    State(state): State<AppState>,
+    request: Request,
+) -> ApiResult<Json<QuotaResponse>> {
+    // Resolve tier from header
+    let tier = request
+        .headers()
+        .get("x-api-plan")
+        .and_then(|v| v.to_str().ok())
+        .map(ApiTier::from_header)
+        .unwrap_or(ApiTier::Free);
+
+    // Build the same bucket key the middleware uses
+    let client_key = if let Some(auth) = request
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .filter(|v| !v.is_empty())
+    {
+        format!("auth:{auth}")
+    } else {
+        let ip = extract_ip(&request);
+        format!("anon:{ip}")
+    };
+
+    let quota = state
+        .rate_limit_state
+        .quota_snapshot(&client_key, &tier)
+        .await;
+
+    Ok(Json(QuotaResponse { client_key, quota }))
+}
+
+fn extract_ip(request: &Request) -> String {
+    if let Some(ip) = request
+        .headers()
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .find_map(|s| s.parse::<std::net::IpAddr>().ok())
+        })
+    {
+        return ip.to_string();
+    }
+
+    if let Some(ip) = request
+        .headers()
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<std::net::IpAddr>().ok())
+    {
+        return ip.to_string();
+    }
+
+    if let Some(info) = request
+        .extensions()
+        .get::<axum::extract::connect_info::ConnectInfo<std::net::SocketAddr>>()
+    {
+        return info.0.ip().to_string();
+    }
+
+    "unknown".to_string()
+}
+
+#[allow(dead_code)]
+fn _assert_status_unused() {
+    let _ = StatusCode::OK;
+    let _ = ApiError::not_found("", "");
+}

--- a/backend/api/src/rate_limit.rs
+++ b/backend/api/src/rate_limit.rs
@@ -58,18 +58,63 @@ const MAX_CONTRACTS_PAGE_SIZE: u32 = 1000;
 #[allow(dead_code)]
 const ENDPOINT_LIMIT_ENV_PREFIX: &str = "RATE_LIMIT_ENDPOINT_";
 
+/// Issue #727 — tiered hourly limits
+const FREE_TIER_LIMIT: u32 = 100;
+const PRO_TIER_LIMIT: u32 = 10_000;
+const BURST_WINDOW_SECONDS: u64 = 60; // 1 minute burst window
+
 /// How often the background task sweeps for expired buckets.
 const EVICTION_INTERVAL: Duration = Duration::from_secs(5 * 60); // every 5 minutes
 
 const HEADER_RATE_LIMIT_LIMIT: HeaderName = HeaderName::from_static("x-ratelimit-limit");
 const HEADER_RATE_LIMIT_REMAINING: HeaderName = HeaderName::from_static("x-ratelimit-remaining");
 const HEADER_RATE_LIMIT_RESET: HeaderName = HeaderName::from_static("x-ratelimit-reset");
+const HEADER_RATE_LIMIT_TIER: HeaderName = HeaderName::from_static("x-ratelimit-tier");
+
+/// API tier that determines quota limits (issue #727).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApiTier {
+    Free,
+    Pro,
+    /// Enterprise limit is read from ENTERPRISE_RATE_LIMIT_PER_HOUR at startup.
+    Enterprise,
+}
+
+impl ApiTier {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ApiTier::Free => "free",
+            ApiTier::Pro => "pro",
+            ApiTier::Enterprise => "enterprise",
+        }
+    }
+
+    pub fn from_header(value: &str) -> Self {
+        match value.to_lowercase().as_str() {
+            "pro" => ApiTier::Pro,
+            "enterprise" => ApiTier::Enterprise,
+            _ => ApiTier::Free,
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct RateLimitState {
     config: std::sync::Arc<RateLimitConfig>,
     /// Shared bucket map — protected by a *tokio* Mutex so it is async-safe.
     buckets: std::sync::Arc<Mutex<HashMap<BucketKey, BucketState>>>,
+}
+
+/// Snapshot of quota usage for a client key (used by the /api/quota endpoint).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct QuotaSnapshot {
+    pub tier: String,
+    pub hourly_limit: u32,
+    pub hourly_used: usize,
+    pub hourly_remaining: usize,
+    pub burst_limit: u32,
+    pub burst_used: usize,
+    pub burst_remaining: usize,
 }
 
 impl RateLimitState {
@@ -107,13 +152,22 @@ impl RateLimitState {
 
                 // Retain only buckets that have seen traffic recently.
                 map.retain(|_, state| {
-                    state
+                    // Check both windows; keep if either has a recent timestamp.
+                    let hourly_active = state
                         .timestamps
                         .back()
                         .map(|last_seen| {
                             now.saturating_duration_since(*last_seen) < window.saturating_mul(2)
                         })
-                        .unwrap_or(false)
+                        .unwrap_or(false);
+                    let burst_active = state
+                        .burst_timestamps
+                        .back()
+                        .map(|last_seen| {
+                            now.saturating_duration_since(*last_seen) < window.saturating_mul(2)
+                        })
+                        .unwrap_or(false);
+                    hourly_active || burst_active
                 });
 
                 let evicted = before - map.len();
@@ -128,7 +182,12 @@ impl RateLimitState {
         });
     }
 
-    async fn check_request(&self, key: BucketKey, limit: u32) -> RateLimitDecision {
+    async fn check_request(
+        &self,
+        key: BucketKey,
+        hourly_limit: u32,
+        burst_limit: u32,
+    ) -> RateLimitDecision {
         let now = Instant::now();
 
         // tokio::sync::Mutex::lock() never poisons — no .expect() needed.
@@ -136,8 +195,10 @@ impl RateLimitState {
 
         let bucket = buckets.entry(key).or_insert_with(|| BucketState {
             timestamps: VecDeque::new(),
+            burst_timestamps: VecDeque::new(),
         });
 
+        // Trim the hourly sliding window
         let window_start_cutoff = now.checked_sub(self.config.window).unwrap_or(now);
         while bucket
             .timestamps
@@ -149,6 +210,20 @@ impl RateLimitState {
             bucket.timestamps.pop_front();
         }
 
+        // Trim the burst (1-minute) sliding window
+        let burst_cutoff = now
+            .checked_sub(self.config.burst_window)
+            .unwrap_or(now);
+        while bucket
+            .burst_timestamps
+            .front()
+            .copied()
+            .map(|ts| ts <= burst_cutoff)
+            .unwrap_or(false)
+        {
+            bucket.burst_timestamps.pop_front();
+        }
+
         let reset_seconds = bucket
             .timestamps
             .front()
@@ -156,52 +231,136 @@ impl RateLimitState {
             .map(|expiry| ceil_duration_to_seconds(expiry.saturating_duration_since(now)).max(1))
             .unwrap_or_else(|| ceil_duration_to_seconds(self.config.window).max(1));
 
-        if (bucket.timestamps.len() as u32) >= limit {
+        // Reject if hourly limit exceeded
+        if (bucket.timestamps.len() as u32) >= hourly_limit {
             return RateLimitDecision {
                 allowed: false,
-                limit,
+                limit: hourly_limit,
                 remaining: 0,
                 reset_seconds,
             };
         }
 
+        // Reject if burst limit exceeded (too many in the last minute)
+        if (bucket.burst_timestamps.len() as u32) >= burst_limit {
+            return RateLimitDecision {
+                allowed: false,
+                limit: hourly_limit,
+                remaining: hourly_limit.saturating_sub(bucket.timestamps.len() as u32),
+                reset_seconds: ceil_duration_to_seconds(
+                    self.config.burst_window,
+                )
+                .max(1),
+            };
+        }
+
         bucket.timestamps.push_back(now);
-        let remaining = limit.saturating_sub(bucket.timestamps.len() as u32);
+        bucket.burst_timestamps.push_back(now);
+        let remaining = hourly_limit.saturating_sub(bucket.timestamps.len() as u32);
 
         RateLimitDecision {
             allowed: true,
-            limit,
+            limit: hourly_limit,
             remaining,
             reset_seconds,
         }
     }
 
-    fn select_limit_and_key<B>(&self, request: &Request<B>) -> (u32, BucketKey) {
+    /// Returns the current quota snapshot for a client key without consuming a token.
+    pub async fn quota_snapshot(
+        &self,
+        client_key: &str,
+        tier: &ApiTier,
+    ) -> QuotaSnapshot {
+        let now = Instant::now();
+        let hourly_limit = self.config.hourly_limit_for_tier(tier);
+        let burst_limit = self.config.burst_limit_for_tier(tier);
+
+        let buckets = self.buckets.lock().await;
+        let key = BucketKey {
+            client_key: client_key.to_owned(),
+        };
+
+        if let Some(bucket) = buckets.get(&key) {
+            let window_cutoff = now.checked_sub(self.config.window).unwrap_or(now);
+            let hourly_used = bucket
+                .timestamps
+                .iter()
+                .filter(|&&ts| ts > window_cutoff)
+                .count();
+
+            let burst_cutoff = now
+                .checked_sub(self.config.burst_window)
+                .unwrap_or(now);
+            let burst_used = bucket
+                .burst_timestamps
+                .iter()
+                .filter(|&&ts| ts > burst_cutoff)
+                .count();
+
+            QuotaSnapshot {
+                tier: tier.as_str().to_owned(),
+                hourly_limit,
+                hourly_used,
+                hourly_remaining: (hourly_limit as usize).saturating_sub(hourly_used),
+                burst_limit,
+                burst_used,
+                burst_remaining: (burst_limit as usize).saturating_sub(burst_used),
+            }
+        } else {
+            QuotaSnapshot {
+                tier: tier.as_str().to_owned(),
+                hourly_limit,
+                hourly_used: 0,
+                hourly_remaining: hourly_limit as usize,
+                burst_limit,
+                burst_used: 0,
+                burst_remaining: burst_limit as usize,
+            }
+        }
+    }
+
+    /// Derive the bucket key and API tier from an incoming request.
+    ///
+    /// Tier is resolved in order:
+    /// 1. `X-Api-Plan: free | pro | enterprise` header
+    /// 2. Defaults to `free` for unauthenticated requests, `free` for authenticated
+    ///    (upgrade to pro/enterprise requires the header or a future DB lookup).
+    fn select_limit_and_key<B>(&self, request: &Request<B>) -> (u32, u32, BucketKey, ApiTier) {
+        let tier = extract_api_tier(request);
+
         if let Some(token) = extract_auth_token(request) {
+            let hourly = self.config.hourly_limit_for_tier(&tier);
+            let burst = self.config.burst_limit_for_tier(&tier);
             return (
-                self.config.auth_limit,
+                hourly,
+                burst,
                 BucketKey {
                     client_key: format!("auth:{token}"),
                 },
+                tier,
             );
         }
 
         let path = request.uri().path();
         let query = request.uri().query();
-        let base_limit = self.config.anonymous_limit;
-        let limit = if let Some(page_size) =
+        let hourly_base = self.config.hourly_limit_for_tier(&tier);
+        let hourly = if let Some(page_size) =
             contracts_page_size_rate_limit(request.method(), path, query)
         {
-            scale_limit_by_page_size(base_limit, page_size)
+            scale_limit_by_page_size(hourly_base, page_size)
         } else {
-            base_limit
+            hourly_base
         };
+        let burst = self.config.burst_limit_for_tier(&tier);
 
         (
-            limit,
+            hourly,
+            burst,
             BucketKey {
                 client_key: format!("anon:{}", extract_client_ip(request)),
             },
+            tier,
         )
     }
 }
@@ -210,6 +369,8 @@ struct RateLimitConfig {
     anonymous_limit: u32,
     auth_limit: u32,
     window: Duration,
+    enterprise_limit: u32,
+    burst_window: Duration,
 }
 
 impl RateLimitConfig {
@@ -227,18 +388,23 @@ impl RateLimitConfig {
             DEFAULT_AUTH_LIMIT,
         );
         let window_seconds = env_u64("RATE_LIMIT_WINDOW_SECONDS", DEFAULT_WINDOW_SECONDS).max(1);
+        // Issue #727: enterprise tier custom limit
+        let enterprise_limit = env_u32("ENTERPRISE_RATE_LIMIT_PER_HOUR", 100_000);
 
         tracing::info!(
             anonymous_limit,
             auth_limit,
             window_seconds,
-            "Rate limiter configured (issue #609: 1000 req/hour per IP default)"
+            enterprise_limit,
+            "Rate limiter configured (issue #609/#727: tiered quotas)"
         );
 
         Self {
             anonymous_limit,
             auth_limit,
             window: Duration::from_secs(window_seconds),
+            enterprise_limit,
+            burst_window: Duration::from_secs(BURST_WINDOW_SECONDS),
         }
     }
 
@@ -248,7 +414,25 @@ impl RateLimitConfig {
             anonymous_limit,
             auth_limit,
             window,
+            enterprise_limit: 100_000,
+            burst_window: Duration::from_secs(BURST_WINDOW_SECONDS),
         }
+    }
+
+    /// Returns the hourly limit for the given tier.
+    fn hourly_limit_for_tier(&self, tier: &ApiTier) -> u32 {
+        match tier {
+            ApiTier::Free => FREE_TIER_LIMIT,
+            ApiTier::Pro => PRO_TIER_LIMIT,
+            ApiTier::Enterprise => self.enterprise_limit,
+        }
+    }
+
+    /// Burst limit = ceil(hourly_limit × 1.2 / 60) requests per minute.
+    fn burst_limit_for_tier(&self, tier: &ApiTier) -> u32 {
+        let hourly = self.hourly_limit_for_tier(tier);
+        // 120 % of the per-minute equivalent; minimum 1
+        ((hourly as f64 * 1.2 / 60.0).ceil() as u32).max(1)
     }
 }
 
@@ -259,6 +443,8 @@ struct BucketKey {
 
 struct BucketState {
     timestamps: VecDeque<Instant>,
+    /// Timestamps in the 1-minute burst window (subset of `timestamps`).
+    burst_timestamps: VecDeque<Instant>,
 }
 
 struct RateLimitDecision {
@@ -274,8 +460,10 @@ pub async fn rate_limit_middleware(
     next: Next,
 ) -> Response {
     // Extract request metadata before awaiting to avoid borrowing `request` across `.await`.
-    let (limit, key) = rate_limiter.select_limit_and_key(&request);
-    let decision = rate_limiter.check_request(key, limit).await;
+    let (hourly_limit, burst_limit, key, tier) = rate_limiter.select_limit_and_key(&request);
+    let decision = rate_limiter
+        .check_request(key, hourly_limit, burst_limit)
+        .await;
 
     if !decision.allowed {
         let mut response =
@@ -285,6 +473,7 @@ pub async fn rate_limit_middleware(
                 }))
                 .into_response();
         attach_rate_limit_headers(&mut response, &decision);
+        attach_tier_header(&mut response, &tier);
         response.headers_mut().insert(
             RETRY_AFTER,
             HeaderValue::from_str(&decision.reset_seconds.to_string())
@@ -295,7 +484,14 @@ pub async fn rate_limit_middleware(
 
     let mut response = next.run(request).await;
     attach_rate_limit_headers(&mut response, &decision);
+    attach_tier_header(&mut response, &tier);
     response
+}
+
+fn attach_tier_header(response: &mut Response, tier: &ApiTier) {
+    if let Ok(val) = HeaderValue::from_str(tier.as_str()) {
+        response.headers_mut().insert(HEADER_RATE_LIMIT_TIER, val);
+    }
 }
 
 fn attach_rate_limit_headers(response: &mut Response, decision: &RateLimitDecision) {
@@ -345,6 +541,17 @@ fn extract_client_ip<B>(request: &Request<B>) -> String {
     }
 
     "unknown".to_string()
+}
+
+/// Resolve API tier from the `X-Api-Plan` request header.
+/// Falls back to `Free` when the header is absent or unrecognised.
+fn extract_api_tier<B>(request: &Request<B>) -> ApiTier {
+    request
+        .headers()
+        .get("x-api-plan")
+        .and_then(|v| v.to_str().ok())
+        .map(ApiTier::from_header)
+        .unwrap_or(ApiTier::Free)
 }
 
 fn extract_auth_token<B>(request: &Request<B>) -> Option<String> {
@@ -796,8 +1003,8 @@ mod tests {
             .header("x-forwarded-for", "10.0.0.1")
             .body(Body::empty())
             .unwrap();
-        let (limit, key) = state.select_limit_and_key(&req);
-        state.check_request(key, limit).await;
+        let (hourly, burst, key, _tier) = state.select_limit_and_key(&req);
+        state.check_request(key, hourly, burst).await;
 
         // Confirm one bucket exists
         assert_eq!(state.buckets.lock().await.len(), 1);
@@ -810,12 +1017,21 @@ mod tests {
             let now = Instant::now();
             let mut map = state.buckets.lock().await;
             map.retain(|_, s| {
-                s.timestamps
+                let hourly = s
+                    .timestamps
                     .back()
                     .map(|last_seen| {
                         now.saturating_duration_since(*last_seen) < window.saturating_mul(2)
                     })
-                    .unwrap_or(false)
+                    .unwrap_or(false);
+                let burst = s
+                    .burst_timestamps
+                    .back()
+                    .map(|last_seen| {
+                        now.saturating_duration_since(*last_seen) < window.saturating_mul(2)
+                    })
+                    .unwrap_or(false);
+                hourly || burst
             });
         }
 

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -3,11 +3,12 @@ use crate::openapi;
 use crate::{
     ab_test_handlers, analytics_handlers, auth, auth_handlers, batch_verify_handlers,
     breaking_changes, canary_handlers, category_handlers, clone_federation_handlers,
-    compatibility_testing_handlers, contract_events, custom_metrics_handlers, deprecation_handlers,
-    gas_estimation_handlers, governance_handlers, handlers, interoperability_handlers,
-    metrics_handler, migration_handlers, org_handlers, patch_handlers, performance_handlers,
-    recommendation_handlers, resource_handlers, security_scan_handlers, similarity_handlers,
-    simulation_handlers, state::AppState, subscription_handlers, verification_handlers, websocket,
+    compatibility_testing_handlers, contract_events, custom_metrics_handlers, dependency_handlers,
+    deprecation_handlers, gas_estimation_handlers, governance_handlers, handlers,
+    interoperability_handlers, metrics_handler, migration_handlers, org_handlers, patch_handlers,
+    performance_handlers, quota_handlers, recommendation_handlers, resource_handlers,
+    security_scan_handlers, similarity_handlers, simulation_handlers, state::AppState,
+    subscription_handlers, verification_handlers, websocket,
 };
 
 use axum::{
@@ -193,11 +194,21 @@ pub fn contract_routes() -> Router<AppState> {
             "/api/analytics/dashboard",
             get(analytics_handlers::get_analytics_dashboard),
         )
+        // Issue #726: GET returns direct (non-recursive) deps; POST declares them
         .route(
             "/api/contracts/:id/dependencies",
-            get(crate::dependency_handlers::get_contract_dependencies)
-                // Issue #610: POST endpoint to declare/save dependencies
+            get(crate::dependency_handlers::get_direct_contract_dependencies)
                 .post(dependency_handlers::declare_contract_dependencies),
+        )
+        // Issue #726: full recursive tree capped at depth 5
+        .route(
+            "/api/contracts/:id/dependency-tree",
+            get(dependency_handlers::get_contract_dependency_tree),
+        )
+        // Issue #726: resolve all transitive dependencies
+        .route(
+            "/api/contracts/:id/resolve-dependencies",
+            post(dependency_handlers::post_resolve_dependencies),
         )
         .route(
             "/api/contracts/:id/graph",
@@ -447,6 +458,11 @@ pub fn favorite_routes() -> Router<AppState> {
             "/api/favorites/search/:id",
             delete(handlers::delete_favorite_search),
         )
+}
+
+/// Issue #727 — quota usage endpoint
+pub fn quota_routes() -> Router<AppState> {
+    Router::new().route("/api/quota", get(quota_handlers::get_quota))
 }
 
 pub fn health_routes() -> Router<AppState> {

--- a/backend/api/src/state.rs
+++ b/backend/api/src/state.rs
@@ -2,6 +2,7 @@ use crate::auth::AuthManager;
 use crate::cache::{CacheConfig, CacheLayer};
 use crate::contract_events::ContractEventHub;
 use crate::health_monitor::HealthMonitorStatus;
+use crate::rate_limit::RateLimitState;
 use crate::resource_tracking::ResourceManager;
 use shared::source_storage::SourceStorage;
 
@@ -53,6 +54,8 @@ pub struct AppState {
     pub resource_mgr: Arc<RwLock<ResourceManager>>,
     pub source_storage: Arc<SourceStorage>,
     pub event_broadcaster: broadcast::Sender<RealtimeEvent>,
+    /// Rate limiter reference — used by the /api/quota endpoint (issue #727).
+    pub rate_limit_state: Arc<RateLimitState>,
 }
 
 impl AppState {
@@ -61,6 +64,7 @@ impl AppState {
         registry: Registry,
         job_engine: Arc<soroban_batch::engine::JobEngine>,
         is_shutting_down: Arc<AtomicBool>,
+        rate_limit_state: Arc<RateLimitState>,
     ) -> Result<Self, shared::error::RegistryError> {
         let config = CacheConfig::from_env();
         let auth_manager = match AuthManager::from_env() {
@@ -96,6 +100,7 @@ impl AppState {
             resource_mgr,
             source_storage,
             event_broadcaster,
+            rate_limit_state,
         })
     }
 }

--- a/database/migrations/062_add_dependency_type.sql
+++ b/database/migrations/062_add_dependency_type.sql
@@ -1,0 +1,5 @@
+-- Add dep_type column to contract_dependencies for filtering by import/call/data (issue #726)
+ALTER TABLE contract_dependencies
+  ADD COLUMN IF NOT EXISTS dep_type VARCHAR(20) NOT NULL DEFAULT 'call';
+
+CREATE INDEX IF NOT EXISTS idx_contract_dependencies_dep_type ON contract_dependencies(dep_type);

--- a/frontend/app/compare/CompareContracts.tsx
+++ b/frontend/app/compare/CompareContracts.tsx
@@ -9,6 +9,122 @@ import ComparisonTable from '@/components/comparison/ComparisonTable';
 import MobileComparisonCard from '@/components/comparison/MobileComparisonCard';
 import { useCopy } from '@/hooks/useCopy';
 import { exportComparisonToCsv, exportComparisonToPdf } from '@/utils/export';
+import { uniqueMethodsPerContract, type ComparableContract } from '@/utils/comparison';
+
+// ── Statistics section ────────────────────────────────────────────────────────
+
+function StatisticsSection({ contracts }: { contracts: ComparableContract[] }) {
+  const maxDeployments = Math.max(...contracts.map((c) => c.deploymentCount));
+  const maxPopularity = Math.max(...contracts.map((c) => c.popularityScore));
+
+  return (
+    <div className="rounded-2xl border border-border bg-card p-5">
+      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Statistics</div>
+      <div className="mt-3 overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="border-b border-border">
+              <th className="py-2 pr-4 text-left text-xs font-semibold text-muted-foreground">Metric</th>
+              {contracts.map((c) => (
+                <th key={c.id} className="py-2 px-3 text-left text-xs font-semibold text-foreground min-w-[160px]">
+                  {c.name}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="border-b border-border/50">
+              <td className="py-2 pr-4 text-xs text-muted-foreground font-medium">Deployments</td>
+              {contracts.map((c) => (
+                <td key={c.id} className="py-2 px-3">
+                  <span className={`rounded-lg px-2 py-1 text-xs font-semibold ${
+                    c.deploymentCount === maxDeployments && maxDeployments > 0
+                      ? 'bg-green-500/10 text-green-700 dark:text-green-300'
+                      : 'text-foreground'
+                  }`}>
+                    {c.deploymentCount}
+                  </span>
+                </td>
+              ))}
+            </tr>
+            <tr className="border-b border-border/50">
+              <td className="py-2 pr-4 text-xs text-muted-foreground font-medium">Popularity score</td>
+              {contracts.map((c) => (
+                <td key={c.id} className="py-2 px-3">
+                  <span className={`rounded-lg px-2 py-1 text-xs font-semibold ${
+                    c.popularityScore === maxPopularity && maxPopularity > 0
+                      ? 'bg-green-500/10 text-green-700 dark:text-green-300'
+                      : 'text-foreground'
+                  }`}>
+                    {c.popularityScore}
+                  </span>
+                </td>
+              ))}
+            </tr>
+            <tr className="border-b border-border/50">
+              <td className="py-2 pr-4 text-xs text-muted-foreground font-medium">Versions</td>
+              {contracts.map((c) => (
+                <td key={c.id} className="py-2 px-3 text-xs text-foreground">{c.versionCount}</td>
+              ))}
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-xs text-muted-foreground font-medium">ABI methods</td>
+              {contracts.map((c) => (
+                <td key={c.id} className="py-2 px-3 text-xs text-foreground">{c.abiMethods.length}</td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ── Unique methods section ────────────────────────────────────────────────────
+
+function UniqueMethodsSection({ contracts }: { contracts: ComparableContract[] }) {
+  const uniqueMap = uniqueMethodsPerContract(contracts);
+  const hasAnyUnique = contracts.some((c) => uniqueMap[c.id]?.length > 0);
+
+  if (!hasAnyUnique) {
+    return (
+      <div className="rounded-2xl border border-border bg-card p-5">
+        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Unique to each contract</div>
+        <p className="mt-3 text-xs text-muted-foreground">All selected contracts share the same ABI methods — no unique methods found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-border bg-card p-5">
+      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Unique to each contract</div>
+      <p className="mt-1 text-xs text-muted-foreground">Methods present in one contract but absent from all others.</p>
+      <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {contracts.map((c) => {
+          const methods = uniqueMap[c.id] ?? [];
+          return (
+            <div key={c.id} className="rounded-xl border border-border bg-accent/30 p-3">
+              <div className="mb-2 truncate text-xs font-semibold text-foreground">{c.name}</div>
+              {methods.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">No unique methods</p>
+              ) : (
+                <ul className="space-y-1">
+                  {methods.map((m) => (
+                    <li key={m} className="rounded bg-primary/10 px-2 py-0.5 font-mono text-[11px] text-primary">
+                      {m}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── Main page component ───────────────────────────────────────────────────────
 
 export default function CompareContracts() {
   const [viewMode, setViewMode] = useState<'table' | 'diff'>('table');
@@ -204,6 +320,7 @@ export default function CompareContracts() {
 
             {selectedContracts.length > 0 && (
               <>
+                {/* Summary cards — version, ABI, tags */}
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                   <div className="rounded-2xl border border-border bg-card p-5">
                     <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Version comparison</div>
@@ -243,7 +360,17 @@ export default function CompareContracts() {
                     </div>
                   </div>
                 </div>
+
+                {/* Statistics card — deployments & popularity */}
+                <StatisticsSection contracts={selectedContracts} />
+
+                {/* Main comparison table (metadata + ABI + deployments) */}
                 <ComparisonTable contracts={selectedContracts} metrics={metrics} tones={metricTones} />
+
+                {/* Unique methods per contract */}
+                <UniqueMethodsSection contracts={selectedContracts} />
+
+                {/* Mobile stacked view */}
                 <div className="grid grid-cols-1 gap-4 lg:hidden">
                   {selectedContracts.map((c) => (
                     <MobileComparisonCard key={c.id} contract={c} metrics={metrics} tones={metricTones} />

--- a/frontend/hooks/useComparison.ts
+++ b/frontend/hooks/useComparison.ts
@@ -159,9 +159,27 @@ export function useComparison() {
       },
       {
         key: 'verification_status',
-        label: 'Verification status',
+        label: 'Verification',
         getDisplayValue: (c) => (c.isVerified ? 'Verified' : 'Unverified'),
         getRawValue: (c) => c.isVerified,
+      },
+      {
+        key: 'wasm_hash',
+        label: 'WASM hash',
+        getDisplayValue: (c) => c.wasmHash ? `${c.wasmHash.slice(0, 12)}…` : '—',
+        getRawValue: (c) => c.wasmHash,
+      },
+      {
+        key: 'deployment_count',
+        label: 'Deployments',
+        getDisplayValue: (c) => String(c.deploymentCount),
+        getRawValue: (c) => c.deploymentCount,
+      },
+      {
+        key: 'popularity_score',
+        label: 'Popularity score',
+        getDisplayValue: (c) => String(c.popularityScore),
+        getRawValue: (c) => c.popularityScore,
       },
     ],
     [],

--- a/frontend/utils/comparison.ts
+++ b/frontend/utils/comparison.ts
@@ -5,7 +5,11 @@ export type ComparisonMetricKey =
   | 'network'
   | 'category'
   | 'publisher'
-  | 'verification_status';
+  | 'verification_status'
+  | 'wasm_hash'
+  | 'deployment_count'
+  | 'popularity_score'
+  | 'health_score';
 
 export type CellTone = 'neutral' | 'best' | 'worst' | 'different';
 
@@ -27,6 +31,10 @@ export interface ComparableContract {
   isVerified: boolean;
   tags: string[];
   sourceCode: string;
+  wasmHash: string;
+  deploymentCount: number;
+  popularityScore: number;
+  healthScore: number;
   base?: Pick<Contract, 'contract_id' | 'network' | 'publisher_id' | 'wasm_hash' | 'updated_at'>;
 }
 
@@ -144,6 +152,10 @@ export function toComparableContract(
     isVerified,
     tags: contract.tags,
     sourceCode,
+    wasmHash: contract.wasm_hash,
+    deploymentCount: contract.deployment_count ?? 0,
+    popularityScore: contract.popularity_score ?? 0,
+    healthScore: 0,
     base: {
       contract_id: contract.contract_id,
       network: contract.network,
@@ -168,7 +180,14 @@ export function toneForMetricCell(
     return v ? 'best' : 'worst';
   }
 
-  if (metric === 'contract_id' || metric === 'network' || metric === 'category' || metric === 'publisher') {
+  if (metric === 'deployment_count' || metric === 'popularity_score' || metric === 'health_score') {
+    const nums = allValues.map(Number).filter(isFinite);
+    const max = Math.max(...nums);
+    if (max === 0) return 'neutral';
+    return Number(value) === max ? 'best' : 'different';
+  }
+
+  if (metric === 'wasm_hash') {
     return 'different';
   }
 
@@ -187,7 +206,31 @@ export function getMetricValue(contract: ComparableContract, metric: ComparisonM
       return contract.publisherId;
     case 'verification_status':
       return contract.isVerified;
+    case 'wasm_hash':
+      return contract.wasmHash;
+    case 'deployment_count':
+      return contract.deploymentCount;
+    case 'popularity_score':
+      return contract.popularityScore;
+    case 'health_score':
+      return contract.healthScore;
   }
+}
+
+/**
+ * For each contract in `contracts`, returns the ABI methods that appear in
+ * that contract but in none of the others — i.e. truly unique methods.
+ */
+export function uniqueMethodsPerContract(
+  contracts: ComparableContract[],
+): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+  for (const contract of contracts) {
+    const others = contracts.filter((c) => c.id !== contract.id);
+    const otherMethods = new Set(others.flatMap((c) => c.abiMethods));
+    result[contract.id] = contract.abiMethods.filter((m) => !otherMethods.has(m));
+  }
+  return result;
 }
 
 export function diffMethodSets(base: string[], other: string[]) {


### PR DESCRIPTION
## Summary

- **closes #726** — Implements contract dependency tracking endpoints: direct deps (`GET /dependencies`), recursive tree capped at depth 5 (`GET /dependency-tree`), and full transitive resolution with circular-dep detection (`POST /resolve-dependencies`). Adds `dep_type` column (migration 062) for `import|call|data` filtering.
- **closes #727** — Adds tiered rate limiting: Free (100 req/hr), Pro (10k req/hr), Enterprise (configurable via `ENTERPRISE_RATE_LIMIT_PER_HOUR`). Tier resolved from `X-Api-Plan` header. Burst allowance enforced via a separate 1-minute sliding window at 120% of per-minute equivalent. New `GET /api/quota` endpoint returns live usage snapshot. `X-RateLimit-Tier` header added to every response.
- **closes #740** — Extends the contract comparison tool with a Statistics section (deployments, popularity, version count, ABI method count with best-value highlighting), a Unique Methods section (ABI methods exclusive to each contract), and three new comparison metrics (WASM hash, deployment count, popularity score).

## Test plan

- [ ] `GET /api/contracts/:id/dependencies` returns flat list; `?dep_type=call` filters correctly
- [ ] `GET /api/contracts/:id/dependency-tree` returns tree ≤ 5 levels deep; circular nodes flagged with `is_circular: true`
- [ ] `POST /api/contracts/:id/resolve-dependencies` returns all transitive deps; `has_circular: true` when cycles exist; unresolvable entries in `unresolvable` array
- [ ] Requests with `X-Api-Plan: free` header are capped at 100/hr; `pro` at 10,000/hr
- [ ] Burst requests beyond ceil(hourly×1.2/60) per minute receive 429 before hourly quota is exhausted
- [ ] `GET /api/quota` returns accurate `hourly_used` and `burst_used` counts
- [ ] All responses include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `X-RateLimit-Tier` headers
- [ ] Compare page Statistics card renders for 2–4 selected contracts
- [ ] Unique Methods section shows only methods absent from all other selected contracts
- [ ] CSV and PDF export include the new metrics; share URL preserves selected contract IDs