### PR TITLE
feat: add ValidatedPath/Query extractors and validate_request middleware (#734)

### DIFF
--- a/backend/api/src/validation/enhanced_extractors.rs
+++ b/backend/api/src/validation/enhanced_extractors.rs
@@ -4,8 +4,9 @@
 //! logging and rate limiting into the request/response pipeline.
 
 use axum::{
+    body::Body,
     extract::{connect_info::ConnectInfo, MatchedPath},
-    http::Request,
+    http::{Request, StatusCode},
     middleware::Next,
     response::Response,
 };
@@ -50,6 +51,139 @@ pub async fn validation_failure_tracking_middleware(
             &correlation_id,
             1,
         );
+    }
+
+    response
+}
+
+/// A validation rule applied by `validate_request` middleware.
+///
+/// Each rule names a source (e.g. `"query.contract_id"`) and a validator closure
+/// returning `Ok(())` or an error message.
+pub struct ValidationRule {
+    pub field: &'static str,
+    pub validator: Box<dyn Fn(&Request<Body>) -> Result<(), String> + Send + Sync>,
+}
+
+impl ValidationRule {
+    pub fn new(
+        field: &'static str,
+        validator: impl Fn(&Request<Body>) -> Result<(), String> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            field,
+            validator: Box::new(validator),
+        }
+    }
+}
+
+/// Middleware factory that applies a static list of `ValidationRule`s to every
+/// request passing through the route it wraps.
+///
+/// Validation failures are collected and returned as a single 400 JSON response
+/// using the same `ValidationErrorResponse` shape as `ValidatedJson<T>`.
+///
+/// # Example
+///
+/// ```ignore
+/// use axum::{Router, middleware};
+/// use crate::validation::enhanced_extractors::{validate_request, ValidationRule};
+/// use crate::validation::validators::validate_contract_id;
+///
+/// let app = Router::new()
+///     .route("/api/contracts/:id", get(handler))
+///     .layer(middleware::from_fn(validate_request(vec![
+///         ValidationRule::new("path.id", |req| {
+///             let id = req.uri().path().split('/').last().unwrap_or("");
+///             validate_contract_id(id)
+///         }),
+///     ])));
+/// ```
+pub fn validate_request(
+    rules: Vec<ValidationRule>,
+) -> impl Fn(Request<Body>, Next) -> std::pin::Pin<Box<dyn std::future::Future<Output = Response> + Send>>
+       + Clone
+       + Send
+       + 'static {
+    use std::sync::Arc;
+    let rules = Arc::new(rules);
+
+    move |req: Request<Body>, next: Next| {
+        let rules = rules.clone();
+        Box::pin(async move {
+            let correlation_id = crate::request_tracing::get_or_create_request_id(&req);
+
+            let mut errors = vec![];
+            for rule in rules.iter() {
+                if let Err(msg) = (rule.validator)(&req) {
+                    errors.push(super::extractors::FieldError::new(rule.field, msg));
+                }
+            }
+
+            if !errors.is_empty() {
+                let body = super::extractors::ValidationErrorResponse::new(errors, correlation_id.clone());
+                let json = serde_json::to_vec(&body).unwrap_or_default();
+                let mut response = Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .header("Content-Type", "application/json")
+                    .body(axum::body::Body::from(json))
+                    .unwrap_or_default();
+                crate::request_tracing::attach_request_id_headers(
+                    response.headers_mut(),
+                    &correlation_id,
+                );
+                return response;
+            }
+
+            next.run(req).await
+        })
+    }
+}
+
+/// Development-only middleware that validates response bodies are non-empty
+/// JSON when the response status is 2xx and Content-Type is application/json.
+///
+/// Only active when compiled in debug mode (`cfg(debug_assertions)`).
+/// In release builds this middleware is a no-op pass-through.
+pub async fn validate_response_schema_dev(req: Request<Body>, next: Next) -> Response {
+    let response = next.run(req).await;
+
+    #[cfg(debug_assertions)]
+    {
+        let status = response.status();
+        let is_json = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(|ct| ct.contains("application/json"))
+            .unwrap_or(false);
+
+        if status.is_success() && is_json {
+            let (parts, body) = response.into_parts();
+            let bytes = match axum::body::to_bytes(body, 1024 * 1024).await {
+                Ok(b) => b,
+                Err(_) => {
+                    tracing::warn!(
+                        "[dev] validate_response_schema_dev: failed to buffer response body"
+                    );
+                    return Response::from_parts(parts, axum::body::Body::empty());
+                }
+            };
+
+            if bytes.is_empty() {
+                tracing::warn!(
+                    status = status.as_u16(),
+                    "[dev] Response has empty body for JSON content-type"
+                );
+            } else if serde_json::from_slice::<serde_json::Value>(&bytes).is_err() {
+                tracing::warn!(
+                    status = status.as_u16(),
+                    "[dev] Response body is not valid JSON despite application/json content-type"
+                );
+            }
+
+            return Response::from_parts(parts, axum::body::Body::from(bytes));
+        }
     }
 
     response

--- a/backend/api/src/validation/extractors.rs
+++ b/backend/api/src/validation/extractors.rs
@@ -5,8 +5,8 @@
 
 use axum::{
     async_trait,
-    extract::{FromRequest, Request},
-    http::StatusCode,
+    extract::{FromRequest, FromRequestParts, Request},
+    http::{request::Parts, StatusCode},
     Json,
 };
 use chrono::{SecondsFormat, Utc};
@@ -222,6 +222,142 @@ impl<T> std::ops::Deref for ValidatedJson<T> {
 impl<T> std::ops::DerefMut for ValidatedJson<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+/// Custom Path extractor that validates path parameters implementing `Validatable`.
+pub struct ValidatedPath<T>(pub T);
+
+#[async_trait]
+impl<S, T> FromRequestParts<S> for ValidatedPath<T>
+where
+    T: serde::de::DeserializeOwned + Validatable + Send,
+    S: Send + Sync,
+{
+    type Rejection = ValidationError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let correlation_id = parts
+            .extensions
+            .get::<crate::request_tracing::RequestId>()
+            .map(|r| r.0.clone())
+            .unwrap_or_else(crate::request_tracing::generate_request_id);
+        let path = parts
+            .extensions
+            .get::<axum::extract::MatchedPath>()
+            .map(|p| p.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let axum::extract::Path(mut data) =
+            axum::extract::Path::<T>::from_request_parts(parts, state)
+                .await
+                .map_err(|err| {
+                    let message = format!("Invalid path parameters: {}", err);
+                    crate::security_log::log_validation_failure(
+                        std::net::IpAddr::from([127, 0, 0, 1]),
+                        "path",
+                        &message,
+                        &path,
+                        parts.method.as_str(),
+                        &correlation_id,
+                        1,
+                    );
+                    ValidationError::single("path", message)
+                })?;
+
+        data.sanitize();
+        data.validate().map_err(|errors| {
+            for error in &errors {
+                crate::security_log::log_validation_failure(
+                    std::net::IpAddr::from([127, 0, 0, 1]),
+                    &error.field,
+                    &error.message,
+                    &path,
+                    parts.method.as_str(),
+                    &correlation_id,
+                    1,
+                );
+            }
+            ValidationError::new(errors)
+        })?;
+
+        Ok(ValidatedPath(data))
+    }
+}
+
+impl<T> std::ops::Deref for ValidatedPath<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Custom Query extractor that validates query parameters implementing `Validatable`.
+pub struct ValidatedQuery<T>(pub T);
+
+#[async_trait]
+impl<S, T> FromRequestParts<S> for ValidatedQuery<T>
+where
+    T: serde::de::DeserializeOwned + Validatable + Send,
+    S: Send + Sync,
+{
+    type Rejection = ValidationError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let correlation_id_q = parts
+            .extensions
+            .get::<crate::request_tracing::RequestId>()
+            .map(|r| r.0.clone())
+            .unwrap_or_else(crate::request_tracing::generate_request_id);
+        let path_q = parts
+            .extensions
+            .get::<axum::extract::MatchedPath>()
+            .map(|p| p.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let axum::extract::Query(mut data) =
+            axum::extract::Query::<T>::from_request_parts(parts, state)
+                .await
+                .map_err(|err| {
+                    let message = format!("Invalid query parameters: {}", err);
+                    crate::security_log::log_validation_failure(
+                        std::net::IpAddr::from([127, 0, 0, 1]),
+                        "query",
+                        &message,
+                        &path_q,
+                        parts.method.as_str(),
+                        &correlation_id_q,
+                        1,
+                    );
+                    ValidationError::single("query", message)
+                })?;
+
+        data.sanitize();
+        data.validate().map_err(|errors| {
+            for error in &errors {
+                crate::security_log::log_validation_failure(
+                    std::net::IpAddr::from([127, 0, 0, 1]),
+                    &error.field,
+                    &error.message,
+                    &path_q,
+                    parts.method.as_str(),
+                    &correlation_id_q,
+                    1,
+                );
+            }
+            ValidationError::new(errors)
+        })?;
+
+        Ok(ValidatedQuery(data))
+    }
+}
+
+impl<T> std::ops::Deref for ValidatedQuery<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/backend/api/src/validation/mod.rs
+++ b/backend/api/src/validation/mod.rs
@@ -84,7 +84,14 @@ mod integration_guide;
 
 // Re-export commonly used items
 #[allow(unused_imports)]
-pub use extractors::{FieldError, Validatable, ValidatedJson, ValidationBuilder, ValidationError};
+pub use extractors::{
+    FieldError, Validatable, ValidatedJson, ValidatedPath, ValidatedQuery, ValidationBuilder,
+    ValidationError,
+};
+#[allow(unused_imports)]
+pub use enhanced_extractors::{
+    validate_request, validate_response_schema_dev, ValidationRule,
+};
 #[allow(unused_imports)]
 pub use sanitizers::{
     normalize_contract_id, normalize_stellar_address, sanitize_description,


### PR DESCRIPTION
## Summary

- `ValidatedPath<T>` extractor: mirrors `ValidatedJson<T>` for Axum path params — deserializes, sanitizes, validates, and logs failures via `security_log`
- `ValidatedQuery<T>` extractor: same pattern for query string params
- `validate_request(rules)` middleware factory: accepts a `Vec<ValidationRule>` so route-level validation rules can be declared inline without a custom extractor
- `validate_response_schema_dev()` middleware: no-op in release builds; logs a warning in debug mode when a 2xx JSON response body is empty or unparseable
- All new types re-exported from `validation::mod` for convenient import

## Test plan

- [ ] Handler using `ValidatedPath` with invalid path param returns structured 400 with field-level errors
- [ ] Handler using `ValidatedQuery` with missing required field returns 400
- [ ] Route wrapped in `validate_request` middleware rejects requests that fail custom rules
- [ ] `validate_response_schema_dev` logs warning for empty JSON body in debug builds

Closes #734