### PR TITLE
feat: implement webhook system with HMAC signing and retry delivery (#731)

### DIFF
--- a/backend/api/src/subscription_handlers.rs
+++ b/backend/api/src/subscription_handlers.rs
@@ -677,18 +677,29 @@ pub async fn create_webhook(
         ));
     }
 
-    let webhook = sqlx::query_as::<_, WebhookConfiguration>(
+    // Generate a random signing secret if the caller didn't supply one.
+    let secret: String = req.secret.filter(|s| !s.is_empty()).unwrap_or_else(|| {
+        use std::fmt::Write as _;
+        let bytes: Vec<u8> = (0..32).map(|_| rand::random::<u8>()).collect();
+        bytes.iter().fold(String::with_capacity(64), |mut s, b| {
+            let _ = write!(s, "{:02x}", b);
+            s
+        })
+    });
+
+    let mut webhook = sqlx::query_as::<_, WebhookConfiguration>(
         r#"
         INSERT INTO webhook_configurations
-            (user_id, name, url, notification_types, is_active, verify_ssl, custom_headers,
-             created_at, updated_at)
-        VALUES ($1, $2, $3, $4, true, $5, $6, NOW(), NOW())
+            (user_id, name, url, secret, notification_types, is_active, verify_ssl,
+             custom_headers, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, true, $6, $7, NOW(), NOW())
         RETURNING *
         "#,
     )
     .bind(auth_user.publisher_id)
     .bind(&req.name)
     .bind(&req.url)
+    .bind(&secret)
     .bind(&req.notification_types)
     .bind(req.verify_ssl.unwrap_or(true))
     .bind(&req.custom_headers)
@@ -696,6 +707,8 @@ pub async fn create_webhook(
     .await
     .map_err(|e| ApiError::internal(format!("Failed to create webhook: {}", e)))?;
 
+    // Only include the secret in the creation response.
+    webhook.secret = Some(secret);
     Ok(Json(webhook))
 }
 
@@ -705,28 +718,14 @@ pub async fn delete_webhook(
     Path(webhook_id): Path<Uuid>,
     auth_user: auth::AuthenticatedUser,
 ) -> ApiResult<StatusCode> {
-
-    let rows_affected = sqlx::query(
-        "DELETE FROM webhook_configurations WHERE id = $1 AND user_id = $2",
-    )
-    .bind(webhook_id)
-    .bind(auth_user.publisher_id)
-    .execute(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
-    .rows_affected();
-
-    let user_id = auth_user.publisher_id;
-
     let rows_affected =
         sqlx::query("DELETE FROM webhook_configurations WHERE id = $1 AND user_id = $2")
             .bind(webhook_id)
-            .bind(user_id)
+            .bind(auth_user.publisher_id)
             .execute(&state.db)
             .await
             .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
             .rows_affected();
-
 
     if rows_affected == 0 {
         return Err(ApiError::not_found("webhook", "Webhook not found"));

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -4106,6 +4106,9 @@ pub struct WebhookConfiguration {
     pub last_success_at: Option<DateTime<Utc>>,
     pub last_failure_at: Option<DateTime<Utc>>,
     pub consecutive_failures: i32,
+    /// Signing secret — only populated in the creation response, never in reads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/database/migrations/20260427000000_issue731_webhook_system.sql
+++ b/database/migrations/20260427000000_issue731_webhook_system.sql
@@ -1,0 +1,54 @@
+-- Migration: 20260427000000_issue731_webhook_system
+-- Issue #731: Implement Webhook System for Contract Events
+
+BEGIN;
+
+-- ── 1. Add plain-text secret to webhook_configurations ───────────────────────
+-- The delivery worker needs to sign payloads with HMAC-SHA256 using a plain
+-- text secret. The existing secret_encrypted BYTEA column is not usable for
+-- this without the encryption key at query time.
+ALTER TABLE webhook_configurations
+    ADD COLUMN IF NOT EXISTS secret TEXT;
+
+-- ── 2. Extend notification_delivery_logs for webhook delivery tracking ────────
+-- The webhook_delivery worker queries these columns; they don't exist yet.
+ALTER TABLE notification_delivery_logs
+    ADD COLUMN IF NOT EXISTS webhook_id UUID REFERENCES webhook_configurations(id) ON DELETE CASCADE,
+    ADD COLUMN IF NOT EXISTS event_type TEXT,
+    ADD COLUMN IF NOT EXISTS attempt_number INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS delivery_duration_ms BIGINT,
+    ADD COLUMN IF NOT EXISTS response_body TEXT;
+
+-- Allow notification_id to be optional (webhook-triggered deliveries have no
+-- associated notification_queue entry).
+ALTER TABLE notification_delivery_logs
+    ALTER COLUMN notification_id DROP NOT NULL;
+
+-- ── 3. Indexes for the new columns ───────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_ndl_webhook_id
+    ON notification_delivery_logs(webhook_id);
+
+CREATE INDEX IF NOT EXISTS idx_ndl_webhook_status
+    ON notification_delivery_logs(webhook_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_ndl_webhook_attempt
+    ON notification_delivery_logs(webhook_id, attempt_number);
+
+-- ── 4. Make webhook_configurations aware of contract event types ──────────────
+-- The existing notification_types enum covers subscription types (new_version,
+-- verification_status, etc.). Add a companion text[] for raw contract event
+-- types (contract_created, verified, updated, deprecated) used by the
+-- webhook-only delivery path.
+ALTER TABLE webhook_configurations
+    ADD COLUMN IF NOT EXISTS event_types TEXT[] NOT NULL DEFAULT ARRAY['contract_created','verified','updated','deprecated'];
+
+COMMENT ON COLUMN webhook_configurations.secret IS
+    'Plain-text HMAC-SHA256 signing secret returned only on webhook creation (#731)';
+
+COMMENT ON COLUMN notification_delivery_logs.webhook_id IS
+    'Foreign key to the webhook_configurations that triggered this delivery (#731)';
+
+COMMENT ON COLUMN notification_delivery_logs.attempt_number IS
+    'Zero-based retry attempt counter used by the delivery worker (#731)';
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Migration adds `secret`, `webhook_id`, `event_type`, `attempt_number`, `delivery_duration_ms`, `response_body` columns to the existing webhook tables
- Fixes `create_webhook` handler to generate a random 32-byte hex signing secret returned once in the creation response
- Fixes `delete_webhook` handler: removes duplicate DELETE execution that silently discarded the first result
- Existing `webhook_delivery.rs` background worker signs payloads with HMAC-SHA256 and retries up to 5 times with exponential backoff; this PR wires the missing DB schema it depends on

## Test plan

- [ ] POST `/api/webhooks` returns `secret` field in response
- [ ] Secret is not included in subsequent GET responses
- [ ] Delivery worker picks up pending rows, signs with `X-Soroban-Signature: sha256=<hex>`, retries on failure
- [ ] DELETE `/api/webhooks/:id` removes exactly one row

Closes #731 