### PR TITLE
fix(frontend): prevent CLS in contract card logos with proper next/image

### DIFF
--- a/frontend/components/ContractCard.tsx
+++ b/frontend/components/ContractCard.tsx
@@ -1,5 +1,6 @@
 import type { Contract } from '@/lib/api';
 import {
+  Box,
   Check,
   CheckCircle2,
   Clock,
@@ -13,6 +14,7 @@ import {
   Tag,
   Star,
 } from 'lucide-react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
@@ -20,10 +22,14 @@ import { useAnalytics } from '@/hooks/useAnalytics';
 import { useCopy } from '@/hooks/useCopy';
 import { formatContractId } from '@/lib/utils/formatting';
 import { useTranslation } from '@/lib/i18n/client';
+import { generateSolidPlaceholder } from '@/lib/images';
 import VerificationBadge from '@/components/verification/VerificationBadge';
 import HealthWidget from './HealthWidget';
 import ContractQuickViewModal from './contracts/ContractQuickViewModal';
 import FavoriteButton from './FavoriteButton';
+
+const LOGO_SIZE_PX = 40;
+const LOGO_PLACEHOLDER = generateSolidPlaceholder('#e5e7eb');
 
 interface ContractCardProps {
   contract: Contract;
@@ -43,6 +49,7 @@ export default function ContractCard({ contract, sortBy }: ContractCardProps) {
   const router = useRouter();
   const { copy, copied, isCopying } = useCopy();
   const [quickViewOpen, setQuickViewOpen] = React.useState(false);
+  const [logoError, setLogoError] = React.useState(false);
 
   const networkColors = {
     mainnet: 'bg-green-500/10 text-green-600 border-green-500/20',
@@ -127,6 +134,29 @@ export default function ContractCard({ contract, sortBy }: ContractCardProps) {
             )}
 
             <div className="mb-3 flex items-start justify-between gap-3">
+              <div
+                className="relative flex shrink-0 items-center justify-center overflow-hidden rounded-lg border border-border bg-accent"
+                style={{ width: LOGO_SIZE_PX, height: LOGO_SIZE_PX }}
+                aria-hidden="true"
+              >
+                {contract.logo_url && !logoError ? (
+                  <Image
+                    src={contract.logo_url}
+                    alt=""
+                    width={LOGO_SIZE_PX}
+                    height={LOGO_SIZE_PX}
+                    sizes={`${LOGO_SIZE_PX}px`}
+                    placeholder="blur"
+                    blurDataURL={LOGO_PLACEHOLDER}
+                    loading="lazy"
+                    onError={() => setLogoError(true)}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <Box className="h-5 w-5 text-muted-foreground" />
+                )}
+              </div>
+
               <div className="min-w-0 flex-1">
                 <div className="mb-1 flex items-center gap-2">
                   <h3 className="truncate text-lg font-semibold text-foreground transition-colors group-hover:text-primary">

--- a/frontend/components/ContractCardSkeleton.tsx
+++ b/frontend/components/ContractCardSkeleton.tsx
@@ -9,8 +9,9 @@ export default function ContractCardSkeleton() {
       aria-label="Loading contract"
     >
       <div className="relative h-full flex flex-col">
-        {/* Header: name + network badge */}
-        <div className="flex items-start justify-between mb-3">
+        {/* Header: logo + name + network badge */}
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <LoadingSkeleton width="2.5rem" height="2.5rem" className="rounded-lg shrink-0" />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
               <LoadingSkeleton width="60%" height="1.5rem" />


### PR DESCRIPTION
## Summary
- Render `contract.logo_url` in `ContractCard` using `next/image` with explicit `width`/`height`, `sizes="40px"`, `loading="lazy"`, and a solid blur `blurDataURL` so the image slot reserves space and avoids cumulative layout shift (CLS).
- Add a graceful fallback (`Box` icon) when `logo_url` is missing or fails to load — the slot stays the same size, so layout is stable in every state.
- Update `ContractCardSkeleton` to reserve a matching 40×40 logo slot so the loading→loaded transition is layout-stable.

## Notes for reviewers
- `Contract.logo_url` was already defined on the type (`frontend/lib/api.ts:86`) but never rendered — this wires it up while satisfying all four AC tasks in the issue.
- I could not verify the change in the browser locally because `/contracts` currently returns HTTP 500 on `main` due to **pre-existing** ReferenceErrors unrelated to this change:
  - `categoryOptions is not defined` in `app/contracts/contracts-content.tsx:515`
  - `useFavorites is not defined` in `components/Navbar.tsx:180`
  Happy to file a separate issue/PR for those.

## Test plan
- [ ] `pnpm install && pnpm next build` (once the unrelated runtime errors are resolved)
- [ ] Load `/contracts`, confirm cards render the logo for contracts with `logo_url` and the fallback icon otherwise
- [ ] Run Lighthouse on `/contracts` — confirm CLS score is healthy (≈0)
- [ ] Verify no layout shift when scrolling/loading more contracts (lazy-loaded images should appear without pushing surrounding content)
- [ ] Confirm skeleton (visible while loading) and loaded card occupy identical space

Closes #590