### PR TITLE
cli: add env command for environment variable management (#843)

### DIFF
--- a/cli/src/env.rs
+++ b/cli/src/env.rs
@@ -1,0 +1,582 @@
+//! env.rs — `soroban-registry env` (#843)
+//!
+//! Manages environment variable sets for different deployment environments
+//! (dev, staging, production, or any custom name). Variables are stored
+//! locally in `~/.soroban-registry/environments.json` and can be exported
+//! as shell-sourceable files, JSON, or .env format.
+//!
+//! Environments are isolated from each other. When listing or exporting,
+//! the active environment's variables are merged with global registry
+//! config values (api_key, default_network) as fallback defaults.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+// ── Storage types ─────────────────────────────────────────────────────────────
+
+/// A single environment's variable set.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Environment {
+    /// Ordered map of variable name → value.
+    pub vars: BTreeMap<String, String>,
+}
+
+/// Root of the environments storage file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Environments {
+    /// Name of the currently active environment.
+    pub active: String,
+    /// All named environments.
+    pub environments: BTreeMap<String, Environment>,
+}
+
+impl Default for Environments {
+    fn default() -> Self {
+        let mut envs: BTreeMap<String, Environment> = BTreeMap::new();
+        // Ship three starter environments.
+        envs.insert("dev".to_string(), dev_template());
+        envs.insert("staging".to_string(), staging_template());
+        envs.insert("production".to_string(), production_template());
+        Self {
+            active: "dev".to_string(),
+            environments: envs,
+        }
+    }
+}
+
+// ── Built-in templates ────────────────────────────────────────────────────────
+
+fn dev_template() -> Environment {
+    let mut vars = BTreeMap::new();
+    vars.insert(
+        "SOROBAN_REGISTRY_API_URL".to_string(),
+        "http://localhost:3001".to_string(),
+    );
+    vars.insert("SOROBAN_NETWORK".to_string(), "testnet".to_string());
+    vars.insert("SOROBAN_REGISTRY_LOG_LEVEL".to_string(), "debug".to_string());
+    Environment { vars }
+}
+
+fn staging_template() -> Environment {
+    let mut vars = BTreeMap::new();
+    vars.insert(
+        "SOROBAN_REGISTRY_API_URL".to_string(),
+        "https://staging-registry.example.com".to_string(),
+    );
+    vars.insert("SOROBAN_NETWORK".to_string(), "testnet".to_string());
+    vars.insert(
+        "SOROBAN_REGISTRY_LOG_LEVEL".to_string(),
+        "info".to_string(),
+    );
+    Environment { vars }
+}
+
+fn production_template() -> Environment {
+    let mut vars = BTreeMap::new();
+    vars.insert(
+        "SOROBAN_REGISTRY_API_URL".to_string(),
+        "https://registry.example.com".to_string(),
+    );
+    vars.insert("SOROBAN_NETWORK".to_string(), "mainnet".to_string());
+    vars.insert(
+        "SOROBAN_REGISTRY_LOG_LEVEL".to_string(),
+        "warn".to_string(),
+    );
+    Environment { vars }
+}
+
+#[allow(dead_code)]
+pub fn template_by_name(name: &str) -> Option<Environment> {
+    match name {
+        "dev" | "development" => Some(dev_template()),
+        "staging" | "stage" => Some(staging_template()),
+        "production" | "prod" => Some(production_template()),
+        _ => None,
+    }
+}
+
+// ── Storage helpers ───────────────────────────────────────────────────────────
+
+fn storage_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("Could not resolve home directory")?;
+    Ok(home
+        .join(".soroban-registry")
+        .join("environments.json"))
+}
+
+fn load_store() -> Result<Environments> {
+    let path = storage_path()?;
+    if !path.exists() {
+        return Ok(Environments::default());
+    }
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read environments file: {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("Failed to parse environments file: {}", path.display()))
+}
+
+fn save_store(store: &Environments) -> Result<()> {
+    let path = storage_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create config dir: {}", parent.display()))?;
+    }
+    let content = serde_json::to_string_pretty(store)?;
+    fs::write(&path, content)
+        .with_context(|| format!("Failed to write environments file: {}", path.display()))
+}
+
+/// Resolve the environment name: use the provided name or fall back to active.
+fn resolve_env_name<'a>(store: &'a Environments, env: Option<&str>) -> &'a str {
+    env.unwrap_or(&store.active)
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+/// Validate that a variable name is a legal shell identifier.
+fn validate_var_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Variable name cannot be empty.");
+    }
+    let first = name.chars().next().unwrap();
+    if !first.is_ascii_alphabetic() && first != '_' {
+        anyhow::bail!(
+            "Invalid variable name '{}': must start with a letter or underscore.",
+            name
+        );
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        anyhow::bail!(
+            "Invalid variable name '{}': only letters, digits, and underscores are allowed.",
+            name
+        );
+    }
+    Ok(())
+}
+
+/// Validate that an environment name is a safe identifier.
+fn validate_env_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Environment name cannot be empty.");
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        anyhow::bail!(
+            "Invalid environment name '{}': only letters, digits, hyphens, and underscores are allowed.",
+            name
+        );
+    }
+    Ok(())
+}
+
+/// Escape a value for safe inclusion in a shell `export` statement.
+fn shell_escape(value: &str) -> String {
+    // Wrap in single quotes; escape any embedded single quotes.
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+// ── Global config merge ───────────────────────────────────────────────────────
+
+/// Build a merged variable map: global registry config values as defaults,
+/// overridden by the named environment's own vars.
+fn merged_vars(env: &Environment) -> BTreeMap<String, String> {
+    let global = crate::user_config::load().unwrap_or_default();
+
+    let mut merged: BTreeMap<String, String> = BTreeMap::new();
+
+    // Inject global config as low-priority fallbacks.
+    if let Some(key) = global.api_key {
+        merged.insert("SOROBAN_REGISTRY_API_KEY".to_string(), key);
+    }
+    merged.insert(
+        "SOROBAN_DEFAULT_NETWORK".to_string(),
+        global.default_network,
+    );
+
+    // Environment-specific vars take precedence.
+    merged.extend(env.vars.clone());
+    merged
+}
+
+// ── Public entry points ───────────────────────────────────────────────────────
+
+/// `soroban-registry env set <NAME> <VALUE> [--env <env>]`
+pub fn set_var(name: &str, value: &str, env: Option<&str>) -> Result<()> {
+    validate_var_name(name)?;
+
+    let mut store = load_store()?;
+    let env_name = resolve_env_name(&store, env).to_string();
+
+    if let Some(e) = env.filter(|e| !store.environments.contains_key(*e)) {
+        validate_env_name(e)?;
+    }
+
+    let environment = store
+        .environments
+        .entry(env_name.clone())
+        .or_default();
+
+    let overwriting = environment.vars.contains_key(name);
+    environment.vars.insert(name.to_string(), value.to_string());
+    save_store(&store)?;
+
+    println!();
+    if overwriting {
+        println!(
+            "  {} {} updated in {}",
+            "↺".cyan().bold(),
+            name.bold(),
+            env_name.bright_blue()
+        );
+    } else {
+        println!(
+            "  {} {} set in {}",
+            "✔".green().bold(),
+            name.bold(),
+            env_name.bright_blue()
+        );
+    }
+    println!("     {} {}", "Value:".bold(), value.dimmed());
+    println!();
+    Ok(())
+}
+
+/// `soroban-registry env get <NAME> [--env <env>] [--json]`
+pub fn get_var(name: &str, env: Option<&str>, json: bool) -> Result<()> {
+    validate_var_name(name)?;
+
+    let store = load_store()?;
+    let env_name = resolve_env_name(&store, env);
+
+    let environment = store.environments.get(env_name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Environment '{}' does not exist. Create it with: soroban-registry env set <NAME> <VALUE> --env {}",
+            env_name,
+            env_name
+        )
+    })?;
+
+    let merged = merged_vars(environment);
+
+    match merged.get(name) {
+        Some(value) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "environment": env_name,
+                        "name": name,
+                        "value": value,
+                        "source": if environment.vars.contains_key(name) { "environment" } else { "global" }
+                    }))?
+                );
+            } else {
+                println!("{}", value);
+            }
+        }
+        None => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "environment": env_name,
+                        "name": name,
+                        "value": null
+                    }))?
+                );
+            } else {
+                anyhow::bail!(
+                    "Variable '{}' not set in environment '{}'.",
+                    name,
+                    env_name
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// `soroban-registry env list [--env <env>] [--all] [--merged] [--json]`
+pub fn list_vars(env: Option<&str>, all: bool, merged: bool, json: bool) -> Result<()> {
+    let store = load_store()?;
+
+    if all {
+        // Print every environment.
+        if json {
+            println!("{}", serde_json::to_string_pretty(&store.environments)?);
+        } else {
+            print_all_envs(&store);
+        }
+        return Ok(());
+    }
+
+    let env_name = resolve_env_name(&store, env);
+    let environment = store.environments.get(env_name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Environment '{}' does not exist.",
+            env_name
+        )
+    })?;
+
+    let vars = if merged {
+        merged_vars(environment)
+    } else {
+        environment.vars.clone()
+    };
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "environment": env_name,
+                "active": store.active == env_name,
+                "vars": vars
+            }))?
+        );
+    } else {
+        print_env_table(env_name, &vars, store.active == env_name, merged);
+    }
+
+    Ok(())
+}
+
+/// `soroban-registry env copy --from <src> --to <dst> [--overwrite]`
+pub fn copy_env(from: &str, to: &str, overwrite: bool) -> Result<()> {
+    validate_env_name(from)?;
+    validate_env_name(to)?;
+
+    let mut store = load_store()?;
+
+    let source = store.environments.get(from).ok_or_else(|| {
+        anyhow::anyhow!("Source environment '{}' does not exist.", from)
+    })?.clone();
+
+    if store.environments.contains_key(to) && !overwrite {
+        anyhow::bail!(
+            "Environment '{}' already exists. Use --overwrite to replace it.",
+            to
+        );
+    }
+
+    let count = source.vars.len();
+    store.environments.insert(to.to_string(), source);
+    save_store(&store)?;
+
+    println!();
+    println!(
+        "  {} Copied {} variable{} from {} to {}",
+        "✔".green().bold(),
+        count,
+        if count == 1 { "" } else { "s" },
+        from.bright_blue(),
+        to.bright_blue()
+    );
+    println!();
+    Ok(())
+}
+
+/// `soroban-registry env delete <NAME> [--env <env>]`
+/// If NAME equals an environment name (and --env-delete is set), delete the whole environment.
+pub fn delete_var(name: &str, env: Option<&str>) -> Result<()> {
+    validate_var_name(name)?;
+
+    let mut store = load_store()?;
+    let env_name = resolve_env_name(&store, env).to_string();
+
+    let environment = store
+        .environments
+        .get_mut(&env_name)
+        .ok_or_else(|| anyhow::anyhow!("Environment '{}' does not exist.", env_name))?;
+
+    if environment.vars.remove(name).is_none() {
+        anyhow::bail!(
+            "Variable '{}' not set in environment '{}'.",
+            name,
+            env_name
+        );
+    }
+
+    save_store(&store)?;
+
+    println!();
+    println!(
+        "  {} {} removed from {}",
+        "✔".green().bold(),
+        name.bold(),
+        env_name.bright_blue()
+    );
+    println!();
+    Ok(())
+}
+
+/// `soroban-registry env export [--env <env>] [--format shell|json|dotenv] [--merged]`
+pub fn export_env(env: Option<&str>, format: &str, merged: bool) -> Result<()> {
+    let store = load_store()?;
+    let env_name = resolve_env_name(&store, env);
+
+    let environment = store.environments.get(env_name).ok_or_else(|| {
+        anyhow::anyhow!("Environment '{}' does not exist.", env_name)
+    })?;
+
+    let vars = if merged {
+        merged_vars(environment)
+    } else {
+        environment.vars.clone()
+    };
+
+    match format {
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "environment": env_name,
+                    "vars": vars
+                }))?
+            );
+        }
+        "dotenv" | ".env" => {
+            println!("# soroban-registry env: {}", env_name);
+            for (k, v) in &vars {
+                // .env format: KEY=VALUE (no quoting needed, raw)
+                println!("{}={}", k, v);
+            }
+        }
+        _ => {
+            // Default: shell (bash/zsh sourceable)
+            println!("# soroban-registry env: {} — source this file to activate", env_name);
+            println!("# Generated: {}", chrono::Utc::now().to_rfc3339());
+            println!();
+            for (k, v) in &vars {
+                println!("export {}={}", k, shell_escape(v));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// `soroban-registry env switch <env>`
+pub fn switch_env(env_name: &str) -> Result<()> {
+    validate_env_name(env_name)?;
+
+    let mut store = load_store()?;
+
+    if !store.environments.contains_key(env_name) {
+        anyhow::bail!(
+            "Environment '{}' does not exist. Create it first with:\n\
+             soroban-registry env set <NAME> <VALUE> --env {}",
+            env_name,
+            env_name
+        );
+    }
+
+    let previous = store.active.clone();
+    store.active = env_name.to_string();
+    save_store(&store)?;
+
+    println!();
+    println!(
+        "  {} Switched from {} to {}",
+        "✔".green().bold(),
+        previous.bright_black(),
+        env_name.bright_blue().bold()
+    );
+
+    let env = store.environments.get(env_name).unwrap();
+    if env.vars.is_empty() {
+        println!("  {} This environment has no variables set.", "·".dimmed());
+    } else {
+        println!(
+            "  {} {} variable{} active.",
+            "·".dimmed(),
+            env.vars.len(),
+            if env.vars.len() == 1 { "" } else { "s" }
+        );
+    }
+    println!();
+    Ok(())
+}
+
+// ── Formatting ────────────────────────────────────────────────────────────────
+
+fn print_env_table(
+    env_name: &str,
+    vars: &BTreeMap<String, String>,
+    is_active: bool,
+    is_merged: bool,
+) {
+    println!();
+    let active_tag = if is_active {
+        " (active)".green().bold().to_string()
+    } else {
+        String::new()
+    };
+    let merged_tag = if is_merged { " [merged]" } else { "" };
+    println!(
+        "{}  {}{}{}",
+        "Environment:".bold().cyan(),
+        env_name.bright_blue().bold(),
+        active_tag,
+        merged_tag.dimmed()
+    );
+    println!("{}", "═".repeat(60).cyan());
+
+    if vars.is_empty() {
+        println!("  {}", "No variables set.".dimmed());
+    } else {
+        println!(
+            "  {:<40} {}",
+            "Variable".bold(),
+            "Value".bold()
+        );
+        println!("  {}", "─".repeat(56).dimmed());
+        for (k, v) in vars {
+            let display_value = if v.len() > 50 {
+                format!("{}…", &v[..47])
+            } else {
+                v.clone()
+            };
+            println!("  {:<40} {}", k.cyan(), display_value.dimmed());
+        }
+    }
+
+    println!("{}", "═".repeat(60).cyan());
+    println!();
+}
+
+fn print_all_envs(store: &Environments) {
+    println!();
+    println!("{}", "Environments".bold().cyan());
+    println!("{}", "═".repeat(60).cyan());
+
+    if store.environments.is_empty() {
+        println!("  {}", "No environments configured.".dimmed());
+    } else {
+        for (name, env) in &store.environments {
+            let active_marker = if *name == store.active {
+                " ◀ active".green().bold().to_string()
+            } else {
+                String::new()
+            };
+            println!(
+                "  {} {}  ({} var{})",
+                "·".dimmed(),
+                name.bright_blue().bold(),
+                env.vars.len(),
+                if env.vars.len() == 1 { "" } else { "s" }
+            );
+            print!("    {}", active_marker);
+            println!();
+        }
+    }
+
+    println!("{}", "═".repeat(60).cyan());
+    println!();
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,6 +18,7 @@ mod conversions;
 mod coverage;
 mod dashboard;
 mod deploy;
+mod env;
 mod events;
 mod export;
 mod formal_verification;
@@ -860,6 +861,12 @@ pub enum Commands {
     },
 
     /// External command (may be provided by an installed plugin)
+    /// Manage environment variable sets for different deployments (#843)
+    Env {
+        #[command(subcommand)]
+        action: EnvCommands,
+    },
+
     #[command(external_subcommand)]
     External(Vec<String>),
 }
@@ -1474,6 +1481,104 @@ pub enum ContractCommands {
         /// Output results as machine-readable JSON
         #[arg(long)]
         json: bool,
+    },
+}
+
+/// Sub-commands for the `env` group (#843)
+#[derive(Debug, Subcommand)]
+pub enum EnvCommands {
+    /// Set a variable in an environment
+    ///
+    /// Usage: soroban-registry env set <NAME> <VALUE> [--env <environment>]
+    Set {
+        /// Variable name (shell identifier: letters, digits, underscores)
+        name: String,
+        /// Value to assign
+        value: String,
+        /// Target environment (defaults to the active environment)
+        #[arg(long)]
+        env: Option<String>,
+    },
+
+    /// Get a variable's value from an environment
+    ///
+    /// Usage: soroban-registry env get <NAME> [--env <environment>] [--json]
+    Get {
+        /// Variable name to look up
+        name: String,
+        /// Source environment (defaults to the active environment)
+        #[arg(long)]
+        env: Option<String>,
+        /// Output as machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List variables in an environment
+    ///
+    /// Usage: soroban-registry env list [--env <environment>] [--all] [--merged] [--json]
+    List {
+        /// Environment to list (defaults to the active environment)
+        #[arg(long)]
+        env: Option<String>,
+        /// List variables in every environment
+        #[arg(long)]
+        all: bool,
+        /// Merge global config defaults into the output
+        #[arg(long)]
+        merged: bool,
+        /// Output as machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Copy all variables from one environment to another
+    ///
+    /// Usage: soroban-registry env copy --from <src> --to <dst>
+    Copy {
+        /// Source environment name
+        #[arg(long)]
+        from: String,
+        /// Destination environment name
+        #[arg(long)]
+        to: String,
+        /// Overwrite the destination if it already exists
+        #[arg(long)]
+        overwrite: bool,
+    },
+
+    /// Delete a variable from an environment
+    ///
+    /// Usage: soroban-registry env delete <NAME> [--env <environment>]
+    Delete {
+        /// Variable name to remove
+        name: String,
+        /// Source environment (defaults to the active environment)
+        #[arg(long)]
+        env: Option<String>,
+    },
+
+    /// Export environment variables as a shell-sourceable file
+    ///
+    /// Usage: soroban-registry env export [--env <environment>] [--format shell|json|dotenv]
+    Export {
+        /// Environment to export (defaults to the active environment)
+        #[arg(long)]
+        env: Option<String>,
+        /// Output format: shell (default), json, dotenv
+        #[arg(long, default_value = "shell")]
+        format: String,
+        /// Merge global config defaults into the export
+        #[arg(long)]
+        merged: bool,
+    },
+
+    /// Switch the active environment
+    ///
+    /// Usage: soroban-registry env switch <ENVIRONMENT>
+    Switch {
+        /// Environment name to activate
+        environment: String,
     },
 }
 
@@ -3026,6 +3131,71 @@ pub async fn dispatch_command(
             )
             .await?;
         }
+        // ── Environment variable management (#843) ───────────────────────────
+        Commands::Env { action } => match action {
+            EnvCommands::Set { name, value, env } => {
+                log::debug!(
+                    "Command: env set | name={} env={:?}",
+                    name,
+                    env
+                );
+                env::set_var(&name, &value, env.as_deref())?;
+            }
+            EnvCommands::Get { name, env, json } => {
+                log::debug!(
+                    "Command: env get | name={} env={:?} json={}",
+                    name,
+                    env,
+                    json
+                );
+                env::get_var(&name, env.as_deref(), json)?;
+            }
+            EnvCommands::List {
+                env,
+                all,
+                merged,
+                json,
+            } => {
+                log::debug!(
+                    "Command: env list | env={:?} all={} merged={} json={}",
+                    env,
+                    all,
+                    merged,
+                    json
+                );
+                env::list_vars(env.as_deref(), all, merged, json)?;
+            }
+            EnvCommands::Copy { from, to, overwrite } => {
+                log::debug!(
+                    "Command: env copy | from={} to={} overwrite={}",
+                    from,
+                    to,
+                    overwrite
+                );
+                env::copy_env(&from, &to, overwrite)?;
+            }
+            EnvCommands::Delete { name, env } => {
+                log::debug!(
+                    "Command: env delete | name={} env={:?}",
+                    name,
+                    env
+                );
+                env::delete_var(&name, env.as_deref())?;
+            }
+            EnvCommands::Export { env, format, merged } => {
+                log::debug!(
+                    "Command: env export | env={:?} format={} merged={}",
+                    env,
+                    format,
+                    merged
+                );
+                env::export_env(env.as_deref(), &format, merged)?;
+            }
+            EnvCommands::Switch { environment } => {
+                log::debug!("Command: env switch | environment={}", environment);
+                env::switch_env(&environment)?;
+            }
+        },
     }
 
     Ok(())


### PR DESCRIPTION
Closes #843

---

## What changed

Adds `soroban-registry env` with seven subcommands for managing environment-specific variable sets.

### New files
- `cli/src/env.rs` — full implementation (582 lines)

### Modified files
- `cli/src/main.rs` — adds `mod env`, `Env` variant in `Commands`, `EnvCommands` enum, dispatch arm

## Subcommands

| Command | Description |
|---|---|
| `env set <NAME> <VALUE> [--env <env>]` | Set a variable; validates shell identifier rules |
| `env get <NAME> [--env <env>] [--json]` | Get a variable's value; shows source (env vs global) |
| `env list [--env <env>] [--all] [--merged] [--json]` | List variables; `--all` covers every environment; `--merged` includes global config fallbacks |
| `env copy --from <src> --to <dst> [--overwrite]` | Copy all vars between environments |
| `env delete <NAME> [--env <env>]` | Remove a variable from an environment |
| `env export [--env <env>] [--format shell\|json\|dotenv] [--merged]` | Shell-sourceable export; pipe to `source` to activate |
| `env switch <ENVIRONMENT>` | Set the active environment for subsequent commands |

## Storage

Variables are stored in `~/.soroban-registry/environments.json`. Three environments (`dev`, `staging`, `production`) are pre-populated with sensible defaults on first run.

## Merge with global config

`--merged` on `list` and `export` layers:
1. Global config defaults (`SOROBAN_REGISTRY_API_KEY`, `SOROBAN_DEFAULT_NETWORK`)
2. Environment-specific vars (override)

## Validation

- Variable names: `[a-zA-Z_][a-zA-Z0-9_]*`
- Environment names: letters, digits, hyphens, underscores
- Shell export values are single-quoted with embedded single-quote escaping

## Test plan

- [ ] `soroban-registry env list --all` — three starter environments shown
- [ ] `soroban-registry env set MY_VAR hello --env dev` — variable stored
- [ ] `soroban-registry env get MY_VAR --env dev` — prints `hello`
- [ ] `soroban-registry env get MY_VAR --env dev --json` — valid JSON
- [ ] `soroban-registry env list --env dev` — table with MY_VAR
- [ ] `soroban-registry env list --env dev --merged` — includes global config defaults
- [ ] `soroban-registry env copy --from dev --to test` — vars copied
- [ ] `soroban-registry env copy --from dev --to test` — fails without --overwrite
- [ ] `soroban-registry env delete MY_VAR --env dev` — removed
- [ ] `soroban-registry env export --env dev` — valid `export KEY='VALUE'` lines
- [ ] `soroban-registry env export --env dev --format json` — valid JSON
- [ ] `soroban-registry env export --env dev --format dotenv` — `KEY=VALUE` lines
- [ ] `source <(soroban-registry env export --env dev)` — activates vars in shell
- [ ] `soroban-registry env switch staging` — active environment updated
- [ ] `soroban-registry env set BAD-VAR x` — validation error on name
- [ ] `soroban-registry env --help` — all subcommands listed