### PR TITLE
feat: add verification status flow, contract favorites, and CLI contract/import commands

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -660,6 +660,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,6 +2967,7 @@ dependencies = [
  "colored",
  "contract_abi",
  "criterion",
+ "csv",
  "dirs",
  "ed25519-dalek",
  "env_logger",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -45,6 +45,7 @@ ripemd = "0.1"
 rustyline = "14.0"
 shlex = "1.3"
 semver = "1.0"
+csv = "1.4.0"
 
 
 [dev-dependencies]

--- a/cli/src/compare.rs
+++ b/cli/src/compare.rs
@@ -53,7 +53,9 @@ pub async fn run(
 
     if format_opt == Some("csv") || export_path.map_or(false, |p| p.ends_with(".csv")) {
         let mut csv_data = String::new();
-        let headers = ["Field"].iter().chain(ids.iter().map(|s| s.as_str())).collect::<Vec<_>>();
+        let headers: Vec<String> = std::iter::once("Field".to_string())
+            .chain(ids.iter().cloned())
+            .collect();
         csv_data.push_str(&headers.join(","));
         csv_data.push('\n');
 

--- a/cli/src/contracts.rs
+++ b/cli/src/contracts.rs
@@ -333,3 +333,69 @@ fn print_csv(contracts: &[ContractListItem]) {
         );
     }
 }
+
+pub async fn run_details(
+    api_url: &str,
+    address: &str,
+    network: &str,
+    json_output: bool,
+) -> Result<()> {
+    let url = format!("{}/api/contracts/{}?network={}", api_url, address, network);
+    log::debug!("Fetching contract details from: {}", url);
+
+    let client = crate::net::client();
+    let response = client
+        .get(&url)
+        .send_with_retry().await
+        .context("Failed to fetch contract details from API")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("API request failed with status {}: {}", status, body);
+    }
+
+    let contract: serde_json::Value = response
+        .json()
+        .await
+        .context("Failed to parse contract response")?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&contract)?);
+        return Ok(());
+    }
+
+    let name = contract.get("name").and_then(|v| v.as_str()).unwrap_or("Unknown");
+    let desc = contract.get("description").and_then(|v| v.as_str()).unwrap_or("No description provided");
+    let publisher = contract.get("publisher_id").and_then(|v| v.as_str()).unwrap_or("Unknown");
+    let category = contract.get("category").and_then(|v| v.as_str()).unwrap_or("—");
+    let verified = contract.get("is_verified").and_then(|v| v.as_bool()).unwrap_or(false);
+    
+    let deployments = contract.get("deployment_count").and_then(|v| v.as_u64()).unwrap_or(0);
+    let interactions = contract.get("interaction_count").and_then(|v| v.as_u64()).unwrap_or(0);
+    let tags = contract.get("tags").and_then(|v| v.as_array()).map(|arr| {
+        arr.iter().filter_map(|t| t.as_str()).collect::<Vec<_>>().join(", ")
+    }).unwrap_or_default();
+
+    println!("\n{}", "Contract Details".bold().underline());
+    println!("{:<15} {}", "Name:".bold(), name.cyan());
+    println!("{:<15} {}", "Address:".bold(), address.cyan());
+    println!("{:<15} {}", "Network:".bold(), network.cyan());
+    println!("{:<15} {}", "Publisher:".bold(), publisher);
+    println!("{:<15} {}", "Category:".bold(), category);
+    println!("{:<15} {}", "Tags:".bold(), tags);
+    
+    let verified_str = if verified { "Yes".green() } else { "No".red() };
+    println!("{:<15} {}", "Verified:".bold(), verified_str);
+    
+    println!("\n{}", "Description".bold().underline());
+    println!("{}", desc);
+    
+    println!("\n{}", "Statistics".bold().underline());
+    println!("{:<15} {}", "Deployments:".bold(), deployments.to_string().yellow());
+    println!("{:<15} {}", "Interactions:".bold(), interactions.to_string().yellow());
+    
+    println!();
+    
+    Ok(())
+}

--- a/cli/src/import.rs
+++ b/cli/src/import.rs
@@ -4,9 +4,12 @@ use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
+use colored::Colorize;
+use serde::{Deserialize, Serialize};
 
 use crate::io_utils::{compute_sha256_streaming, extract_tar_gz};
 use crate::manifest::{AuditEntry, ExportManifest};
+use crate::net::RequestBuilderExt;
 
 pub fn extract_and_verify(archive_path: &Path, output_dir: &Path) -> Result<ExportManifest> {
     let tmp_dir = tempfile::tempdir().context("failed to create temp dir")?;
@@ -48,4 +51,245 @@ pub fn extract_and_verify(archive_path: &Path, output_dir: &Path) -> Result<Expo
     });
 
     Ok(manifest)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportPayload {
+    pub contract_id: String,
+    pub name: String,
+    pub network: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wasm_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    pub publisher_address: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CsvImportPayload {
+    pub contract_id: String,
+    pub name: String,
+    pub network: Option<String>,
+    pub description: Option<String>,
+    pub category: Option<String>,
+    pub tags: Option<String>,
+    pub wasm_hash: Option<String>,
+    pub source_url: Option<String>,
+    pub publisher_address: Option<String>,
+}
+
+pub async fn run(
+    api_url: &str,
+    file_path: &str,
+    format: Option<&str>,
+    network_flag: Option<&str>,
+    output_dir: &str,
+    validate: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let path = Path::new(file_path);
+    anyhow::ensure!(path.is_file(), "File not found: {}", file_path);
+
+    let format_str = format.unwrap_or_else(|| {
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("unknown");
+        if ext == "gz" || ext == "tar" {
+            "archive"
+        } else {
+            ext
+        }
+    });
+
+    match format_str.to_lowercase().as_str() {
+        "json" => import_json(api_url, path, network_flag, validate, dry_run).await,
+        "csv" => import_csv(api_url, path, network_flag, validate, dry_run).await,
+        "archive" | "tar.gz" => {
+            if dry_run {
+                println!("{} Archive dry-run not fully supported, skipping extraction.", "i".cyan());
+                return Ok(());
+            }
+            if validate {
+                println!("{} Validating archive...", "i".cyan());
+            }
+            let dest = Path::new(output_dir);
+            let manifest = extract_and_verify(path, dest)?;
+            
+            println!("{}", "✓ Import complete — integrity verified!".green().bold());
+            println!("  {}: {}", "Contract".bold(), manifest.contract_id.bright_black());
+            println!("  {}: {}", "Name".bold(), manifest.name);
+            if let Some(n) = network_flag {
+                println!("  {}: {}", "Network".bold(), n.bright_blue());
+            }
+            println!("  {}: {}", "SHA-256".bold(), manifest.sha256.bright_black());
+            Ok(())
+        }
+        _ => bail!("Unsupported format: {}. Use json, csv, or archive.", format_str),
+    }
+}
+
+async fn import_json(api_url: &str, path: &Path, network_flag: Option<&str>, validate: bool, dry_run: bool) -> Result<()> {
+    let content = fs::read_to_string(path).context("Failed to read JSON file")?;
+    
+    // Support either an array of contracts or a wrapper object like {"contracts": [...]}
+    let mut payload_list: Vec<ImportPayload> = match serde_json::from_str(&content) {
+        Ok(arr) => arr,
+        Err(_) => {
+            let wrapper: serde_json::Value = serde_json::from_str(&content)?;
+            if let Some(arr) = wrapper.get("contracts").and_then(|c| c.as_array()) {
+                serde_json::from_value(serde_json::Value::Array(arr.clone()))?
+            } else {
+                bail!("Invalid JSON format. Expected array of contracts or {{\"contracts\": [...]}}")
+            }
+        }
+    };
+    
+    process_bulk_import(api_url, &mut payload_list, network_flag, validate, dry_run).await
+}
+
+async fn import_csv(api_url: &str, path: &Path, network_flag: Option<&str>, validate: bool, dry_run: bool) -> Result<()> {
+    let mut reader = csv::Reader::from_path(path)?;
+    let mut payload_list = Vec::new();
+
+    for result in reader.deserialize() {
+        let record: CsvImportPayload = result?;
+        
+        let tags = record.tags
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+            
+        payload_list.push(ImportPayload {
+            contract_id: record.contract_id,
+            name: record.name,
+            network: record.network.unwrap_or_else(|| "testnet".to_string()),
+            description: record.description,
+            category: record.category,
+            tags,
+            wasm_hash: record.wasm_hash,
+            source_url: record.source_url,
+            publisher_address: record.publisher_address.unwrap_or_else(|| "Unknown".to_string()),
+        });
+    }
+
+    process_bulk_import(api_url, &mut payload_list, network_flag, validate, dry_run).await
+}
+
+async fn process_bulk_import(
+    api_url: &str,
+    payload_list: &mut Vec<ImportPayload>,
+    network_flag: Option<&str>,
+    validate: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let default_network = network_flag.unwrap_or("testnet").to_string();
+
+    // 1. Resolve network overrides and validate
+    let mut errors = Vec::new();
+    for (i, p) in payload_list.iter_mut().enumerate() {
+        if p.network.is_empty() {
+            p.network = default_network.clone();
+        }
+        
+        if validate {
+            if p.contract_id.trim().is_empty() {
+                errors.push(format!("Row {}: contract_id is empty", i + 1));
+            }
+            if p.name.trim().is_empty() {
+                errors.push(format!("Row {}: name is empty", i + 1));
+            }
+            if !["mainnet", "testnet", "futurenet"].contains(&p.network.as_str()) {
+                errors.push(format!("Row {}: invalid network '{}'", i + 1, p.network));
+            }
+        }
+    }
+
+    if validate && !errors.is_empty() {
+        bail!("Validation failed:\n  {}", errors.join("\n  "));
+    }
+
+    println!("\n{}", "Bulk Contract Import".bold().cyan());
+    println!("{}", "=".repeat(60).cyan());
+    println!("  {}: {}", "Contracts to import".bold(), payload_list.len());
+    if dry_run {
+        println!("  {}: {}", "Mode".bold(), "DRY RUN".yellow());
+    }
+
+    if dry_run {
+        println!("\n{}", "Dry-run complete. No data imported.".yellow());
+        return Ok(());
+    }
+
+    println!("\n{}", "Starting import...".bold());
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()?;
+    
+    let url = format!("{}/api/contracts", api_url);
+    let mut success_ids = Vec::new();
+    let mut has_failure = false;
+
+    for (i, payload) in payload_list.iter().enumerate() {
+        print!("  [{}/{}] Importing {} ... ", i + 1, payload_list.len(), payload.contract_id.bold());
+        
+        let response = client
+            .post(&url)
+            .json(payload)
+            .send_with_retry().await;
+
+        match response {
+            Ok(resp) => {
+                if resp.status() == reqwest::StatusCode::CONFLICT {
+                    println!("{}", "skipped (already exists)".bright_black());
+                } else if resp.status().is_success() {
+                    println!("{}", "success".green());
+                    success_ids.push(payload.contract_id.clone());
+                } else {
+                    let err_text = resp.text().await.unwrap_or_default();
+                    println!("{} - {}", "failed".red(), err_text.red());
+                    has_failure = true;
+                    break;
+                }
+            }
+            Err(e) => {
+                println!("{} - {}", "error".red(), e.to_string().red());
+                has_failure = true;
+                break;
+            }
+        }
+    }
+
+    if has_failure && !success_ids.is_empty() {
+        println!("\n{}", "Error encountered. Rolling back successful imports...".yellow().bold());
+        // Since the API might not support rollback delete directly from the CLI (no endpoint in contracts.rs),
+        // we will print a warning if we cannot rollback or try DELETE.
+        // Assuming there is a DELETE endpoint: DELETE /api/contracts/{id}
+        for id in success_ids {
+            print!("  Rolling back {} ... ", id.bold());
+            let del_url = format!("{}/api/contracts/{}", api_url, id);
+            let del_resp = client.delete(&del_url).send_with_retry().await;
+            if let Ok(resp) = del_resp {
+                if resp.status().is_success() {
+                    println!("{}", "rolled back".yellow());
+                } else {
+                    println!("{}", "rollback failed".red());
+                }
+            } else {
+                println!("{}", "rollback failed".red());
+            }
+        }
+        bail!("Import failed and rollback executed.");
+    } else if has_failure {
+        bail!("Import failed.");
+    }
+
+    println!("\n{}", "✓ All contracts imported successfully!".green().bold());
+    Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -36,18 +36,16 @@ mod shell;
 mod sla;
 mod table_format;
 mod test_framework;
-mod shell;
-mod track_deployment;
 mod track_deployment;
 mod webhook;
 mod wizard;
-mod shell;
 mod plugins;
 mod deploy;
 mod upgrade;
 mod compare;
 mod verification;
 mod user_config;
+mod version;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -299,14 +297,26 @@ pub enum Commands {
         contract_dir: String,
     },
 
-    /// Import a contract from an archive
+    /// Import contract data from a file (JSON, CSV, or Archive)
     Import {
-        /// Path to the archive file
-        archive: String,
+        /// Path to the import file
+        file: String,
 
-        /// Directory to extract into
+        /// Format of the file (json | csv | archive). If omitted, inferred from extension.
+        #[arg(long)]
+        format: Option<String>,
+
+        /// Directory to extract into (only for archive format)
         #[arg(long, default_value = "./imported")]
         output_dir: String,
+
+        /// Validate the data before importing
+        #[arg(long)]
+        validate: bool,
+
+        /// Perform a dry run without actually importing
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// Generate documentation from a contract WASM
@@ -1413,6 +1423,22 @@ pub enum ContractCommands {
         #[arg(long)]
         json: bool,
     },
+    
+    /// Display detailed information about a contract
+    ///
+    /// Usage: soroban-registry contract details <address> --network <network> [--json]
+    Details {
+        /// On-chain contract address to inspect
+        address: String,
+
+        /// Stellar network (mainnet | testnet | futurenet)
+        #[arg(long, default_value = "mainnet")]
+        network: String,
+
+        /// Output results as machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Sub-commands for the `webhook` group
@@ -1635,6 +1661,26 @@ pub async fn dispatch_command(
             // We could call shell::run here again but to break recursion we don't.
             println!("{}", "Warning: REPL already running".yellow());
             return Ok(());
+        }
+        Commands::TrackDeployment {
+            contract_id,
+            network,
+            tx_hash,
+            wait_timeout,
+            json,
+        } => {
+            log::debug!(
+                "Command: track-deployment | contract_id={} network={} tx_hash={:?} wait_timeout={} json={}",
+                contract_id, network, tx_hash, wait_timeout, json
+            );
+            track_deployment::run(
+                &cli.api_url,
+                &contract_id,
+                &network,
+                tx_hash.as_deref(),
+                wait_timeout,
+                json,
+            ).await?;
         }
         Commands::Plugins { action } => match action {
             PluginCommands::List { json } => {
@@ -1963,15 +2009,18 @@ pub async fn dispatch_command(
             commands::export(&cli.api_url, &id, &output, &contract_dir).await?;
         }
         Commands::Import {
-            archive,
+            file,
+            format,
             output_dir,
+            validate,
+            dry_run,
         } => {
+            let network = cli.network.as_deref();
             log::debug!(
-                "Command: import | archive={} output_dir={}",
-                archive,
-                output_dir
+                "Command: import | file={} format={:?} output_dir={} validate={} dry_run={}",
+                file, format, output_dir, validate, dry_run
             );
-            commands::import(&cli.api_url, &archive, network, &output_dir).await?;
+            crate::import::run(&cli.api_url, &file, format.as_deref(), network, &output_dir, validate, dry_run).await?;
         }
         Commands::Doc {
             contract_path,
@@ -2619,6 +2668,19 @@ pub async fn dispatch_command(
                     json
                 );
                 contract_verify::run(&cli.api_url, &address, &network, json).await?;
+            }
+            ContractCommands::Details {
+                address,
+                network,
+                json,
+            } => {
+                log::debug!(
+                    "Command: contract details | address={} network={} json={}",
+                    address,
+                    network,
+                    json
+                );
+                contracts::run_details(&cli.api_url, &address, &network, json).await?;
             }
         },
         // ── Release Notes commands ───────────────────────────────────────────

--- a/cli/src/shell.rs
+++ b/cli/src/shell.rs
@@ -14,8 +14,6 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::Cli;
-
 pub struct ShellContext {
     pub api_url: String,
     pub contract_id: Option<String>,

--- a/frontend/app/contracts/[id]/page.tsx
+++ b/frontend/app/contracts/[id]/page.tsx
@@ -39,6 +39,7 @@ import { useContractAutoRefresh } from "@/hooks/useContractAutoRefresh";
 import { ContractTimeline } from "@/components/contracts/contract-timeline";
 import ContractInteractionFlow from "@/components/contracts/ContractInteractionFlow";
 import ContractAbiMethodExplorer from "@/components/contracts/ContractAbiMethodExplorer";
+import VerificationBadge from "@/components/verification/VerificationBadge";
 
 
 const NETWORKS: Network[] = ["mainnet", "testnet", "futurenet"];
@@ -383,12 +384,11 @@ function ContractDetailsContent() {
                 <Share2 className="w-3.5 h-3.5" />
                 {copiedShareLink ? 'Link Copied' : 'Share'}
               </button>
-              {displayVerified && (
-                <span className="flex items-center gap-1 text-green-600 dark:text-green-400 text-sm font-medium">
-                  <CheckCircle2 className="w-4 h-4" />
-                  Verified
-                </span>
-              )}
+              <VerificationBadge 
+                status={displayVerified ? 'approved' : 'unverified'} 
+                level={contract.verification_level} 
+                size="md" 
+              />
             </div>
           </div>
 
@@ -754,20 +754,50 @@ function ContractDetailsContent() {
             <div className="bg-card rounded-2xl border border-border p-6">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <h2 className="text-xl font-semibold text-foreground">Verification Status</h2>
-                <span className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold ${displayVerified ? 'border-green-500/30 bg-green-500/10 text-green-600' : 'border-amber-500/30 bg-amber-500/10 text-amber-600'}`}>
-                  <CheckCircle2 className="h-3.5 w-3.5" />
-                  {displayVerified ? 'Verified' : 'Pending Verification'}
-                </span>
+                <div className="flex items-center gap-4">
+                  <VerificationBadge 
+                    status={displayVerified ? 'approved' : 'unverified'} 
+                    level={contract.verification_level} 
+                    size="md" 
+                  />
+                  {!displayVerified && (
+                    <Link
+                      href={`/verify-contract?id=${contract.id}`}
+                      className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:brightness-110 transition-all"
+                    >
+                      Submit for Verification
+                    </Link>
+                  )}
+                </div>
               </div>
               <dl className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
-                <div>
-                  <dt className="text-muted-foreground">Auditor</dt>
-                  <dd className="font-medium text-foreground">Automated verification pipeline</dd>
-                </div>
-                <div>
+                {displayVerified ? (
+                  <>
+                    <div>
+                      <dt className="text-muted-foreground">Auditor</dt>
+                      <dd className="font-medium text-foreground">Soroban Auto-Auditor</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Verification Date</dt>
+                      <dd className="font-medium text-foreground">{contract.verified_at ? new Date(contract.verified_at).toLocaleDateString() : 'Recent'}</dd>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div>
+                      <dt className="text-muted-foreground">Status</dt>
+                      <dd className="font-medium text-foreground">Not submitted</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Progress</dt>
+                      <dd className="font-medium text-foreground">0%</dd>
+                    </div>
+                  </>
+                )}
+                <div className="sm:col-span-2">
                   <dt className="text-muted-foreground">Report</dt>
                   <dd>
-                    <Link href="/verification-status" className="text-primary hover:underline">Open verification report</Link>
+                    <Link href="/verification-status" className="text-primary hover:underline">Open detailed verification report</Link>
                   </dd>
                 </div>
               </dl>

--- a/frontend/app/contracts/contracts-content.tsx
+++ b/frontend/app/contracts/contracts-content.tsx
@@ -15,6 +15,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useAnalytics } from '@/hooks/useAnalytics';
 import QueryBuilder from '@/components/contracts/QueryBuilder';
 import FavoriteSearches from '@/components/contracts/FavoriteSearches';
+import { useFavorites } from '@/hooks/useFavorites';
 import {
   DEFAULT_SORT_PREFERENCE,
   persistSortPreference,
@@ -131,6 +132,7 @@ export type ContractsUiFilters = {
   author: string;
   networks: NonNullable<ContractSearchParams['network']>[];
   verified_only: boolean;
+  favorites_only: boolean;
   sort_by: SortBy;
   sort_order: 'asc' | 'desc';
   page: number;
@@ -174,6 +176,7 @@ export function getInitialFilters(searchParams: URLSearchParams): ContractsUiFil
     author: searchParams.get('author') || '',
     networks,
     verified_only: searchParams.get('verified_only') === 'true',
+    favorites_only: searchParams.get('favorites_only') === 'true',
     sort_by: sortPreference.sort_by,
     sort_order: sortPreference.sort_order,
     page: Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1,
@@ -233,7 +236,9 @@ export function ContractsContent() {
     getInitialFilters(new URLSearchParams(searchParams?.toString() ?? '')),
   );
 
-  const { query, categories, languages, tags, networks, author, verified_only, sort_by, sort_order, page, page_size } = filters;
+  const { favorites } = useFavorites();
+
+  const { query, categories, languages, tags, networks, author, verified_only, favorites_only, sort_by, sort_order, page, page_size } = filters;
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -244,6 +249,7 @@ export function ContractsContent() {
     networks.forEach((network) => params.append('network', network));
     if (author) params.set('author', author);
     if (verified_only) params.set('verified_only', 'true');
+    if (favorites_only) params.set('favorites_only', 'true');
     if (sort_by !== DEFAULT_SORT_BY || query) params.set('sort_by', sort_by);
     if (sort_order !== DEFAULT_SORT_ORDER) params.set('sort_order', sort_order);
     if (page > 1) params.set('page', String(page));
@@ -251,7 +257,7 @@ export function ContractsContent() {
 
     const next = params.toString();
     router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
-  }, [query, categories, languages, tags, networks, author, verified_only, sort_by, sort_order, page, page_size, pathname, router]);
+  }, [query, categories, languages, tags, networks, author, verified_only, favorites_only, sort_by, sort_order, page, page_size, pathname, router]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -274,6 +280,8 @@ export function ContractsContent() {
       networks,
       author,
       verified_only,
+      favorites_only,
+      favoritesList: favorites_only ? favorites : [],
       sort_by,
       sort_order,
       page,
@@ -292,6 +300,7 @@ export function ContractsContent() {
       tags,
       useAdvancedSearch,
       verified_only,
+      favorites_only,
     ],
   );
 
@@ -305,6 +314,8 @@ export function ContractsContent() {
           tags,
           author,
           verified_only,
+          favorites_only: favorites_only || undefined,
+          favorites_list: favorites_only ? favorites : undefined,
         });
 
         return api.advancedSearchContracts({
@@ -324,6 +335,8 @@ export function ContractsContent() {
         networks: networks.length > 0 ? (networks as Array<'mainnet' | 'testnet' | 'futurenet'>) : undefined,
         author: author || undefined,
         verified_only: verified_only || undefined,
+        favorites_only: favorites_only || undefined,
+        favorites_list: favorites_only ? favorites : undefined,
         sort_by,
         sort_order,
         page,
@@ -386,6 +399,7 @@ export function ContractsContent() {
       author: '',
       networks: [],
       verified_only: false,
+      favorites_only: false,
       sort_by: DEFAULT_SORT_BY,
       sort_order: DEFAULT_SORT_ORDER,
       page: 1,
@@ -471,6 +485,15 @@ export function ContractsContent() {
       });
     }
 
+    if (filters.favorites_only) {
+      chips.push({
+        id: 'favorites',
+        label: 'Favorites only',
+        onRemove: () =>
+          setFilters((current) => ({ ...current, favorites_only: false, page: 1 })),
+      });
+    }
+
     if (filters.sort_by !== DEFAULT_SORT_BY || filters.sort_order !== DEFAULT_SORT_ORDER) {
       chips.push({
         id: 'sort',
@@ -531,6 +554,9 @@ export function ContractsContent() {
     verifiedOnly: filters.verified_only,
     onVerifiedChange: (value: boolean) =>
       setFilters((current) => ({ ...current, verified_only: value, page: 1 })),
+    favoritesOnly: filters.favorites_only,
+    onFavoritesChange: (value: boolean) =>
+      setFilters((current) => ({ ...current, favorites_only: value, page: 1 })),
     activeFilterCount: activeFilterChips.length,
     onResetAll: clearAllFilters,
   };
@@ -662,7 +688,7 @@ export function ContractsContent() {
                 <Filter className="w-4 h-4 text-primary" />
                 <h3 className="text-sm font-semibold text-foreground">Filters</h3>
               </div>
-              
+
               <>
                 <FilterPanel {...filterPanelProps} />
                 <div className="mt-5 pt-4 border-t border-border">

--- a/frontend/app/favorites/page.tsx
+++ b/frontend/app/favorites/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQueries } from '@tanstack/react-query';
-import { Star, BookmarkX, ArrowRight } from 'lucide-react';
+import { Star, BookmarkX, ArrowRight, Share2, FolderPlus } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { api } from '@/lib/api';
@@ -9,10 +9,12 @@ import ContractCard from '@/components/ContractCard';
 import ContractCardSkeleton from '@/components/ContractCardSkeleton';
 import Navbar from '@/components/Navbar';
 import { useFavorites } from '@/hooks/useFavorites';
+import { useCopy } from '@/hooks/useCopy';
 
 export default function FavoritesPage() {
   const { favorites, isLoading: favoritesLoading, clearAllFavorites } = useFavorites();
   const [confirmingClear, setConfirmingClear] = useState(false);
+  const { copy, copied } = useCopy();
 
   // Fetch contract data for each favorited UUID in parallel
   const contractQueries = useQueries({
@@ -68,7 +70,34 @@ export default function FavoritesPage() {
           </div>
 
           {favorites.length > 0 && !isLoading && (
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+                disabled
+                title="Coming soon"
+              >
+                <FolderPlus className="w-4 h-4" />
+                Collections
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  if (typeof window !== 'undefined') {
+                    const url = new URL(window.location.href);
+                    url.searchParams.set('list', favorites.join(','));
+                    copy(url.toString(), {
+                      successMessage: 'Favorites list link copied!',
+                      failureMessage: 'Failed to copy link',
+                    });
+                  }
+                }}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                <Share2 className="w-4 h-4" />
+                {copied ? 'Copied Link' : 'Share'}
+              </button>
+              <div className="w-px h-6 bg-border mx-1 hidden sm:block"></div>
               {confirmingClear ? (
                 <>
                   <span className="text-sm text-muted-foreground">Remove all {favorites.length} favorites?</span>

--- a/frontend/components/ContractCard.tsx
+++ b/frontend/components/ContractCard.tsx
@@ -11,6 +11,7 @@ import {
   RefreshCw,
   Sparkles,
   Tag,
+  Star,
 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -131,7 +132,7 @@ export default function ContractCard({ contract, sortBy }: ContractCardProps) {
                   <h3 className="truncate text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
                     {contract.name}
                   </h3>
-                  {contract.is_verified && <VerificationBadge status="approved" />}
+                  <VerificationBadge status={contract.is_verified ? 'approved' : 'unverified'} level={contract.verification_level} />
                 </div>
                 <p className="font-mono text-xs text-muted-foreground">
                   {address}
@@ -151,16 +152,7 @@ export default function ContractCard({ contract, sortBy }: ContractCardProps) {
                 <Tag className="h-3 w-3 shrink-0" />
                 <span className="truncate">{categoryLabel}</span>
               </span>
-              <span
-                className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
-                  contract.is_verified
-                    ? 'bg-green-500/10 text-green-500 border-green-500/20'
-                    : 'bg-yellow-500/10 text-yellow-600 border-yellow-500/20'
-                }`}
-              >
-                <CheckCircle2 className="h-3 w-3" />
-                {contract.is_verified ? t('contractCard.verified') : t('contractCard.pending')}
-              </span>
+              <VerificationBadge status={contract.is_verified ? 'approved' : 'unverified'} level={contract.verification_level} />
             </div>
 
             {contract.description && (
@@ -221,7 +213,14 @@ export default function ContractCard({ contract, sortBy }: ContractCardProps) {
                 {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
                 <span>{copied ? t('contractCard.copied') : t('contractCard.copyAddress')}</span>
               </button>
-              <FavoriteButton contractId={contract.id} size="sm" />
+              <div className="ml-auto flex items-center gap-1">
+                <FavoriteButton contractId={contract.id} size="sm" />
+                {contract.favorites_count !== undefined && (
+                  <span className="text-xs text-muted-foreground ml-1 font-medium bg-accent px-1.5 py-0.5 rounded-md">
+                    {contract.favorites_count}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/components/contracts/FilterPanel.tsx
+++ b/frontend/components/contracts/FilterPanel.tsx
@@ -32,6 +32,8 @@ interface FilterPanelProps {
   onAuthorChange: (value: string) => void;
   verifiedOnly: boolean;
   onVerifiedChange: (value: boolean) => void;
+  favoritesOnly: boolean;
+  onFavoritesChange: (value: boolean) => void;
   activeFilterCount: number;
   onResetAll: () => void;
 }
@@ -240,6 +242,8 @@ export function FilterPanel({
   onAuthorChange,
   verifiedOnly,
   onVerifiedChange,
+  favoritesOnly,
+  onFavoritesChange,
   activeFilterCount,
   onResetAll,
 }: FilterPanelProps) {
@@ -320,6 +324,27 @@ export function FilterPanel({
           {verifiedOnly && <Check className="w-3 h-3 text-white" />}
         </div>
         Verified only
+      </button>
+
+      <button
+        type="button"
+        role="checkbox"
+        aria-checked={favoritesOnly}
+        onClick={() => onFavoritesChange(!favoritesOnly)}
+        className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-all ${
+          favoritesOnly
+            ? "bg-yellow-500/10 text-yellow-600 font-medium"
+            : "text-muted-foreground hover:text-foreground hover:bg-accent"
+        }`}
+      >
+        <div
+          className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-colors ${
+            favoritesOnly ? "bg-yellow-500 border-yellow-500" : "border-border"
+          }`}
+        >
+          {favoritesOnly && <Check className="w-3 h-3 text-white" />}
+        </div>
+        Favorites only
       </button>
     </div>
   );

--- a/frontend/components/verification/VerificationBadge.tsx
+++ b/frontend/components/verification/VerificationBadge.tsx
@@ -1,53 +1,56 @@
 'use client';
 
 import React from 'react';
-import { CheckCircle2, ShieldAlert, ShieldCheck, ShieldX } from 'lucide-react';
-import type { VerificationStatus } from '@/types/verification';
+import { CheckCircle2, ShieldAlert, ShieldCheck, ShieldX, Info } from 'lucide-react';
+import type { VerificationStatus, VerificationLevel } from '@/types/verification';
 import { useTranslation } from '@/lib/i18n/client';
 
-function getBadgeConfig(status: VerificationStatus, t: any): {
+function getBadgeConfig(status: VerificationStatus, level?: VerificationLevel): {
   label: string;
   className: string;
   Icon: React.ComponentType<{ className?: string }>;
+  tooltip: string;
 } {
   switch (status) {
     case 'approved':
+      const levelLabel = level ? ` (${level.charAt(0).toUpperCase() + level.slice(1)})` : '';
       return {
-        label: t('verificationBadge.verified'),
-        className: 'bg-green-500/10 text-green-500 border-green-500/20',
+        label: `Verified${levelLabel}`,
+        className: 'bg-green-500/10 text-green-600 border-green-500/20',
         Icon: CheckCircle2,
+        tooltip: level === 'advanced' ? 'Advanced Verification: Fully audited code with formal verification' :
+                 level === 'intermediate' ? 'Intermediate Verification: Audited code' :
+                 'Basic Verification: Automated checks passed',
       };
     case 'under_review':
+    case 'submitted':
       return {
-        label: t('verificationBadge.underReview'),
-        className: 'bg-blue-500/10 text-blue-500 border-blue-500/20',
+        label: 'Pending',
+        className: 'bg-yellow-500/10 text-yellow-600 border-yellow-500/20',
         Icon: ShieldCheck,
+        tooltip: 'Verification is currently in progress',
       };
     case 'rejected':
       return {
-        label: t('verificationBadge.rejected'),
+        label: 'Rejected',
         className: 'bg-red-500/10 text-red-500 border-red-500/20',
         Icon: ShieldX,
+        tooltip: 'Verification was rejected',
       };
-    case 'submitted':
-      return {
-        label: t('verificationBadge.submitted'),
-        className: 'bg-yellow-500/10 text-yellow-600 border-yellow-500/20',
-        Icon: ShieldAlert,
-      };
+    case 'unverified':
     default:
       return {
-        label: t('verificationBadge.draft'),
-        className: 'bg-muted text-muted-foreground border-border',
+        label: 'Unverified',
+        className: 'bg-gray-500/10 text-gray-500 border-gray-500/20',
         Icon: ShieldAlert,
+        tooltip: 'This contract has not been verified',
       };
   }
 }
 
-export default function VerificationBadge(props: { status: VerificationStatus; size?: 'sm' | 'md' }) {
-  const { t } = useTranslation('common');
-  const { status, size = 'sm' } = props;
-  const cfg = getBadgeConfig(status, t);
+export default function VerificationBadge(props: { status: VerificationStatus; level?: VerificationLevel; size?: 'sm' | 'md' }) {
+  const { status, level, size = 'sm' } = props;
+  const cfg = getBadgeConfig(status, level);
 
   const iconSize = size === 'md' ? 'w-4 h-4' : 'w-3 h-3';
   const textSize = size === 'md' ? 'text-xs' : 'text-[10px]';
@@ -56,9 +59,11 @@ export default function VerificationBadge(props: { status: VerificationStatus; s
   return (
     <span
       className={`inline-flex items-center gap-1 rounded-full border ${padding} ${textSize} font-semibold uppercase tracking-wide ${cfg.className}`}
+      title={cfg.tooltip}
     >
       <cfg.Icon className={iconSize} />
       {cfg.label}
+      <Info className="w-3 h-3 ml-1 opacity-70 cursor-help" />
     </span>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -22,6 +22,7 @@ import {
   extractErrorData,
   createApiError,
 } from "./errors";
+import type { VerificationLevel } from "../types/verification";
 
 export type Network = "mainnet" | "testnet" | "futurenet";
 
@@ -69,6 +70,7 @@ export interface Contract {
   publisher_id: string;
   network: Network;
   is_verified: boolean;
+  verification_level?: VerificationLevel;
   category?: string;
   tags: string[];
   popularity_score?: number;
@@ -78,6 +80,7 @@ export interface Contract {
   review_count?: number;
   deployment_count?: number;
   interaction_count?: number;
+  favorites_count?: number;
   relevance_score?: number;
   // Image fields for contract logo/icon
   logo_url?: string;
@@ -355,6 +358,8 @@ export interface ContractSearchParams {
   network?: "mainnet" | "testnet" | "futurenet";
   networks?: Array<"mainnet" | "testnet" | "futurenet">;
   verified_only?: boolean;
+  favorites_only?: boolean;
+  favorites_list?: string[];
   category?: string;
   categories?: string[];
   language?: string;
@@ -892,6 +897,10 @@ export const api = {
 
           if (params?.verified_only) {
             filtered = filtered.filter((c) => c.is_verified);
+          }
+
+          if (params?.favorites_only && params.favorites_list) {
+            filtered = filtered.filter((c) => params.favorites_list!.includes(c.id));
           }
 
           if (params?.date_from) {

--- a/frontend/pages/VerifyContract.tsx
+++ b/frontend/pages/VerifyContract.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Navbar from '@/components/Navbar';
 import Stepper from '@/components/verification/Stepper';
 import ContractInfoStep from '@/components/verification/ContractInfoStep';
@@ -17,6 +17,8 @@ export const dynamic = 'force-dynamic';
 
 export default function VerifyContractPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const contractIdParam = searchParams?.get('id') || '';
   const { showError, showSuccess, showInfo } = useToast();
 
   const flow = useVerificationFlow();
@@ -53,6 +55,12 @@ export default function VerifyContractPage() {
       })),
     [files]
   );
+
+  React.useEffect(() => {
+    if (contractIdParam && !form.getValues('contractAddress')) {
+      form.setValue('contractAddress', contractIdParam);
+    }
+  }, [contractIdParam, form]);
 
   return (
     <div className="flex flex-col min-h-screen bg-background">

--- a/frontend/types/verification.ts
+++ b/frontend/types/verification.ts
@@ -1,4 +1,5 @@
-export type VerificationStatus = 'draft' | 'submitted' | 'under_review' | 'approved' | 'rejected';
+export type VerificationStatus = 'unverified' | 'draft' | 'submitted' | 'under_review' | 'approved' | 'rejected';
+export type VerificationLevel = 'basic' | 'intermediate' | 'advanced';
 export type VerificationLogLevel = 'info' | 'warn' | 'error' | 'debug';
 
 export type SorobanNetwork = 'mainnet' | 'testnet' | 'futurenet';


### PR DESCRIPTION




## Summary

Implements four features across the frontend UI and Rust CLI in a single PR.

---

### Verification Status Badge and Flow

Adds a fully redesigned `VerificationBadge` component supporting `unverified`, `pending`, `approved` statuses and `basic`, `intermediate`, `advanced` verification levels. Badges display with appropriate colors (gray, yellow, green) and include an info icon with a tooltip explaining the current level. The contract detail page now shows a **"Submit for Verification"** call-to-action for unverified contracts, displays the auditor name and verification date for verified ones, and the verification form pre-fills the contract address from the URL.

Closes #745

---

### Contract Favorites / Bookmarking System

Extends the existing favorites infrastructure with visible favorites counts on each `ContractCard`. The Favorites page gains a **Share** button that copies a shareable URL with the current favorites list encoded, and a disabled **Collections** placeholder for future use. The main contracts list adds a **"Favorites only"** filter in the sidebar panel — with URL persistence and an active filter chip — so users can browse only their saved contracts.

Closes #748

---

### `soroban-registry contract details` CLI Command

Adds a new `details` sub-command to the `contract` command group. Given a contract address and network, it fetches full contract metadata from the registry API and renders a structured, color-coded terminal table (name, address, network, publisher, category, tags, verification status, description, deployments, interactions). Pass `--json` for machine-readable output suitable for scripting.

**Usage:**
soroban-registry contract details --network mainnet [--json]


Closes #751

---

### `soroban-registry import` CLI Command

Expands the `import` command to support bulk contract loading from **JSON** files (array or `{"contracts":[...]}` wrapper), **CSV** files, and existing **archives**. New flags:

- `--format` — explicitly set format (`json`, `csv`, `archive`); inferred from extension if omitted
- `--validate` — runs field-level validation (contract ID, name, network) before any API calls
- `--dry-run` — prints what would be imported without writing anything

On partial failure mid-batch, the command attempts to roll back already-imported contracts via the registry API.

**Usage:**
soroban-registry import contracts.json --validate --dry-run soroban-registry import contracts.csv --network testnet
Closes #752

