### PR TITLE
feat(cli): api-key, contract highlight/interaction/dependency commands

### DIFF
--- a/cli/src/api_key.rs
+++ b/cli/src/api_key.rs
@@ -1,0 +1,114 @@
+//! api_key.rs — `soroban-registry api-key [create|list|delete|revoke]` (#842)
+//!
+//! CLI-based API key management for programmatic / automation access. Keys are
+//! created with optional expiry and scopes, listed, deleted, and revoked
+//! against the registry's `/api/api-keys` endpoints.
+
+use crate::net::RequestBuilderExt;
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde_json::{json, Value};
+
+fn base(api_url: &str) -> String {
+    format!("{}/api/api-keys", api_url.trim_end_matches('/'))
+}
+
+/// `soroban-registry api-key create [--expires <when>] [--scopes a,b,c] [--json]`
+pub async fn create(api_url: &str, expires: Option<&str>, scopes: Option<&str>, json: bool) -> Result<()> {
+    let client = crate::net::client();
+    let scope_list: Vec<String> = scopes
+        .map(|s| s.split(',').map(|p| p.trim().to_string()).filter(|p| !p.is_empty()).collect())
+        .unwrap_or_default();
+
+    let body = json!({ "expires": expires, "scopes": scope_list });
+    let resp = client
+        .post(base(api_url))
+        .json(&body)
+        .send_with_retry()
+        .await
+        .context("Failed to reach the registry API. Is the registry running?")?;
+
+    let status = resp.status();
+    let value: Value = resp.json().await.unwrap_or(Value::Null);
+    if !status.is_success() {
+        anyhow::bail!("api-key create failed ({}): {}", status, value);
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+    println!("{} API key created", "✓".green().bold());
+    if let Some(key) = value.get("key").and_then(Value::as_str) {
+        println!("  key:     {}", key.yellow());
+        println!("  {}", "store this now — it will not be shown again".dimmed());
+    }
+    if let Some(id) = value.get("id").and_then(Value::as_str) {
+        println!("  id:      {}", id);
+    }
+    if let Some(exp) = value.get("expiresAt").and_then(Value::as_str) {
+        println!("  expires: {}", exp);
+    }
+    Ok(())
+}
+
+/// `soroban-registry api-key list [--json]`
+pub async fn list(api_url: &str, json: bool) -> Result<()> {
+    let client = crate::net::client();
+    let resp = client
+        .get(base(api_url))
+        .send_with_retry()
+        .await
+        .context("Failed to reach the registry API. Is the registry running?")?;
+    let status = resp.status();
+    let value: Value = resp.json().await.unwrap_or(Value::Null);
+    if !status.is_success() {
+        anyhow::bail!("api-key list failed ({}): {}", status, value);
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+    let keys = value.get("keys").and_then(Value::as_array).cloned().unwrap_or_default();
+    if keys.is_empty() {
+        println!("{}", "No API keys.".dimmed());
+        return Ok(());
+    }
+    println!("{}", "API keys:".bold());
+    for k in keys {
+        let id = k.get("id").and_then(Value::as_str).unwrap_or("?");
+        let scopes = k.get("scopes").and_then(Value::as_array)
+            .map(|a| a.iter().filter_map(Value::as_str).collect::<Vec<_>>().join(","))
+            .unwrap_or_default();
+        let status = k.get("status").and_then(Value::as_str).unwrap_or("active");
+        let last_used = k.get("lastUsedAt").and_then(Value::as_str).unwrap_or("never");
+        println!("  {}  [{}]  scopes=[{}]  last_used={}", id, status, scopes, last_used);
+    }
+    Ok(())
+}
+
+/// `soroban-registry api-key delete <id>` / `revoke <id>`
+pub async fn delete(api_url: &str, id: &str, revoke_only: bool, json: bool) -> Result<()> {
+    let client = crate::net::client();
+    let url = format!("{}/{}", base(api_url), id);
+    let resp = if revoke_only {
+        // Revoke disables the key but keeps the audit record.
+        client.post(format!("{}/revoke", url)).send_with_retry().await
+    } else {
+        client.delete(&url).send_with_retry().await
+    }
+    .context("Failed to reach the registry API. Is the registry running?")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let value: Value = resp.json().await.unwrap_or(Value::Null);
+        anyhow::bail!("api-key {} failed ({}): {}", if revoke_only { "revoke" } else { "delete" }, status, value);
+    }
+    if json {
+        println!("{}", json!({ "id": id, "action": if revoke_only { "revoked" } else { "deleted" } }));
+    } else {
+        println!("{} API key {} {}", "✓".green().bold(), id, if revoke_only { "revoked" } else { "deleted" });
+    }
+    Ok(())
+}

--- a/cli/src/contract_dependency.rs
+++ b/cli/src/contract_dependency.rs
@@ -1,0 +1,75 @@
+//! contract_dependency.rs — `soroban-registry contract dependency <ADDRESS>` (#836)
+//!
+//! Analyze a contract's dependencies: contracts it depends on, contracts that
+//! depend on it, and a dependency tree with a configurable `--depth`.
+
+use crate::net::RequestBuilderExt;
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde_json::Value;
+
+/// `soroban-registry contract dependency <ADDRESS> [--depth N] [--json]`
+pub async fn run(api_url: &str, address: &str, depth: u32, json: bool) -> Result<()> {
+    let client = crate::net::client();
+    let url = format!(
+        "{}/api/contracts/{}/dependencies?depth={}",
+        api_url.trim_end_matches('/'),
+        address,
+        depth
+    );
+    log::debug!("GET {}", url);
+
+    let resp = client
+        .get(&url)
+        .send_with_retry()
+        .await
+        .context("Failed to reach the registry API. Is the registry running?")?;
+    let status = resp.status();
+    let value: Value = resp.json().await.unwrap_or(Value::Null);
+    if status.as_u16() == 404 {
+        anyhow::bail!("no dependency data found for {}", address);
+    }
+    if !status.is_success() {
+        anyhow::bail!("contract dependency failed ({}): {}", status, value);
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+
+    println!("{} {}", "Dependencies for".bold(), address.cyan());
+
+    let depends_on = value.get("dependsOn").and_then(Value::as_array).cloned().unwrap_or_default();
+    println!("\n  {} ({})", "Depends on:".bold(), depends_on.len());
+    for d in &depends_on {
+        let addr = d.get("address").and_then(Value::as_str).unwrap_or("?");
+        let name = d.get("name").and_then(Value::as_str).unwrap_or("");
+        println!("    → {} {}", addr.cyan(), name.dimmed());
+    }
+
+    let dependents = value.get("dependents").and_then(Value::as_array).cloned().unwrap_or_default();
+    println!("\n  {} ({})", "Depended on by:".bold(), dependents.len());
+    for d in &dependents {
+        let addr = d.get("address").and_then(Value::as_str).unwrap_or("?");
+        let name = d.get("name").and_then(Value::as_str).unwrap_or("");
+        println!("    ← {} {}", addr.cyan(), name.dimmed());
+    }
+
+    if let Some(tree) = value.get("tree") {
+        println!("\n  {} (depth {})", "Dependency tree:".bold(), depth);
+        print_tree(tree, 0);
+    }
+    Ok(())
+}
+
+fn print_tree(node: &Value, indent: usize) {
+    let pad = "  ".repeat(indent + 2);
+    let addr = node.get("address").and_then(Value::as_str).unwrap_or("?");
+    println!("{}{}", pad, addr);
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for child in children {
+            print_tree(child, indent + 1);
+        }
+    }
+}

--- a/cli/src/contract_highlight.rs
+++ b/cli/src/contract_highlight.rs
@@ -1,0 +1,91 @@
+//! contract_highlight.rs — `soroban-registry contract highlight [ADDRESS]` (#832)
+//!
+//! Manage featured/highlighted contracts in the registry. Supports the
+//! actions add | remove | list | check against `/api/contracts/highlights`.
+//! Mutating actions require curator authentication (sent as a bearer token).
+
+use crate::net::RequestBuilderExt;
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde_json::{json, Value};
+
+fn highlights_url(api_url: &str) -> String {
+    format!("{}/api/contracts/highlights", api_url.trim_end_matches('/'))
+}
+
+/// `soroban-registry contract highlight [ADDRESS] --action <add|remove|list|check> [--token <t>] [--json]`
+pub async fn run(
+    api_url: &str,
+    address: Option<&str>,
+    action: &str,
+    token: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let client = crate::net::client();
+    let base = highlights_url(api_url);
+
+    let resp = match action {
+        "list" => client.get(&base).send_with_retry().await,
+        "check" => {
+            let addr = address.context("`check` requires a contract ADDRESS")?;
+            client.get(format!("{}/{}", base, addr)).send_with_retry().await
+        }
+        "add" => {
+            let addr = address.context("`add` requires a contract ADDRESS")?;
+            let mut req = client.post(&base).json(&json!({ "address": addr }));
+            if let Some(t) = token {
+                req = req.bearer_auth(t);
+            }
+            req.send_with_retry().await
+        }
+        "remove" => {
+            let addr = address.context("`remove` requires a contract ADDRESS")?;
+            let mut req = client.delete(format!("{}/{}", base, addr));
+            if let Some(t) = token {
+                req = req.bearer_auth(t);
+            }
+            req.send_with_retry().await
+        }
+        other => anyhow::bail!("unknown highlight action '{}' (use add|remove|list|check)", other),
+    }
+    .context("Failed to reach the registry API. Is the registry running?")?;
+
+    let status = resp.status();
+    let value: Value = resp.json().await.unwrap_or(Value::Null);
+    if !status.is_success() {
+        anyhow::bail!("contract highlight {} failed ({}): {}", action, status, value);
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+
+    match action {
+        "list" => {
+            let items = value.get("highlights").and_then(Value::as_array).cloned().unwrap_or_default();
+            if items.is_empty() {
+                println!("{}", "No highlighted contracts.".dimmed());
+            } else {
+                println!("{}", "Highlighted contracts:".bold());
+                for it in items {
+                    let addr = it.get("address").and_then(Value::as_str).unwrap_or("?");
+                    let since = it.get("highlightedAt").and_then(Value::as_str).unwrap_or("");
+                    println!("  {}  {}", addr.cyan(), since.dimmed());
+                }
+            }
+        }
+        "check" => {
+            let on = value.get("highlighted").and_then(Value::as_bool).unwrap_or(false);
+            println!(
+                "{} {}",
+                address.unwrap_or(""),
+                if on { "is highlighted".green() } else { "is not highlighted".dimmed() }
+            );
+        }
+        "add" => println!("{} highlighted {}", "✓".green().bold(), address.unwrap_or("")),
+        "remove" => println!("{} removed highlight for {}", "✓".green().bold(), address.unwrap_or("")),
+        _ => {}
+    }
+    Ok(())
+}

--- a/cli/src/contract_interaction.rs
+++ b/cli/src/contract_interaction.rs
@@ -1,0 +1,79 @@
+//! contract_interaction.rs — `soroban-registry contract interaction <ADDRESS>` (#835)
+//!
+//! View and analyze a contract's interactions: recent calls with timestamps,
+//! caller frequency, function-call distribution, and success/error rates.
+
+use crate::net::RequestBuilderExt;
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde_json::Value;
+
+/// `soroban-registry contract interaction <ADDRESS> [--limit N] [--json]`
+pub async fn run(api_url: &str, address: &str, limit: u32, json: bool) -> Result<()> {
+    let client = crate::net::client();
+    let url = format!(
+        "{}/api/contracts/{}/interactions?limit={}",
+        api_url.trim_end_matches('/'),
+        address,
+        limit
+    );
+    log::debug!("GET {}", url);
+
+    let resp = client
+        .get(&url)
+        .send_with_retry()
+        .await
+        .context("Failed to reach the registry API. Is the registry running?")?;
+    let status = resp.status();
+    let value: Value = resp.json().await.unwrap_or(Value::Null);
+    if status.as_u16() == 404 {
+        anyhow::bail!("no interaction data found for {}", address);
+    }
+    if !status.is_success() {
+        anyhow::bail!("contract interaction failed ({}): {}", status, value);
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+
+    println!("{} {}", "Interactions for".bold(), address.cyan());
+
+    if let Some(total) = value.get("totalCalls").and_then(Value::as_u64) {
+        let success = value.get("successRate").and_then(Value::as_f64).unwrap_or(0.0);
+        println!("  total calls: {}   success rate: {:.1}%", total, success * 100.0);
+    }
+
+    if let Some(recent) = value.get("recent").and_then(Value::as_array) {
+        println!("\n  {}", "Recent:".bold());
+        for it in recent.iter().take(limit as usize) {
+            let func = it.get("function").and_then(Value::as_str).unwrap_or("?");
+            let caller = it.get("caller").and_then(Value::as_str).unwrap_or("?");
+            let when = it.get("timestamp").and_then(Value::as_str).unwrap_or("");
+            let ok = it.get("success").and_then(Value::as_bool).unwrap_or(true);
+            let mark = if ok { "✓".green() } else { "✗".red() };
+            println!("    {} {}  {}  {}", mark, func, caller.dimmed(), when.dimmed());
+        }
+    }
+
+    if let Some(dist) = value.get("functionDistribution").and_then(Value::as_object) {
+        println!("\n  {}", "Function call distribution:".bold());
+        let mut rows: Vec<(&String, u64)> =
+            dist.iter().map(|(k, v)| (k, v.as_u64().unwrap_or(0))).collect();
+        rows.sort_by(|a, b| b.1.cmp(&a.1));
+        for (func, count) in rows {
+            println!("    {:>6}  {}", count, func);
+        }
+    }
+
+    if let Some(callers) = value.get("topCallers").and_then(Value::as_array) {
+        println!("\n  {}", "Top callers:".bold());
+        for c in callers {
+            let addr = c.get("caller").and_then(Value::as_str).unwrap_or("?");
+            let count = c.get("count").and_then(Value::as_u64).unwrap_or(0);
+            println!("    {:>6}  {}", count, addr.dimmed());
+        }
+    }
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,6 +12,10 @@ mod codegen;
 mod commands;
 mod compare;
 mod config;
+mod api_key;
+mod contract_dependency;
+mod contract_highlight;
+mod contract_interaction;
 mod contract_verify;
 mod contracts;
 mod conversions;
@@ -753,6 +757,13 @@ pub enum Commands {
         action: ContractCommands,
     },
 
+    /// Manage API keys for programmatic access (#842)
+    #[command(name = "api-key")]
+    ApiKey {
+        #[command(subcommand)]
+        action: ApiKeyCommands,
+    },
+
     /// Verify multiple contracts in a single atomic batch (all succeed or all rollback)
     BatchVerify {
         /// Comma-separated list of contract IDs to verify.
@@ -1472,6 +1483,79 @@ pub enum ContractCommands {
         network: String,
 
         /// Output results as machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Manage featured (highlighted) contracts (#832)
+    ///
+    /// Usage: soroban-registry contract highlight [ADDRESS] --action <add|remove|list|check>
+    Highlight {
+        /// Contract address (required for add/remove/check)
+        address: Option<String>,
+        /// Action to perform: add | remove | list | check
+        #[arg(long, default_value = "list")]
+        action: String,
+        /// Curator bearer token for mutating actions (add/remove)
+        #[arg(long)]
+        token: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// View a contract's interactions and call patterns (#835)
+    Interaction {
+        /// On-chain contract address
+        address: String,
+        /// Max number of recent interactions to display
+        #[arg(long, default_value_t = 20)]
+        limit: u32,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Analyze a contract's dependencies and relationships (#836)
+    Dependency {
+        /// On-chain contract address
+        address: String,
+        /// Dependency tree depth
+        #[arg(long, default_value_t = 1)]
+        depth: u32,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// Sub-commands for the `api-key` group (#842)
+#[derive(Debug, Subcommand)]
+pub enum ApiKeyCommands {
+    /// Create a new API key
+    Create {
+        /// Expiry (ISO date or duration, e.g. 2026-12-31 or 30d)
+        #[arg(long)]
+        expires: Option<String>,
+        /// Comma-separated scopes / permissions
+        #[arg(long)]
+        scopes: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// List your API keys
+    List {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Permanently delete an API key
+    Delete {
+        /// API key id
+        id: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Revoke (disable) an API key without deleting its audit record
+    Revoke {
+        /// API key id
+        id: String,
         #[arg(long)]
         json: bool,
     },
@@ -2836,6 +2920,60 @@ pub async fn dispatch_command(
                     json
                 );
                 contracts::run_details(&cli.api_url, &address, &network, json).await?;
+            }
+            ContractCommands::Highlight {
+                address,
+                action,
+                token,
+                json,
+            } => {
+                log::debug!("Command: contract highlight | action={}", action);
+                contract_highlight::run(
+                    &cli.api_url,
+                    address.as_deref(),
+                    &action,
+                    token.as_deref(),
+                    json,
+                )
+                .await?;
+            }
+            ContractCommands::Interaction {
+                address,
+                limit,
+                json,
+            } => {
+                log::debug!("Command: contract interaction | address={}", address);
+                contract_interaction::run(&cli.api_url, &address, limit, json).await?;
+            }
+            ContractCommands::Dependency {
+                address,
+                depth,
+                json,
+            } => {
+                log::debug!("Command: contract dependency | address={} depth={}", address, depth);
+                contract_dependency::run(&cli.api_url, &address, depth, json).await?;
+            }
+        },
+        Commands::ApiKey { action } => match action {
+            ApiKeyCommands::Create {
+                expires,
+                scopes,
+                json,
+            } => {
+                log::debug!("Command: api-key create");
+                api_key::create(&cli.api_url, expires.as_deref(), scopes.as_deref(), json).await?;
+            }
+            ApiKeyCommands::List { json } => {
+                log::debug!("Command: api-key list");
+                api_key::list(&cli.api_url, json).await?;
+            }
+            ApiKeyCommands::Delete { id, json } => {
+                log::debug!("Command: api-key delete | id={}", id);
+                api_key::delete(&cli.api_url, &id, false, json).await?;
+            }
+            ApiKeyCommands::Revoke { id, json } => {
+                log::debug!("Command: api-key revoke | id={}", id);
+                api_key::delete(&cli.api_url, &id, true, json).await?;
             }
         },
         // ── Release Notes commands ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
Four new `soroban-registry` CLI commands, each wired into the existing clap command enum + dispatch and following the established `net::client()` + `send_with_retry()` handler pattern (anyhow `Result`, `colored` output, `--json` mode).

closes #842
closes #832
closes #835
closes #836

- **#842 `api-key [create|list|delete|revoke]`** — create (with `--expires`, `--scopes`), list (id/status/scopes/last-used), delete, and revoke (disable but keep audit record).
- **#832 `contract highlight [ADDRESS]`** — `--action add|remove|list|check`; mutating actions take a curator `--token` (bearer auth).
- **#835 `contract interaction <ADDRESS>`** — recent interactions, top callers, function-call distribution, success rate (`--limit`).
- **#836 `contract dependency <ADDRESS>`** — depends-on, dependents, and a dependency tree with `--depth`.

Each handler calls the corresponding `/api/...` registry endpoint; where a backend endpoint is new, that's a server-side follow-up — the CLI surface + flags are complete per the issues.
