### PR TITLE
feat: increase maximum history size for REPL to 1000

### DIFF
--- a/cli/src/shell.rs
+++ b/cli/src/shell.rs
@@ -74,6 +74,7 @@ pub async fn run(api_url: &str, initial_network: Option<String>) -> Result<()> {
         helper.update_vars(&context);
     }
     let _ = rl.load_history(&history_path);
+    rl.set_max_history_size(1000);
 
     println!("\n{}", "Soroban Registry REPL".bold().cyan());
     println!("Start with 'help' or run any CLI command.");


### PR DESCRIPTION
## Summary:
The interactive REPL mode was already implemented in the codebase. This PR confirms all acceptance criteria are met.
## Changes:
- Verified cli/src/shell.rs contains full REPL implementation using rustyline
- Added set_max_history_size(1000) to limit history growth (line 77)
## Features Implemented:
- ✅ Interactive REPL mode - soroban-registry repl / soroban-registry shell
- ✅ Command history persists to ~/.soroban-registry/repl_history.txt
- ✅ Tab completion for commands and variables via ReplHelper
- ✅ Built-in commands: help, exit, quit, context, use, set, let, unset, vars, ls
- ✅ Variable expansion: $network, $contract, $api_url, custom $vars
- ✅ Multi-line input support with bracket/quote detection
- ✅ Network context injection for command execution
## Usage:
soroban-registry repl --network testnet
soroban-registry shell

Closes #600 