### PR TITLE
fix(cli): support repeated -v flag for tiered verbosity

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -48,7 +48,7 @@ mod user_config;
 mod version;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand};
 use colored::Colorize;
 use patch::Severity;
 
@@ -68,9 +68,19 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub timeout: Option<u64>,
 
-    /// Enable verbose output (shows HTTP requests, responses, and debug info)
-    #[arg(long, short = 'v', global = true)]
-    pub verbose: bool,
+    /// Enable verbose output. Repeat to increase verbosity (-v, -vv, -vvv).
+    #[arg(
+        long,
+        short = 'v',
+        global = true,
+        action = ArgAction::Count,
+        long_help = "Enable verbose output. Repeat the flag to raise the log level:\n  \
+                     (none)  warn   — errors and warnings only (default)\n  \
+                     -v      info   — high-level operations\n  \
+                     -vv     debug  — HTTP requests, responses, and timing\n  \
+                     -vvv+   trace  — full internal tracing"
+    )]
+    pub verbose: u8,
 
     /// Check for CLI updates before running the command.
     #[arg(long, global = true)]
@@ -1628,13 +1638,17 @@ async fn main() -> Result<()> {
     cli.timeout = Some(runtime.timeout);
 
     // ── Initialise logger ─────────────────────────────────────────────────────
-    // --verbose / -v  →  DEBUG level (shows HTTP calls, payloads, timing)
-    // default         →  WARN level  (only errors and warnings)
-    let log_level = if cli.verbose { "debug" } else { "warn" };
+    // -v counts; each level raises verbosity by one step.
+    let log_level = match cli.verbose {
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
     env_logger::Builder::new()
         .parse_filters(log_level)
         .format_timestamp(None) // no timestamps in CLI output
-        .format_module_path(cli.verbose) // show module path only in verbose
+        .format_module_path(cli.verbose > 0) // show module path only when verbose
         .init();
 
     log::debug!("Verbose mode enabled");
@@ -2903,4 +2917,50 @@ pub async fn dispatch_command(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod verbose_flag_tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse(args: &[&str]) -> Cli {
+        Cli::try_parse_from(args).expect("CLI should parse")
+    }
+
+    #[test]
+    fn no_flag_yields_zero() {
+        let cli = parse(&["soroban-registry", "version"]);
+        assert_eq!(cli.verbose, 0);
+    }
+
+    #[test]
+    fn single_short_flag_yields_one() {
+        let cli = parse(&["soroban-registry", "-v", "version"]);
+        assert_eq!(cli.verbose, 1);
+    }
+
+    #[test]
+    fn repeated_short_flags_count() {
+        let cli = parse(&["soroban-registry", "-v", "-v", "-v", "version"]);
+        assert_eq!(cli.verbose, 3);
+    }
+
+    #[test]
+    fn stacked_short_flag_counts() {
+        let cli = parse(&["soroban-registry", "-vvv", "version"]);
+        assert_eq!(cli.verbose, 3);
+    }
+
+    #[test]
+    fn long_flag_counts_too() {
+        let cli = parse(&["soroban-registry", "--verbose", "--verbose", "version"]);
+        assert_eq!(cli.verbose, 2);
+    }
+
+    #[test]
+    fn verbose_works_after_subcommand_when_global() {
+        let cli = parse(&["soroban-registry", "version", "-vv"]);
+        assert_eq!(cli.verbose, 2);
+    }
 }


### PR DESCRIPTION
## Summary
The global `--verbose` flag in `cli/src/main.rs` was declared as `bool`, so passing `-v -v -v` collapsed to `true` and the log filter only had two states (`warn` or `debug`). This PR converts the flag to `u8` with `ArgAction::Count`, so each `-v` raises the level by one step:

| Flag        | Log level |
|-------------|-----------|
| (none)      | `warn`    |
| `-v`        | `info`    |
| `-vv`       | `debug`   |
| `-vvv`+     | `trace`   |

The flag also accepts long-form repetition (`--verbose --verbose`), stacked short form (`-vvv`), and works after the subcommand thanks to `global = true`.

## What changed
- `cli/src/main.rs`: `pub verbose: bool` → `pub verbose: u8` with `ArgAction::Count` and a `long_help` block explaining the levels. Clap now renders `-v, --verbose...` in `--help`, signalling the flag is repeatable.
- Logger init updated from `if cli.verbose { "debug" } else { "warn" }` to a 4-arm `match` over `cli.verbose`.
- Added six unit tests in `verbose_flag_tests` covering: no flag, single short, repeated short, stacked short (`-vvv`), repeated long, and post-subcommand placement.

## Verification
- `cargo check` — clean (0 errors, only pre-existing warnings).
- `cargo test --bin soroban-registry verbose_flag_tests` — **6/6 pass**.
- `cargo run --bin soroban-registry -- --help` — `-v, --verbose...` rendered with the new long-help body.
- `cargo run --bin soroban-registry -- -vvv version` — exit 0.

## Test plan
- [ ] `cargo test --bin soroban-registry verbose_flag_tests` passes.
- [ ] `soroban-registry --help` shows the four-level `long_help`.
- [ ] `soroban-registry -vvv list` increases log verbosity (visible debug + trace output).
- [ ] No regression for plain `soroban-registry list` (still `warn` only).

Closes #592