### PR TITLE
Cli network error handling

### DIFF
--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -148,6 +148,7 @@ use crate::{
     contract_events::{ContractEventEnvelope, ContractEventVisibility},
     dependency,
     error::{ApiError, ApiResult},
+    models::ContractSourceResponse,
     onchain_verification::OnChainVerifier,
     state::AppState,
     type_safety::parser::parse_json_spec,
@@ -2821,19 +2822,6 @@ pub async fn revert_contract_version(
 pub struct UploadContractSourceRequest {
     pub source_base64: String,
     pub source_format: String,
-}
-
-#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
-pub struct ContractSourceResponse {
-    pub id: Uuid,
-    pub contract_version_id: Uuid,
-    pub source_format: String,
-    pub storage_backend: String,
-    pub storage_key: String,
-    pub source_hash: String,
-    pub source_size: i64,
-    pub source_base64: Option<String>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, utoipa::IntoParams)]

--- a/backend/api/src/models.rs
+++ b/backend/api/src/models.rs
@@ -6,3 +6,16 @@ pub use shared::{
     ModerateReviewRequest, RatingDistribution, ReviewResponse, ReviewSortBy, ReviewStatus,
     ReviewVoteRequest, ReviewVoteResponse,
 };
+
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct ContractSourceResponse {
+    pub id: uuid::Uuid,
+    pub contract_version_id: uuid::Uuid,
+    pub source_format: String,
+    pub storage_backend: String,
+    pub storage_key: String,
+    pub source_hash: String,
+    pub source_size: i64,
+    pub source_base64: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}

--- a/backend/api/src/org_handlers.rs
+++ b/backend/api/src/org_handlers.rs
@@ -1,10 +1,13 @@
-use crate::{auth::AuthClaims, error::ApiResult, handlers::db_internal_error, state::AppState};
+use crate::{
+    auth::AuthClaims,
+    error::{ApiError, ApiResult},
+    state::AppState,
+};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
     Json,
 };
-use chrono::Utc;
 use chrono::Utc;
 use shared::{
     CreateOrganizationRequest, InviteMemberRequest, Organization, OrganizationMember,

--- a/backend/contract_abi/src/parser.rs
+++ b/backend/contract_abi/src/parser.rs
@@ -112,16 +112,16 @@ pub fn parse_contract_abi(
             }
             "error_enum" => {
                 let enum_type = parse_error_enum(spec)?;
-                abi.types.insert(spec.name.clone(), enum_type.clone());
-                if let SorobanType::Enum { variants, .. } = enum_type {
+                if let SorobanType::Enum { variants, .. } = &enum_type {
                     for variant in variants {
                         abi.errors.push(ContractError {
                             name: format!("{}::{}", spec.name, variant.name),
                             code: variant.value.unwrap_or(0),
-                            doc: variant.doc,
+                            doc: variant.doc.clone(),
                         });
                     }
                 }
+                abi.types.insert(spec.name.clone(), enum_type);
             }
             _ => {}
         }

--- a/backend/contract_abi/src/types.rs
+++ b/backend/contract_abi/src/types.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Soroban native types supported in contracts
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SorobanType {
     Bool,
@@ -163,14 +163,14 @@ impl SorobanType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Serialize, Deserialize)]
 pub struct StructField {
     pub name: String,
     pub field_type: SorobanType,
     pub doc: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Serialize, Deserialize)]
 pub struct EnumVariant {
     pub name: String,
     pub value: Option<u32>,
@@ -178,7 +178,7 @@ pub struct EnumVariant {
     pub doc: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum FunctionVisibility {
     #[default]
@@ -186,14 +186,14 @@ pub enum FunctionVisibility {
     Internal,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct FunctionParam {
     pub name: String,
     pub param_type: SorobanType,
     pub doc: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ContractFunction {
     pub name: String,
     pub visibility: FunctionVisibility,
@@ -203,7 +203,7 @@ pub struct ContractFunction {
     pub is_mutable: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ContractABI {
     pub name: String,
     pub version: Option<String>,
@@ -240,7 +240,7 @@ impl ContractABI {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ContractEvent {
     pub name: String,
     pub topics: Vec<FunctionParam>,
@@ -248,9 +248,96 @@ pub struct ContractEvent {
     pub doc: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ContractError {
     pub name: String,
     pub code: u32,
     pub doc: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn soroban_type_serialization_round_trips() {
+        let ty = SorobanType::Map {
+            key_type: Box::new(SorobanType::Symbol),
+            value_type: Box::new(SorobanType::Option {
+                value_type: Box::new(SorobanType::BytesN { n: 32 }),
+            }),
+        };
+
+        let json = serde_json::to_string(&ty).expect("SorobanType should serialize");
+        let decoded: SorobanType =
+            serde_json::from_str(&json).expect("SorobanType should deserialize");
+
+        assert!(matches!(
+            decoded,
+            SorobanType::Map {
+                key_type,
+                value_type
+            } if *key_type == SorobanType::Symbol
+                && matches!(*value_type, SorobanType::Option { .. })
+        ));
+    }
+
+    #[test]
+    fn contract_abi_serialization_round_trips() {
+        let mut abi = ContractABI::new("Token".to_string());
+        abi.version = Some("1.0.0".to_string());
+        abi.types.insert(
+            "Balance".to_string(),
+            SorobanType::Struct {
+                name: "Balance".to_string(),
+                fields: vec![StructField {
+                    name: "amount".to_string(),
+                    field_type: SorobanType::I128,
+                    doc: Some("Current balance".to_string()),
+                }],
+            },
+        );
+        abi.functions.push(ContractFunction {
+            name: "balance".to_string(),
+            visibility: FunctionVisibility::Public,
+            params: vec![FunctionParam {
+                name: "id".to_string(),
+                param_type: SorobanType::Address,
+                doc: None,
+            }],
+            return_type: SorobanType::I128,
+            doc: Some("Read balance".to_string()),
+            is_mutable: false,
+        });
+        abi.events.push(ContractEvent {
+            name: "Transfer".to_string(),
+            topics: vec![FunctionParam {
+                name: "from".to_string(),
+                param_type: SorobanType::Address,
+                doc: None,
+            }],
+            data: vec![FunctionParam {
+                name: "amount".to_string(),
+                param_type: SorobanType::I128,
+                doc: None,
+            }],
+            doc: None,
+        });
+        abi.errors.push(ContractError {
+            name: "InsufficientBalance".to_string(),
+            code: 1,
+            doc: None,
+        });
+
+        let json = serde_json::to_string(&abi).expect("ContractABI should serialize");
+        let decoded: ContractABI =
+            serde_json::from_str(&json).expect("ContractABI should deserialize");
+
+        assert_eq!(decoded.name, "Token");
+        assert_eq!(decoded.version.as_deref(), Some("1.0.0"));
+        assert!(decoded.has_function("balance"));
+        assert_eq!(decoded.functions[0].return_type.display_name(), "i128");
+        assert_eq!(decoded.events[0].topics[0].param_type.display_name(), "Address");
+        assert_eq!(decoded.errors[0].code, 1);
+    }
 }

--- a/cli/src/analyze.rs
+++ b/cli/src/analyze.rs
@@ -3,6 +3,7 @@
 //! Advanced contract analysis: complexity, security patterns, dependency graph,
 //! performance estimates, and actionable optimisation suggestions.
 
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -171,8 +172,7 @@ async fn fetch_contract(
 
     let res = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to connect to registry API")?;
 
     let status = res.status();
@@ -220,7 +220,7 @@ async fn fetch_detail(client: &reqwest::Client, api_url: &str, contract: &Value)
         .or(contract["contract_id"].as_str())?;
     let url = format!("{}/api/contracts/{}/verification-status", api_url, id);
     log::debug!("GET {}", url);
-    let res = client.get(&url).send().await.ok()?;
+    let res = client.get(&url).send_with_retry().await.ok()?;
     if res.status().is_success() {
         res.json::<Value>().await.ok()
     } else {
@@ -235,7 +235,7 @@ async fn fetch_dependencies(
 ) -> Vec<Value> {
     let url = format!("{}/api/contracts/{}/dependencies", api_url, contract_id);
     log::debug!("GET {}", url);
-    let res = match client.get(&url).send().await {
+    let res = match client.get(&url).send_with_retry().await {
         Ok(r) => r,
         Err(_) => return vec![],
     };

--- a/cli/src/backup.rs
+++ b/cli/src/backup.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::net::RequestBuilderExt;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
@@ -34,12 +35,11 @@ struct BackupRestoration {
 }
 
 pub async fn create_backup(api_url: &str, contract_id: &str, include_state: bool) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let backup: ContractBackup = client
         .post(format!("{}/api/contracts/{}/backups", api_url, contract_id))
         .json(&CreateBackupRequest { include_state })
-        .send()
-        .await?
+        .send_with_retry().await?
         .json()
         .await?;
 
@@ -51,11 +51,10 @@ pub async fn create_backup(api_url: &str, contract_id: &str, include_state: bool
 }
 
 pub async fn list_backups(api_url: &str, contract_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let backups: Vec<ContractBackup> = client
         .get(format!("{}/api/contracts/{}/backups", api_url, contract_id))
-        .send()
-        .await?
+        .send_with_retry().await?
         .json()
         .await?;
 
@@ -72,7 +71,7 @@ pub async fn list_backups(api_url: &str, contract_id: &str) -> Result<()> {
 }
 
 pub async fn restore_backup(api_url: &str, contract_id: &str, backup_date: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     println!("🔄 Restoring backup from {}...", backup_date);
 
@@ -84,8 +83,7 @@ pub async fn restore_backup(api_url: &str, contract_id: &str, backup_date: &str)
         .json(&RestoreBackupRequest {
             backup_date: backup_date.to_string(),
         })
-        .send()
-        .await?
+        .send_with_retry().await?
         .json()
         .await?;
 
@@ -100,28 +98,26 @@ pub async fn restore_backup(api_url: &str, contract_id: &str, backup_date: &str)
 }
 
 pub async fn verify_backup(api_url: &str, contract_id: &str, backup_date: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     client
         .post(format!(
             "{}/api/contracts/{}/backups/{}/verify",
             api_url, contract_id, backup_date
         ))
-        .send()
-        .await?;
+        .send_with_retry().await?;
 
     println!("✅ Backup verified: {}", backup_date);
     Ok(())
 }
 
 pub async fn backup_stats(api_url: &str, contract_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let stats: serde_json::Value = client
         .get(format!(
             "{}/api/contracts/{}/backups/stats",
             api_url, contract_id
         ))
-        .send()
-        .await?
+        .send_with_retry().await?
         .json()
         .await?;
 

--- a/cli/src/batch_register.rs
+++ b/cli/src/batch_register.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -402,8 +403,7 @@ async fn register_one(
     let response = client
         .post(url)
         .json(&entry.payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if response.status() == reqwest::StatusCode::CONFLICT {

--- a/cli/src/batch_verify.rs
+++ b/cli/src/batch_verify.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -117,8 +118,7 @@ pub async fn run_batch_verify(
     let response = client
         .post(format!("{}/api/contracts/batch-verify", api_url))
         .json(&request)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API — is the server running?")?;
 
     if !response.status().is_success() {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -133,7 +134,7 @@ pub async fn search(
     json: bool,
 ) -> Result<()> {
     let t0 = std::time::Instant::now();
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     let mut params: Vec<(&str, String)> = vec![
         ("query", query.to_string()),
@@ -162,8 +163,7 @@ pub async fn search(
     let response = client
         .get(format!("{}/api/contracts", api_url))
         .query(&params)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to search contracts")?;
 
     let data: serde_json::Value = response.json().await?;
@@ -348,12 +348,11 @@ pub async fn upgrade_analyze(
     }
 
     // Otherwise try to fetch versions from the API (assumes endpoint exists)
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contract_versions/{}", api_url, old_id);
     let old_res = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("failed to fetch old version")?;
     if old_res.status() == StatusCode::NOT_FOUND {
         anyhow::bail!(
@@ -366,8 +365,7 @@ pub async fn upgrade_analyze(
     let url2 = format!("{}/api/contract_versions/{}", api_url, new_id);
     let new_res = client
         .get(&url2)
-        .send()
-        .await
+        .send_with_retry().await
         .context("failed to fetch new version")?;
     if new_res.status() == StatusCode::NOT_FOUND {
         anyhow::bail!(
@@ -503,7 +501,7 @@ pub async fn publish(
         .await?;
     }
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts", api_url);
 
     let mut payload = json!({
@@ -525,8 +523,7 @@ pub async fn publish(
     let response = client
         .post(&url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to publish contract")?;
 
     if !response.status().is_success() {
@@ -988,7 +985,7 @@ pub async fn contract_list(
     category: Option<String>,
     format: &str,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let mut query = vec![
         ("page_size", limit.to_string()),
         ("page", ((offset / limit) + 1).to_string()),
@@ -1005,8 +1002,7 @@ pub async fn contract_list(
     let response = client
         .get(&url)
         .query(&query)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to list contracts")?;
 
     if !response.status().is_success() {
@@ -1089,13 +1085,12 @@ pub async fn contract_list(
 }
 
 pub async fn contract_info(api_url: &str, id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}", api_url.trim_end_matches('/'), id);
     
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch contract info")?;
 
     if !response.status().is_success() {
@@ -1181,7 +1176,7 @@ fn extract_migration_id(migration: &serde_json::Value) -> Result<String> {
     Ok(migration_id.to_string())
 }
 pub async fn breaking_changes(api_url: &str, old_id: &str, new_id: &str, json: bool) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!(
         "{}/api/contracts/breaking-changes?old_id={}&new_id={}",
         api_url, old_id, new_id
@@ -1189,8 +1184,7 @@ pub async fn breaking_changes(api_url: &str, old_id: &str, new_id: &str, json: b
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch breaking changes")?;
 
     if !response.status().is_success() {
@@ -1279,7 +1273,7 @@ pub async fn migrate(
     }
 
     // 3. Create Migration Record (Pending)
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let create_url = format!("{}/api/migrations", api_url);
 
     let payload = json!({
@@ -1291,8 +1285,7 @@ pub async fn migrate(
     let response = client
         .post(&create_url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to contact registry API")?;
 
     if !response.status().is_success() {
@@ -1361,8 +1354,7 @@ pub async fn migrate(
     let update_res = client
         .put(&update_url)
         .json(&update_payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to update migration status")?;
 
     if !update_res.status().is_success() {
@@ -1507,12 +1499,11 @@ pub async fn trust_score(api_url: &str, contract_id: &str, network: Network) -> 
     let url = format!("{}/api/contracts/{}/trust-score", api_url, contract_id);
     log::debug!("GET {}", url);
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let resp = client
         .get(&url)
         .query(&[("network", network.to_string())])
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !resp.status().is_success() {
@@ -1627,13 +1618,12 @@ pub async fn patch_apply(api_url: &str, contract_id: &str, patch_id: &str) -> Re
 }
 
 pub async fn deps_list(api_url: &str, contract_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/dependencies", api_url, contract_id);
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch contract dependencies")?;
 
     if !response.status().is_success() {
@@ -1902,7 +1892,7 @@ pub fn incident_trigger(contract_id: &str, severity_str: &str) -> Result<()> {
 }
 
 pub async fn config_get(api_url: &str, contract_id: &str, environment: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!(
         "{}/api/contracts/{}/config?environment={}",
         api_url, contract_id, environment
@@ -1910,8 +1900,7 @@ pub async fn config_get(api_url: &str, contract_id: &str, environment: &str) -> 
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch configuration")?;
 
     if !response.status().is_success() {
@@ -1962,7 +1951,7 @@ pub async fn config_set(
     secrets_data: Option<&str>,
     created_by: &str,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/config", api_url, contract_id);
 
     let mut payload = json!({
@@ -1982,8 +1971,7 @@ pub async fn config_set(
     let response = client
         .post(&url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to set configuration")?;
 
     if !response.status().is_success() {
@@ -2011,7 +1999,7 @@ pub async fn config_set(
 }
 
 pub async fn config_history(api_url: &str, contract_id: &str, environment: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!(
         "{}/api/contracts/{}/config/history?environment={}",
         api_url, contract_id, environment
@@ -2019,8 +2007,7 @@ pub async fn config_history(api_url: &str, contract_id: &str, environment: &str)
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch configuration history")?;
 
     if !response.status().is_success() {
@@ -2061,7 +2048,7 @@ pub async fn config_rollback(
     version: i32,
     created_by: &str,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!(
         "{}/api/contracts/{}/config/rollback?environment={}",
         api_url, contract_id, environment
@@ -2082,8 +2069,7 @@ pub async fn config_rollback(
     let response = client
         .post(&url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to rollback configuration")?;
 
     if !response.status().is_success() {
@@ -2253,7 +2239,7 @@ async fn try_remote_state_get(
         .map_err(|_| anyhow::anyhow!("Invalid API URL"))?
         .extend(["api", "contracts", contract_id, "state", key]);
 
-    let response = match reqwest::Client::new().get(url).send().await {
+    let response = match crate::net::client().get(url).send_with_retry().await {
         Ok(resp) => resp,
         Err(_) => return Ok(None),
     };
@@ -2284,11 +2270,10 @@ async fn try_remote_state_set(
         .map_err(|_| anyhow::anyhow!("Invalid API URL"))?
         .extend(["api", "contracts", contract_id, "state", key]);
 
-    let response = match reqwest::Client::new()
+    let response = match crate::net::client()
         .put(url)
         .json(&json!({ "value": value }))
-        .send()
-        .await
+        .send_with_retry().await
     {
         Ok(resp) => resp,
         Err(_) => return Ok(false),
@@ -2691,7 +2676,7 @@ pub async fn scan_deps(
 ) -> Result<()> {
     println!("\n{}", "Scanning Dependencies...".bold().cyan());
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/scan", api_url, contract_id);
 
     // Parse dependencies
@@ -2716,8 +2701,7 @@ pub async fn scan_deps(
     let response = client
         .post(&url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to run dependency scan")?;
 
     if !response.status().is_success() {
@@ -2961,7 +2945,7 @@ pub async fn validate_call(
     params: &[String],
     strict: bool,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/validate-call", api_url, contract_id);
 
     let body = json!({
@@ -2975,8 +2959,7 @@ pub async fn validate_call(
     let response = client
         .post(&url)
         .json(&body)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to validate contract call")?;
 
     let status = response.status();
@@ -3083,7 +3066,7 @@ pub async fn generate_bindings(
     language: &str,
     output: Option<&str>,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!(
         "{}/api/contracts/{}/bindings?language={}",
         api_url, contract_id, language
@@ -3093,8 +3076,7 @@ pub async fn generate_bindings(
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to generate bindings")?;
 
     let status = response.status();
@@ -3125,15 +3107,14 @@ pub async fn generate_bindings(
 
 /// List functions available on a contract
 pub async fn list_functions(api_url: &str, contract_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/functions", api_url, contract_id);
 
     log::debug!("GET {}", url);
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to list contract functions")?;
 
     let status = response.status();
@@ -3218,7 +3199,7 @@ pub async fn info(
     highlight_method: Option<&str>,
     network: crate::config::Network,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let base_url = api_url.trim_end_matches('/');
 
     if format == "text" {
@@ -3230,8 +3211,7 @@ pub async fn info(
     let metadata_res = client
         .get(&metadata_url)
         .query(&[("network", network.to_string())])
-        .send()
-        .await?;
+        .send_with_retry().await?;
 
     if !metadata_res.status().is_success() {
         anyhow::bail!(
@@ -3249,7 +3229,7 @@ pub async fn info(
 
     // 2. Fetch ABI
     let abi_url = format!("{}/api/contracts/{}/abi", base_url, contract_uuid);
-    let abi_res = client.get(&abi_url).send().await;
+    let abi_res = client.get(&abi_url).send_with_retry().await;
     let abi: Option<serde_json::Value> = if let Ok(res) = abi_res {
         if res.status().is_success() {
             res.json::<serde_json::Value>()
@@ -3265,7 +3245,7 @@ pub async fn info(
 
     // 3. Fetch Deployments
     let depl_url = format!("{}/api/contracts/{}/deployments", base_url, contract_uuid);
-    let depl_res = client.get(&depl_url).send().await;
+    let depl_res = client.get(&depl_url).send_with_retry().await;
     let deployments: Vec<serde_json::Value> = if let Ok(res) = depl_res {
         if res.status().is_success() {
             res.json().await.unwrap_or_default()
@@ -3278,7 +3258,7 @@ pub async fn info(
 
     // 4. Fetch Dependencies
     let deps_url = format!("{}/api/contracts/{}/dependencies", base_url, contract_uuid);
-    let deps_res = client.get(&deps_url).send().await;
+    let deps_res = client.get(&deps_url).send_with_retry().await;
     let dependencies: Vec<serde_json::Value> = if let Ok(res) = deps_res {
         if res.status().is_success() {
             res.json::<serde_json::Value>()
@@ -3296,7 +3276,7 @@ pub async fn info(
 
     // 5. Fetch Dependents (Related Contracts)
     let relate_url = format!("{}/api/contracts/{}/dependents", base_url, contract_uuid);
-    let relate_res = client.get(&relate_url).send().await;
+    let relate_res = client.get(&relate_url).send_with_retry().await;
     let dependents: Vec<serde_json::Value> = if let Ok(res) = relate_res {
         if res.status().is_success() {
             res.json::<serde_json::Value>()
@@ -3314,7 +3294,7 @@ pub async fn info(
 
     // 6. Fetch Versions (for verification status)
     let versions_url = format!("{}/api/contracts/{}/versions", base_url, contract_uuid);
-    let versions_res = client.get(&versions_url).send().await;
+    let versions_res = client.get(&versions_url).send_with_retry().await;
     let versions: Vec<serde_json::Value> = if let Ok(res) = versions_res {
         if res.status().is_success() {
             res.json().await.unwrap_or_default()
@@ -3649,15 +3629,14 @@ pub fn sla_status(id: &str) -> Result<()> {
 }
 
 pub async fn snapshot_create(api_url: &str, contract_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/snapshots", api_url, contract_id);
 
     println!("\n{}", "Creating contract snapshot...".bold().cyan());
 
     let response = client
         .post(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to create snapshot")?;
 
     if !response.status().is_success() {
@@ -3679,13 +3658,12 @@ pub async fn snapshot_create(api_url: &str, contract_id: &str) -> Result<()> {
 }
 
 pub async fn snapshot_list(api_url: &str, contract_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/snapshots", api_url, contract_id);
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to list snapshots")?;
 
     if !response.status().is_success() {
@@ -3719,13 +3697,12 @@ pub async fn snapshot_list(api_url: &str, contract_id: &str) -> Result<()> {
 }
 
 pub async fn snapshot_get(api_url: &str, contract_id: &str, timestamp: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/snapshots?timestamp={}", api_url, contract_id, timestamp);
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch snapshot")?;
 
     if !response.status().is_success() {
@@ -3745,13 +3722,12 @@ pub async fn snapshot_get(api_url: &str, contract_id: &str, timestamp: &str) -> 
 }
 
 pub async fn snapshot_diff(api_url: &str, contract_id: &str, v1: i32, v2: i32) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/versions/{}/diff/{}", api_url, contract_id, v1, v2);
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch diff")?;
 
     if !response.status().is_success() {

--- a/cli/src/compare.rs
+++ b/cli/src/compare.rs
@@ -1,3 +1,4 @@
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde_json::Value;
@@ -16,11 +17,11 @@ pub async fn run(
     }
 
     let mut contracts = Vec::new();
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     for id in &ids {
         let url = format!("{}/api/contracts/{}", api_url.trim_end_matches('/'), id);
-        let response = client.get(&url).send().await?;
+        let response = client.get(&url).send_with_retry().await?;
 
         if !response.status().is_success() {
             if response.status() == reqwest::StatusCode::NOT_FOUND {

--- a/cli/src/contract_verify.rs
+++ b/cli/src/contract_verify.rs
@@ -3,6 +3,7 @@
 //! Verifies a deployed contract's authenticity against the on-chain registry.
 //! Displays verification status, security scan results, and audit/review info.
 
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -62,7 +63,7 @@ pub async fn run(api_url: &str, address: &str, network: &str, json: bool) -> Res
         api_url
     );
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     // ── 1. Fetch contract from registry by on-chain address ──────────────────
     let mut contract = fetch_contract(api_url, &client, address, network, json).await?;
@@ -111,8 +112,7 @@ async fn fetch_contract(
 
     let response = client
         .get(&search_url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to connect to registry API. Is the registry running?")?;
 
     let status = response.status();
@@ -187,8 +187,7 @@ async fn initiate_verification(
                 "build_params": build_params,
                 "compiler_version": compiler_version
             }))
-            .send()
-            .await
+            .send_with_retry().await
             .context("Failed to initiate source verification")?;
 
         if response.status().is_success() {
@@ -218,8 +217,7 @@ async fn initiate_verification(
                 }
             ]
         }))
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to initiate verification")?;
 
     if !response.status().is_success() {
@@ -426,7 +424,7 @@ async fn fetch_detail(api_url: &str, client: &reqwest::Client, contract: &Value)
     let url = format!("{}/api/contracts/{}/verification-status", api_url, id);
     log::debug!("GET {}", url);
 
-    let res = client.get(&url).send().await.ok()?;
+    let res = client.get(&url).send_with_retry().await.ok()?;
     if res.status().is_success() {
         res.json::<Value>().await.ok()
     } else {

--- a/cli/src/contracts.rs
+++ b/cli/src/contracts.rs
@@ -1,3 +1,4 @@
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde_json::json;
@@ -104,11 +105,10 @@ pub async fn list_contracts(
 
     log::debug!("Fetching contracts from: {}", url);
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch contracts from API")?;
 
     if !response.status().is_success() {

--- a/cli/src/costs.rs
+++ b/cli/src/costs.rs
@@ -1,3 +1,4 @@
+use crate::net::RequestBuilderExt;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
@@ -44,7 +45,7 @@ pub async fn estimate_costs(
     optimize: bool,
     forecast: bool,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     let request = CostEstimateRequest {
         method_name: method.to_string(),
@@ -56,8 +57,7 @@ pub async fn estimate_costs(
     let estimate: CostEstimate = client
         .post(format!("{}/api/contracts/{}/cost-estimate", api_url, contract_id))
         .json(&request)
-        .send()
-        .await?
+        .send_with_retry().await?
         .json()
         .await?;
 
@@ -82,8 +82,7 @@ pub async fn estimate_costs(
         let optimization: CostOptimization = client
             .post(format!("{}/api/contracts/{}/cost-estimate/optimize", api_url, contract_id))
             .json(&estimate)
-            .send()
-            .await?
+            .send_with_retry().await?
             .json()
             .await?;
 
@@ -107,8 +106,7 @@ pub async fn estimate_costs(
         let forecast_data: CostForecast = client
             .post(format!("{}/api/contracts/{}/cost-estimate/forecast", api_url, contract_id))
             .json(&request)
-            .send()
-            .await?
+            .send_with_retry().await?
             .json()
             .await?;
 

--- a/cli/src/events.rs
+++ b/cli/src/events.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::net::RequestBuilderExt;
 use anyhow::Result;
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -41,15 +42,14 @@ pub async fn query_events(
     println!("\n{}", "Contract Events".bold().cyan());
     println!("{}", "=".repeat(80).cyan());
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     if stats_only {
         let url = format!("{}/api/contracts/{}/events/stats", api_url, contract_id);
 
         let response = client
             .get(&url)
-            .send()
-            .await
+            .send_with_retry().await
             .map_err(|e| anyhow::anyhow!("Failed to fetch event stats: {}", e))?;
 
         if !response.status().is_success() {
@@ -108,8 +108,7 @@ pub async fn query_events(
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .map_err(|e| anyhow::anyhow!("Failed to fetch events: {}", e))?;
 
     if !response.status().is_success() {

--- a/cli/src/formal_verification.rs
+++ b/cli/src/formal_verification.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::*;
 use serde::{Deserialize, Serialize};
@@ -118,7 +119,7 @@ pub async fn run(
             println!("\n{}", "Posting results to registry...".bold().cyan());
         }
 
-        let client = reqwest::Client::new();
+        let client = crate::net::client();
         // Just demonstrating the endpoint structure.
         let url = format!(
             "{}/api/contracts/00000000-0000-0000-0000-000000000000/formal-verification",
@@ -156,7 +157,7 @@ pub async fn run(
             }).collect::<Vec<_>>()
         });
 
-        let resp = client.post(&url).json(&payload).send().await;
+        let resp = client.post(&url).json(&payload).send_with_retry().await;
         match resp {
             Ok(r) if r.status().is_success() => {
                 if output_format != "json" {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,6 +24,7 @@ mod io_utils;
 mod manifest;
 mod migration;
 mod multisig;
+mod net;
 mod network;
 mod package_signing;
 mod patch;

--- a/cli/src/multisig.rs
+++ b/cli/src/multisig.rs
@@ -1,3 +1,4 @@
+use crate::net::RequestBuilderExt;
 // cli/src/multisig.rs
 // CLI functions for Multi-Signature Contract Deployment (issue #47)
 
@@ -17,7 +18,7 @@ pub async fn create_policy(
     expiry_secs: Option<u32>,
     created_by: &str,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/multisig/policies", api_url);
 
     let payload = json!({
@@ -33,8 +34,7 @@ pub async fn create_policy(
     let response = client
         .post(&url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {
@@ -96,7 +96,7 @@ pub async fn create_proposal(
     proposer: &str,
     description: Option<&str>,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/deploy-proposal", api_url);
 
     let payload = json!({
@@ -114,8 +114,7 @@ pub async fn create_proposal(
     let response = client
         .post(&url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to create deployment proposal")?;
 
     if !response.status().is_success() {
@@ -177,7 +176,7 @@ pub async fn sign_proposal(
     signer_address: &str,
     signature_data: Option<&str>,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/sign", api_url, proposal_id);
 
     let payload = json!({
@@ -192,8 +191,7 @@ pub async fn sign_proposal(
     let response = client
         .post(&url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to sign proposal")?;
 
     let status = response.status();
@@ -236,7 +234,7 @@ pub async fn sign_proposal(
 // ─────────────────────────────────────────────────────────────────────────────
 
 pub async fn execute_proposal(api_url: &str, proposal_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/execute", api_url, proposal_id);
 
     println!("\n{}", "Executing deployment proposal...".bold().cyan());
@@ -244,8 +242,7 @@ pub async fn execute_proposal(api_url: &str, proposal_id: &str) -> Result<()> {
 
     let response = client
         .post(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to execute proposal")?;
 
     let status = response.status();
@@ -282,13 +279,12 @@ pub async fn execute_proposal(api_url: &str, proposal_id: &str) -> Result<()> {
 // ─────────────────────────────────────────────────────────────────────────────
 
 pub async fn proposal_info(api_url: &str, proposal_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/contracts/{}/proposal", api_url, proposal_id);
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch proposal info")?;
 
     if !response.status().is_success() {
@@ -411,7 +407,7 @@ pub async fn list_proposals(
     status_filter: Option<&str>,
     limit: usize,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let mut url = format!("{}/api/multisig/proposals?limit={}", api_url, limit);
     if let Some(s) = status_filter {
         url.push_str(&format!("&status={}", s));
@@ -419,8 +415,7 @@ pub async fn list_proposals(
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to list proposals")?;
 
     if !response.status().is_success() {

--- a/cli/src/net.rs
+++ b/cli/src/net.rs
@@ -1,0 +1,159 @@
+use anyhow::{anyhow, Result};
+use reqwest::{Client as ReqwestClient, Method, RequestBuilder, Response, StatusCode, Url};
+use std::{future::Future, pin::Pin, time::Duration};
+
+const MAX_ATTEMPTS: usize = 3;
+const BACKOFFS_MS: [u64; MAX_ATTEMPTS - 1] = [250, 750];
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+pub fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+        .build()
+        .unwrap_or_else(|err| {
+            eprintln!(
+                "Warning: failed to configure HTTP timeout ({}); using reqwest defaults.",
+                err
+            );
+            ReqwestClient::new()
+        })
+}
+
+pub trait RequestBuilderExt {
+    fn send_with_retry(self) -> Pin<Box<dyn Future<Output = Result<Response>> + Send>>;
+}
+
+impl RequestBuilderExt for RequestBuilder {
+    fn send_with_retry(self) -> Pin<Box<dyn Future<Output = Result<Response>> + Send>> {
+        Box::pin(send_with_retry(self))
+    }
+}
+
+async fn send_with_retry(builder: RequestBuilder) -> Result<Response> {
+    let (method, url) = request_summary(&builder);
+
+    if builder.try_clone().is_none() {
+        return builder
+            .send()
+            .await
+            .map_err(|err| friendly_network_error(err, method.as_ref(), url.as_ref(), 1));
+    }
+
+    let mut last_error = None;
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        let response = builder
+            .try_clone()
+            .ok_or_else(|| anyhow!("Failed to retry request: request body is not reusable"))?
+            .send()
+            .await;
+
+        match response {
+            Ok(response) => {
+                if should_retry_status(method.as_ref(), response.status()) && attempt < MAX_ATTEMPTS
+                {
+                    sleep_before_retry(attempt).await;
+                    continue;
+                }
+
+                return Ok(response);
+            }
+            Err(err) => {
+                if is_transient_error(&err, method.as_ref()) && attempt < MAX_ATTEMPTS {
+                    last_error = Some(err);
+                    sleep_before_retry(attempt).await;
+                    continue;
+                }
+
+                return Err(friendly_network_error(
+                    err,
+                    method.as_ref(),
+                    url.as_ref(),
+                    attempt,
+                ));
+            }
+        }
+    }
+
+    if let Some(err) = last_error {
+        return Err(friendly_network_error(
+            err,
+            method.as_ref(),
+            url.as_ref(),
+            MAX_ATTEMPTS,
+        ));
+    }
+
+    Err(anyhow!(
+        "Network request failed after {} attempt(s). Check the API URL, your network connection, and try again.",
+        MAX_ATTEMPTS
+    ))
+}
+
+fn request_summary(builder: &RequestBuilder) -> (Option<Method>, Option<Url>) {
+    builder
+        .try_clone()
+        .and_then(|cloned| cloned.build().ok())
+        .map(|request| (Some(request.method().clone()), Some(request.url().clone())))
+        .unwrap_or((None, None))
+}
+
+fn is_transient_error(err: &reqwest::Error, method: Option<&Method>) -> bool {
+    err.is_connect() || (is_retryable_method(method) && (err.is_timeout() || err.is_request()))
+}
+
+fn should_retry_status(method: Option<&Method>, status: StatusCode) -> bool {
+    is_retryable_method(method)
+        && (status == StatusCode::REQUEST_TIMEOUT
+            || status == StatusCode::TOO_MANY_REQUESTS
+            || status == StatusCode::INTERNAL_SERVER_ERROR
+            || status == StatusCode::BAD_GATEWAY
+            || status == StatusCode::SERVICE_UNAVAILABLE
+            || status == StatusCode::GATEWAY_TIMEOUT)
+}
+
+fn is_retryable_method(method: Option<&Method>) -> bool {
+    match method {
+        Some(method) => {
+            method == Method::GET || method == Method::HEAD || method == Method::OPTIONS
+        }
+        None => true,
+    }
+}
+
+async fn sleep_before_retry(attempt: usize) {
+    let delay_ms = BACKOFFS_MS[attempt.saturating_sub(1).min(BACKOFFS_MS.len() - 1)];
+    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+}
+
+fn friendly_network_error(
+    err: reqwest::Error,
+    method: Option<&Method>,
+    url: Option<&Url>,
+    attempts: usize,
+) -> anyhow::Error {
+    let target = match (method, url) {
+        (Some(method), Some(url)) => format!("{} {}", method, url),
+        (_, Some(url)) => url.to_string(),
+        _ => "registry API".to_string(),
+    };
+
+    let reason = if err.is_timeout() {
+        "the request timed out"
+    } else if err.is_connect() {
+        "the CLI could not connect to the server"
+    } else if err.is_request() {
+        "the request could not be sent"
+    } else if err.is_decode() {
+        "the response could not be decoded"
+    } else {
+        "the network request failed"
+    };
+
+    anyhow!(
+        "Network request failed after {} attempt(s): {} ({}). Check the API URL, your network connection, and try again.",
+        attempts,
+        target,
+        reason
+    )
+}

--- a/cli/src/network.rs
+++ b/cli/src/network.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use chrono::{DateTime, TimeZone, Utc};
 use colored::Colorize;
@@ -141,8 +142,7 @@ async fn check_network(def: &NetworkDef, client: &reqwest::Client) -> NetworkInf
         .post(def.rpc_endpoint)
         .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
         .json(&rpc_req)
-        .send()
-        .await;
+        .send_with_retry().await;
 
     let (sequence, close_time) = match rpc_result {
         Ok(resp) if resp.status().is_success() => {
@@ -189,8 +189,7 @@ async fn fetch_close_time(def: &NetworkDef, client: &reqwest::Client) -> Option<
     let resp = client
         .get(def.horizon_endpoint)
         .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
-        .send()
-        .await
+        .send_with_retry().await
         .ok()?;
 
     if !resp.status().is_success() {
@@ -217,7 +216,7 @@ async fn fetch_close_time(def: &NetworkDef, client: &reqwest::Client) -> Option<
 }
 
 pub async fn status(json: bool) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     // Check all three networks concurrently
     let (mainnet, testnet, futurenet) = tokio::join!(

--- a/cli/src/package_signing.rs
+++ b/cli/src/package_signing.rs
@@ -1,3 +1,4 @@
+use crate::net::RequestBuilderExt;
 use anyhow::{bail, Context, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use chrono::Utc;
@@ -45,7 +46,7 @@ pub async fn sign_package(
     println!("  {}: {}", "Contract ID".bold(), contract_id.bright_black());
     println!("  {}: {}", "Version".bold(), version);
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/signatures", api_url);
 
     let expires_dt = expires_at
@@ -68,8 +69,7 @@ pub async fn sign_package(
     let response = client
         .post(&url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {
@@ -115,7 +115,7 @@ pub async fn verify_package(
     println!("  {}: {}", "Package".bold(), package_path.bright_black());
     println!("  {}: {}", "Hash".bold(), package_hash.bright_black());
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     if let Some(sig_b64) = signature_arg {
         verify_with_signature(
@@ -152,8 +152,7 @@ async fn verify_with_signature(
     let response = client
         .post(&url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     let status = response.status();
@@ -206,8 +205,7 @@ async fn verify_from_registry(
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {
@@ -293,7 +291,7 @@ pub async fn revoke_signature(
 ) -> Result<()> {
     println!("\n{}", "Revoking signature...".bold().cyan());
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/signatures/{}/revoke", api_url, signature_id);
 
     let payload = json!({
@@ -304,8 +302,7 @@ pub async fn revoke_signature(
     let response = client
         .post(&url)
         .json(&payload)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {
@@ -330,13 +327,12 @@ pub async fn get_chain_of_custody(api_url: &str, contract_id: &str) -> Result<()
     println!("\n{}", "Chain of Custody".bold().cyan());
     println!("{}", "=".repeat(70).cyan());
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let url = format!("{}/api/signatures/custody/{}", api_url, contract_id);
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {
@@ -393,7 +389,7 @@ pub async fn get_transparency_log(
     println!("\n{}", "Transparency Log".bold().cyan());
     println!("{}", "=".repeat(70).cyan());
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let mut url = format!("{}/api/signatures/transparency?limit={}", api_url, limit);
 
     if let Some(cid) = contract_id {
@@ -405,8 +401,7 @@ pub async fn get_transparency_log(
 
     let response = client
         .get(&url)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {

--- a/cli/src/patch.rs
+++ b/cli/src/patch.rs
@@ -1,3 +1,4 @@
+use crate::net::RequestBuilderExt;
 use std::fmt;
 use std::str::FromStr;
 
@@ -80,7 +81,7 @@ impl PatchManager {
         severity: Severity,
         rollout: u8,
     ) -> Result<SecurityPatch> {
-        let client = reqwest::Client::new();
+        let client = crate::net::client();
         let payload = serde_json::json!({
             "target_version": version,
             "severity": severity,
@@ -91,8 +92,7 @@ impl PatchManager {
         let resp = client
             .post(format!("{}/api/patches", api_url))
             .json(&payload)
-            .send()
-            .await?;
+            .send_with_retry().await?;
 
         if !resp.status().is_success() {
             bail!("failed to create patch: {}", resp.text().await?);
@@ -105,12 +105,11 @@ impl PatchManager {
         api_url: &str,
         patch_id: &str,
     ) -> Result<(SecurityPatch, Vec<serde_json::Value>)> {
-        let client = reqwest::Client::new();
+        let client = crate::net::client();
 
         let patch_resp = client
             .get(format!("{}/api/patches/{}", api_url, patch_id))
-            .send()
-            .await?;
+            .send_with_retry().await?;
 
         if !patch_resp.status().is_success() {
             bail!("patch not found: {}", patch_id);
@@ -123,8 +122,7 @@ impl PatchManager {
                 "{}/api/contracts?wasm_hash={}",
                 api_url, patch.target_version
             ))
-            .send()
-            .await?;
+            .send_with_retry().await?;
 
         let data: serde_json::Value = contracts_resp.json().await?;
         let contracts = data["items"].as_array().cloned().unwrap_or_default();
@@ -133,12 +131,11 @@ impl PatchManager {
     }
 
     pub async fn apply(api_url: &str, contract_id: &str, patch_id: &str) -> Result<PatchAudit> {
-        let client = reqwest::Client::new();
+        let client = crate::net::client();
 
         let patch_resp = client
             .get(format!("{}/api/patches/{}", api_url, patch_id))
-            .send()
-            .await?;
+            .send_with_retry().await?;
 
         if !patch_resp.status().is_success() {
             bail!("patch not found: {}", patch_id);
@@ -148,8 +145,7 @@ impl PatchManager {
 
         let audits_resp = client
             .get(format!("{}/api/patches/{}/audits", api_url, patch_id))
-            .send()
-            .await?;
+            .send_with_retry().await?;
 
         let audits_data: serde_json::Value = audits_resp.json().await?;
         let applied = audits_data["total"].as_u64().unwrap_or(0) as usize;
@@ -159,8 +155,7 @@ impl PatchManager {
                 "{}/api/contracts?wasm_hash={}",
                 api_url, patch.target_version
             ))
-            .send()
-            .await?;
+            .send_with_retry().await?;
 
         let contracts_data: serde_json::Value = contracts_resp.json().await?;
         let total = contracts_data["total"].as_u64().unwrap_or(0) as usize;
@@ -183,8 +178,7 @@ impl PatchManager {
         let resp = client
             .post(format!("{}/api/patches/{}/apply", api_url, patch_id))
             .json(&payload)
-            .send()
-            .await?;
+            .send_with_retry().await?;
 
         if !resp.status().is_success() {
             bail!("failed to apply patch: {}", resp.text().await?);

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -1,3 +1,4 @@
+use crate::net::RequestBuilderExt;
 use anyhow::{anyhow, Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -326,7 +327,7 @@ pub async fn install_from_registry(api_url: &str, name: &str, version: Option<&s
         }
     };
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let resp = client
         .get(format!(
             "{}/api/plugins/{}/{}",
@@ -334,8 +335,7 @@ pub async fn install_from_registry(api_url: &str, name: &str, version: Option<&s
             name,
             resolved_version
         ))
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch plugin manifest")?;
 
     if !resp.status().is_success() {
@@ -388,14 +388,13 @@ pub fn uninstall(name: &str, version: Option<&str>) -> Result<()> {
 }
 
 pub async fn fetch_marketplace(api_url: &str) -> Result<MarketplaceIndexResponse> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let resp = client
         .get(format!(
             "{}/api/plugins/marketplace",
             api_url.trim_end_matches('/')
         ))
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to fetch plugin marketplace")?;
     if !resp.status().is_success() {
         anyhow::bail!(
@@ -467,8 +466,8 @@ async fn execute_command_steps(ctx: &TemplateContext, steps: &[PluginStep]) -> R
                     runtime_ctx.api_url.trim_end_matches('/'),
                     rendered_path
                 );
-                let client = reqwest::Client::new();
-                let resp = client.get(url).send().await.context("HTTP GET failed")?;
+                let client = crate::net::client();
+                let resp = client.get(url).send_with_retry().await.context("HTTP GET failed")?;
                 let status = resp.status();
                 let body = resp.text().await.context("Failed reading HTTP response body")?;
 

--- a/cli/src/release_notes.rs
+++ b/cli/src/release_notes.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -79,15 +80,14 @@ pub async fn generate(
         "contract_address": contract_address,
     });
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let resp = client
         .post(format!(
             "{}/api/contracts/{}/release-notes/generate",
             api_url, contract_id
         ))
         .json(&body)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to connect to registry API")?;
 
     if !resp.status().is_success() {
@@ -114,14 +114,13 @@ pub async fn view(
     version: &str,
     json_output: bool,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let resp = client
         .get(format!(
             "{}/api/contracts/{}/release-notes/{}",
             api_url, contract_id, version
         ))
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to connect to registry API")?;
 
     if !resp.status().is_success() {
@@ -164,15 +163,14 @@ pub async fn edit(
         "notes_text": text,
     });
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let resp = client
         .put(format!(
             "{}/api/contracts/{}/release-notes/{}",
             api_url, contract_id, version
         ))
         .json(&body)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to connect to registry API")?;
 
     if !resp.status().is_success() {
@@ -211,15 +209,14 @@ pub async fn publish(
         "update_version_record": !skip_version_update,
     });
 
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let resp = client
         .post(format!(
             "{}/api/contracts/{}/release-notes/{}/publish",
             api_url, contract_id, version
         ))
         .json(&body)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to connect to registry API")?;
 
     if !resp.status().is_success() {
@@ -248,14 +245,13 @@ pub async fn publish(
 
 /// List all release notes for a contract
 pub async fn list(api_url: &str, contract_id: &str, json_output: bool) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
     let resp = client
         .get(format!(
             "{}/api/contracts/{}/release-notes",
             api_url, contract_id
         ))
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to connect to registry API")?;
 
     if !resp.status().is_success() {

--- a/cli/src/track_deployment.rs
+++ b/cli/src/track_deployment.rs
@@ -3,6 +3,7 @@
 //! Polls the registry API and the Stellar network to track contract deployment
 //! progress and confirm when a deployment is live on-chain.
 
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -230,7 +231,7 @@ async fn poll_registry(
     );
     log::debug!("GET {}", url);
 
-    let res = client.get(&url).send().await.ok()?;
+    let res = client.get(&url).send_with_retry().await.ok()?;
     if !res.status().is_success() {
         return None;
     }
@@ -262,7 +263,7 @@ async fn poll_horizon_tx(
     let url = format!("{}/transactions/{}", horizon_url, tx_hash);
     log::debug!("GET {}", url);
 
-    let res = client.get(&url).send().await.ok()?;
+    let res = client.get(&url).send_with_retry().await.ok()?;
     if !res.status().is_success() {
         return None;
     }
@@ -291,7 +292,7 @@ async fn poll_horizon_contract(
     );
     log::debug!("GET {}", url);
 
-    let res = client.get(&url).send().await.ok()?;
+    let res = client.get(&url).send_with_retry().await.ok()?;
     if !res.status().is_success() {
         return None;
     }
@@ -336,7 +337,7 @@ async fn poll_rpc_tx(
 
     log::debug!("POST {} getTransaction hash={}", rpc_url, tx_hash);
 
-    let res = client.post(rpc_url).json(&body).send().await.ok()?;
+    let res = client.post(rpc_url).json(&body).send_with_retry().await.ok()?;
     if !res.status().is_success() {
         return None;
     }

--- a/cli/src/verification.rs
+++ b/cli/src/verification.rs
@@ -1,3 +1,4 @@
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
@@ -16,7 +17,7 @@ pub async fn run(
     path: &str,
     notes: Option<String>,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     if submit {
         submit_verification(api_url, &client, id, &level, path, notes, json_output).await?;
@@ -85,7 +86,7 @@ async fn submit_verification(
     });
 
     let url = format!("{}/api/contracts/{}/verify", api_url.trim_end_matches('/'), contract_id);
-    let response = client.post(&url).json(&payload).send().await?;
+    let response = client.post(&url).json(&payload).send_with_retry().await?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -115,7 +116,7 @@ async fn check_status(
     json_output: bool,
 ) -> Result<()> {
     let url = format!("{}/api/contracts/{}/verification-status", api_url.trim_end_matches('/'), contract_id);
-    let response = client.get(&url).send().await?;
+    let response = client.get(&url).send_with_retry().await?;
 
     if !response.status().is_success() {
         if response.status() == 404 {
@@ -170,7 +171,7 @@ async fn show_history(
     json_output: bool,
 ) -> Result<()> {
     let url = format!("{}/api/contracts/{}/verification-history?level={}", api_url.trim_end_matches('/'), contract_id, level);
-    let response = client.get(&url).send().await?;
+    let response = client.get(&url).send_with_retry().await?;
 
     if !response.status().is_success() {
         anyhow::bail!("Failed to fetch history ({}): {}", response.status(), response.text().await.unwrap_or_default());

--- a/cli/src/webhook.rs
+++ b/cli/src/webhook.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::net::RequestBuilderExt;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use hmac::{Hmac, Mac};
@@ -156,8 +157,7 @@ pub async fn deliver_with_retry(
             .header("X-Soroban-Signature", format!("sha256={}", &signature))
             .header("X-Soroban-Delivery-Id", &delivery_id)
             .body(payload_bytes.clone())
-            .send()
-            .await;
+            .send_with_retry().await;
 
         match result {
             Ok(resp) => {
@@ -211,7 +211,7 @@ pub async fn create_webhook(
     events: Vec<String>,
     secret_key: Option<&str>,
 ) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     // Generate a secret key if not provided
     let secret = secret_key.map(|s| s.to_string()).unwrap_or_else(|| {
@@ -230,8 +230,7 @@ pub async fn create_webhook(
     let response = client
         .post(format!("{}/api/webhooks", api_url))
         .json(&body)
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {
@@ -266,12 +265,11 @@ pub async fn create_webhook(
 
 /// List all webhook subscriptions.
 pub async fn list_webhooks(api_url: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     let response = client
         .get(format!("{}/api/webhooks", api_url))
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {
@@ -306,12 +304,11 @@ pub async fn list_webhooks(api_url: &str) -> Result<()> {
 
 /// Delete a webhook by ID.
 pub async fn delete_webhook(api_url: &str, webhook_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     let response = client
         .delete(format!("{}/api/webhooks/{}", api_url, webhook_id))
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {
@@ -330,12 +327,11 @@ pub async fn delete_webhook(api_url: &str, webhook_id: &str) -> Result<()> {
 
 /// Send a test event to a webhook.
 pub async fn test_webhook(api_url: &str, webhook_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     let response = client
         .post(format!("{}/api/webhooks/{}/test", api_url, webhook_id))
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {
@@ -355,15 +351,14 @@ pub async fn test_webhook(api_url: &str, webhook_id: &str) -> Result<()> {
 
 /// View delivery logs for a webhook, including dead-letter entries.
 pub async fn webhook_logs(api_url: &str, webhook_id: &str, limit: usize) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     let response = client
         .get(format!(
             "{}/api/webhooks/{}/deliveries?limit={}",
             api_url, webhook_id, limit
         ))
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {
@@ -421,15 +416,14 @@ pub async fn webhook_logs(api_url: &str, webhook_id: &str, limit: usize) -> Resu
 
 /// Manually retry a dead-letter delivery.
 pub async fn retry_delivery(api_url: &str, delivery_id: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::net::client();
 
     let response = client
         .post(format!(
             "{}/api/webhook-deliveries/{}/retry",
             api_url, delivery_id
         ))
-        .send()
-        .await
+        .send_with_retry().await
         .context("Failed to reach registry API")?;
 
     if !response.status().is_success() {


### PR DESCRIPTION
I fixed CLI network requests so timeouts and transient connection failures are handled through a shared retrying request helper with clearer user-facing error messages instead of failing abruptly.

closes #585