### PR TITLE
 Backend: DB query monitoring, table partitioning, data archival, and enhanced Elasticsearch search

### DIFF
--- a/backend/api/src/archival.rs
+++ b/backend/api/src/archival.rs
@@ -1,0 +1,411 @@
+// Issue #881: Data archival and cleanup strategy for old records.
+//
+// Provides handlers for inspecting archival policies and run history,
+// triggering ad-hoc archival jobs, and restoring individual archived records.
+// The background task runs archival on a configurable schedule.
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::time::Duration;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct ArchivalPolicy {
+    pub id: i64,
+    pub data_type: String,
+    pub source_table: String,
+    pub retention_days: i32,
+    pub archive_storage: String,
+    pub is_enabled: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct ArchivalRun {
+    pub id: i64,
+    pub policy_id: Option<i64>,
+    pub data_type: String,
+    pub status: String,
+    pub rows_archived: i64,
+    pub rows_deleted: i64,
+    pub error_message: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct ArchivalAuditEntry {
+    pub id: i64,
+    pub run_id: Option<i64>,
+    pub source_table: String,
+    pub source_id: String,
+    pub archive_ref: Option<String>,
+    pub archived_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArchivalStatus {
+    pub policies: Vec<ArchivalPolicy>,
+    pub recent_runs: Vec<ArchivalRun>,
+    pub total_archived: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TriggerArchivalRequest {
+    pub data_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RestoreRequest {
+    pub source_table: String,
+    pub source_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdatePolicyRequest {
+    pub retention_days: Option<i32>,
+    pub is_enabled: Option<bool>,
+    pub archive_storage: Option<String>,
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// GET /api/admin/archival/status
+pub async fn get_archival_status(
+    State(state): State<AppState>,
+) -> Result<Json<ArchivalStatus>, ApiError> {
+    let policies = sqlx::query_as::<_, ArchivalPolicy>(
+        "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at FROM archival_policies ORDER BY data_type",
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("ARCHIVAL_STATUS_ERROR", e.to_string()))?;
+
+    let recent_runs = sqlx::query_as::<_, ArchivalRun>(
+        r#"
+        SELECT id, policy_id, data_type, status, rows_archived, rows_deleted,
+               error_message, started_at, completed_at
+        FROM archival_runs
+        ORDER BY started_at DESC
+        LIMIT 20
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let total_archived: i64 =
+        sqlx::query_scalar("SELECT COALESCE(SUM(rows_archived), 0) FROM archival_runs WHERE status = 'completed'")
+            .fetch_one(&state.db)
+            .await
+            .unwrap_or(0);
+
+    Ok(Json(ArchivalStatus {
+        policies,
+        recent_runs,
+        total_archived,
+    }))
+}
+
+/// GET /api/admin/archival/policies
+pub async fn get_archival_policies(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<ArchivalPolicy>>, ApiError> {
+    let rows = sqlx::query_as::<_, ArchivalPolicy>(
+        "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at FROM archival_policies ORDER BY data_type",
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("POLICY_LIST_ERROR", e.to_string()))?;
+
+    Ok(Json(rows))
+}
+
+/// PATCH /api/admin/archival/policies/:data_type
+pub async fn update_archival_policy(
+    State(state): State<AppState>,
+    Path(data_type): Path<String>,
+    Json(req): Json<UpdatePolicyRequest>,
+) -> Result<Json<ArchivalPolicy>, ApiError> {
+    let row = sqlx::query_as::<_, ArchivalPolicy>(
+        r#"
+        UPDATE archival_policies
+        SET
+            retention_days  = COALESCE($1, retention_days),
+            is_enabled      = COALESCE($2, is_enabled),
+            archive_storage = COALESCE($3, archive_storage),
+            updated_at      = NOW()
+        WHERE data_type = $4
+        RETURNING id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at
+        "#,
+    )
+    .bind(req.retention_days)
+    .bind(req.is_enabled)
+    .bind(req.archive_storage)
+    .bind(&data_type)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("POLICY_UPDATE_ERROR", e.to_string()))?
+    .ok_or_else(|| ApiError::not_found("POLICY_NOT_FOUND", format!("Policy '{data_type}' not found")))?;
+
+    Ok(Json(row))
+}
+
+/// POST /api/admin/archival/run
+/// Triggers an immediate archival job.  If `data_type` is provided, only that
+/// policy is run; otherwise all enabled policies are processed.
+pub async fn trigger_archival(
+    State(state): State<AppState>,
+    Json(req): Json<TriggerArchivalRequest>,
+) -> Result<Json<Vec<ArchivalRun>>, ApiError> {
+    let policies: Vec<ArchivalPolicy> = match req.data_type {
+        Some(ref dt) => sqlx::query_as::<_, ArchivalPolicy>(
+            "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at FROM archival_policies WHERE data_type = $1 AND is_enabled = true",
+        )
+        .bind(dt)
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| ApiError::internal_error("POLICY_FETCH_ERROR", e.to_string()))?,
+        None => sqlx::query_as::<_, ArchivalPolicy>(
+            "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at FROM archival_policies WHERE is_enabled = true ORDER BY data_type",
+        )
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| ApiError::internal_error("POLICY_FETCH_ERROR", e.to_string()))?,
+    };
+
+    if policies.is_empty() {
+        return Err(ApiError::not_found(
+            "NO_ENABLED_POLICIES",
+            "No enabled archival policies found",
+        ));
+    }
+
+    let db = state.db.clone();
+    let mut runs = Vec::new();
+
+    for policy in policies {
+        let run = execute_archival_policy(&db, &policy).await;
+        runs.push(run);
+    }
+
+    Ok(Json(runs))
+}
+
+/// GET /api/admin/archival/audit-trail
+pub async fn get_archival_audit_trail(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<ArchivalAuditEntry>>, ApiError> {
+    let rows = sqlx::query_as::<_, ArchivalAuditEntry>(
+        r#"
+        SELECT id, run_id, source_table, source_id, archive_ref, archived_at
+        FROM archival_audit_trail
+        ORDER BY archived_at DESC
+        LIMIT 200
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("AUDIT_TRAIL_ERROR", e.to_string()))?;
+
+    Ok(Json(rows))
+}
+
+/// POST /api/admin/archival/restore
+/// Restores a single record from the archival_audit_trail back into the source table.
+pub async fn restore_archived_record(
+    State(state): State<AppState>,
+    Json(req): Json<RestoreRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let entry = sqlx::query(
+        "SELECT archived_data FROM archival_audit_trail WHERE source_table = $1 AND source_id = $2 ORDER BY archived_at DESC LIMIT 1",
+    )
+    .bind(&req.source_table)
+    .bind(&req.source_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("RESTORE_FETCH_ERROR", e.to_string()))?
+    .ok_or_else(|| ApiError::not_found("ARCHIVE_NOT_FOUND", "No archived record found for the given source_table/source_id"))?;
+
+    use sqlx::Row as _;
+    let data: serde_json::Value = entry.try_get("archived_data").unwrap_or(serde_json::Value::Null);
+
+    if data.is_null() {
+        return Err(ApiError::internal(
+            "Archived record has no stored data snapshot; restore not possible",
+        ));
+    }
+
+    tracing::info!(
+        source_table = %req.source_table,
+        source_id = %req.source_id,
+        "Archived record data retrieved for restore"
+    );
+
+    Ok(Json(serde_json::json!({
+        "source_table": req.source_table,
+        "source_id":    req.source_id,
+        "archived_data": data,
+        "message": "Record data returned. Re-insert into the source table to complete restore."
+    })))
+}
+
+// ── Core archival logic ───────────────────────────────────────────────────────
+
+async fn execute_archival_policy(pool: &PgPool, policy: &ArchivalPolicy) -> ArchivalRun {
+    let run_id: i64 = sqlx::query_scalar(
+        "INSERT INTO archival_runs (policy_id, data_type, status) VALUES ($1, $2, 'running') RETURNING id",
+    )
+    .bind(policy.id)
+    .bind(&policy.data_type)
+    .fetch_one(pool)
+    .await
+    .unwrap_or(0);
+
+    let cutoff = Utc::now()
+        - chrono::Duration::days(policy.retention_days as i64);
+
+    let archived = archive_rows(pool, policy, cutoff, run_id).await;
+
+    match archived {
+        Ok((rows_archived, rows_deleted)) => {
+            let _ = sqlx::query(
+                "UPDATE archival_runs SET status = 'completed', rows_archived = $1, rows_deleted = $2, completed_at = NOW() WHERE id = $3",
+            )
+            .bind(rows_archived)
+            .bind(rows_deleted)
+            .bind(run_id)
+            .execute(pool)
+            .await;
+
+            tracing::info!(
+                data_type = %policy.data_type,
+                rows_archived,
+                rows_deleted,
+                "Archival run completed"
+            );
+
+            ArchivalRun {
+                id: run_id,
+                policy_id: Some(policy.id),
+                data_type: policy.data_type.clone(),
+                status: "completed".to_string(),
+                rows_archived,
+                rows_deleted,
+                error_message: None,
+                started_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+            }
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            let _ = sqlx::query(
+                "UPDATE archival_runs SET status = 'failed', error_message = $1, completed_at = NOW() WHERE id = $2",
+            )
+            .bind(&msg)
+            .bind(run_id)
+            .execute(pool)
+            .await;
+
+            tracing::error!(
+                data_type = %policy.data_type,
+                error = %msg,
+                "Archival run failed"
+            );
+
+            ArchivalRun {
+                id: run_id,
+                policy_id: Some(policy.id),
+                data_type: policy.data_type.clone(),
+                status: "failed".to_string(),
+                rows_archived: 0,
+                rows_deleted: 0,
+                error_message: Some(msg),
+                started_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+            }
+        }
+    }
+}
+
+async fn archive_rows(
+    pool: &PgPool,
+    policy: &ArchivalPolicy,
+    cutoff: DateTime<Utc>,
+    run_id: i64,
+) -> Result<(i64, i64), sqlx::Error> {
+    // Copy eligible rows into the audit trail for restore capability
+    let archived: i64 = sqlx::query_scalar(&format!(
+        r#"
+        WITH archived AS (
+            INSERT INTO archival_audit_trail (run_id, source_table, source_id, archived_data, archived_at)
+            SELECT $1, '{table}', id::TEXT, to_jsonb({table}.*), NOW()
+            FROM {table}
+            WHERE created_at < $2
+            LIMIT 5000
+            RETURNING 1
+        )
+        SELECT COUNT(*) FROM archived
+        "#,
+        table = policy.source_table,
+    ))
+    .bind(run_id)
+    .bind(cutoff)
+    .fetch_one(pool)
+    .await
+    .unwrap_or(0);
+
+    // Delete the archived rows from the source table
+    let deleted: u64 = sqlx::query(&format!(
+        "DELETE FROM {} WHERE created_at < $1 AND id IN (SELECT source_id::BIGINT FROM archival_audit_trail WHERE run_id = $2)",
+        policy.source_table,
+    ))
+    .bind(cutoff)
+    .bind(run_id)
+    .execute(pool)
+    .await
+    .map(|r| r.rows_affected())
+    .unwrap_or(0);
+
+    Ok((archived, deleted as i64))
+}
+
+// ── Background archival task ──────────────────────────────────────────────────
+
+/// Runs archival daily at midnight UTC.
+pub fn spawn_archival_task(pool: PgPool) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(86_400));
+        loop {
+            interval.tick().await;
+
+            let policies: Vec<ArchivalPolicy> = sqlx::query_as::<_, ArchivalPolicy>(
+                "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at FROM archival_policies WHERE is_enabled = true ORDER BY data_type",
+            )
+            .fetch_all(&pool)
+            .await
+            .unwrap_or_default();
+
+            for policy in &policies {
+                let run = execute_archival_policy(&pool, policy).await;
+                if run.status == "failed" {
+                    tracing::error!(
+                        data_type = %policy.data_type,
+                        error = ?run.error_message,
+                        "Scheduled archival failed"
+                    );
+                }
+            }
+        }
+    });
+}

--- a/backend/api/src/elasticsearch_handlers.rs
+++ b/backend/api/src/elasticsearch_handlers.rs
@@ -1,0 +1,356 @@
+// Issue #880: Full-text search integration with Elasticsearch.
+//
+// Provides handlers that first attempt Elasticsearch and transparently fall
+// back to the PostgreSQL full-text search service when ES is unavailable.
+// Search events are recorded to search_analytics for popularity tracking.
+
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use shared::models::Network;
+
+use crate::error::ApiError;
+use crate::search_postgres::{SearchQuery, SearchResult};
+use crate::state::AppState;
+
+// ── Request / response types ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct ElasticsearchSearchParams {
+    pub q: Option<String>,
+    pub category: Option<String>,
+    pub network: Option<String>,
+    pub verified_only: Option<bool>,
+    pub tags: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct SearchAnalyticsRecord {
+    pub id: i64,
+    pub query_text: String,
+    pub backend: String,
+    pub result_count: i32,
+    pub took_ms: i32,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PopularTerm {
+    pub query_text: String,
+    pub search_count: i64,
+    pub avg_result_count: f64,
+    pub avg_took_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct SearchSynonym {
+    pub id: i64,
+    pub term: String,
+    pub synonyms: Vec<String>,
+    pub is_active: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpsertSynonymRequest {
+    pub term: String,
+    pub synonyms: Vec<String>,
+    pub is_active: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TrendingParams {
+    pub hours: Option<i64>,
+    pub limit: Option<i64>,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn parse_networks(network_str: &str) -> Vec<Network> {
+    network_str
+        .split(',')
+        .filter_map(|s| match s.trim() {
+            "mainnet" => Some(Network::Mainnet),
+            "testnet" => Some(Network::Testnet),
+            "futurenet" => Some(Network::Futurenet),
+            _ => None,
+        })
+        .collect()
+}
+
+async fn record_search_event(
+    pool: &sqlx::PgPool,
+    query_text: &str,
+    backend: &str,
+    result_count: i64,
+    took_ms: u64,
+) {
+    let _ = sqlx::query(
+        "INSERT INTO search_analytics (query_text, backend, result_count, took_ms) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(query_text)
+    .bind(backend)
+    .bind(result_count as i32)
+    .bind(took_ms as i32)
+    .execute(pool)
+    .await;
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// GET /api/search/elasticsearch
+/// Runs a search against Elasticsearch with facet aggregations.
+/// Falls back to PostgreSQL full-text search if ES is unavailable.
+pub async fn elasticsearch_search(
+    State(state): State<AppState>,
+    Query(params): Query<ElasticsearchSearchParams>,
+) -> Result<Json<Value>, ApiError> {
+    let query = params.q.as_deref().unwrap_or("").trim().to_string();
+    if query.is_empty() {
+        return Err(ApiError::bad_request_with(
+            "EMPTY_QUERY",
+            "Search query cannot be empty",
+        ));
+    }
+
+    let categories = params.category.as_ref().map(|c| vec![c.clone()]);
+    let networks = params
+        .network
+        .as_deref()
+        .map(parse_networks)
+        .filter(|v| !v.is_empty());
+
+    // Try Elasticsearch first
+    let es_result = state
+        .search
+        .search_contracts(&query, categories.clone(), networks.clone())
+        .await;
+
+    match es_result {
+        Ok(es_response) => {
+            // Extract result count from ES hits for analytics
+            let result_count = es_response["hits"]["total"]["value"]
+                .as_i64()
+                .unwrap_or(0);
+
+            record_search_event(&state.db, &query, "elasticsearch", result_count, 0).await;
+
+            Ok(Json(json!({
+                "backend": "elasticsearch",
+                "query":   query,
+                "results": es_response
+            })))
+        }
+        Err(es_err) => {
+            // ES unavailable — fall back to PostgreSQL
+            tracing::warn!(
+                error = %es_err,
+                query = %query,
+                "Elasticsearch unavailable, falling back to PostgreSQL search"
+            );
+
+            let search_req = SearchQuery {
+                query: query.clone(),
+                categories,
+                networks,
+                verified_only: params.verified_only,
+                tags: params
+                    .tags
+                    .as_deref()
+                    .map(|t| t.split(',').map(|s| s.to_string()).collect()),
+                limit: params.limit,
+                offset: params.offset,
+            };
+
+            let pg_result = state
+                .pg_search
+                .search(search_req)
+                .await
+                .map_err(|e| ApiError::internal_error("SEARCH_FALLBACK_ERROR", e.to_string()))?;
+
+            record_search_event(
+                &state.db,
+                &query,
+                "postgres_fallback",
+                pg_result.total,
+                pg_result.took_ms,
+            )
+            .await;
+
+            Ok(Json(json!({
+                "backend":  "postgres_fallback",
+                "query":    query,
+                "results":  pg_result
+            })))
+        }
+    }
+}
+
+/// GET /api/search/analytics
+/// Returns recent search events from search_analytics.
+pub async fn get_search_analytics(
+    State(state): State<AppState>,
+    Query(params): Query<TrendingParams>,
+) -> Result<Json<Vec<SearchAnalyticsRecord>>, ApiError> {
+    let hours = params.hours.unwrap_or(24).clamp(1, 168);
+    let limit = params.limit.unwrap_or(100).clamp(1, 500);
+
+    let rows = sqlx::query_as::<_, SearchAnalyticsRecord>(
+        r#"
+        SELECT id, query_text, backend, result_count, took_ms, created_at
+        FROM search_analytics
+        WHERE created_at >= NOW() - ($1 * INTERVAL '1 hour')
+        ORDER BY created_at DESC
+        LIMIT $2
+        "#,
+    )
+    .bind(hours as f64)
+    .bind(limit)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("ANALYTICS_FETCH_ERROR", e.to_string()))?;
+
+    Ok(Json(rows))
+}
+
+/// GET /api/search/trending
+/// Returns the most-searched terms in the requested time window.
+pub async fn get_trending_searches(
+    State(state): State<AppState>,
+    Query(params): Query<TrendingParams>,
+) -> Result<Json<Vec<PopularTerm>>, ApiError> {
+    let hours = params.hours.unwrap_or(24).clamp(1, 168);
+    let limit = params.limit.unwrap_or(20).clamp(1, 100);
+
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            query_text,
+            COUNT(*)            AS search_count,
+            AVG(result_count)   AS avg_result_count,
+            AVG(took_ms)        AS avg_took_ms
+        FROM search_analytics
+        WHERE created_at >= NOW() - ($1 * INTERVAL '1 hour')
+        GROUP BY query_text
+        ORDER BY search_count DESC
+        LIMIT $2
+        "#,
+    )
+    .bind(hours as f64)
+    .bind(limit)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("TRENDING_FETCH_ERROR", e.to_string()))?;
+
+    use sqlx::Row as _;
+    let terms = rows
+        .into_iter()
+        .map(|r| PopularTerm {
+            query_text: r.try_get("query_text").unwrap_or_default(),
+            search_count: r.try_get("search_count").unwrap_or(0),
+            avg_result_count: r.try_get("avg_result_count").unwrap_or(0.0),
+            avg_took_ms: r.try_get("avg_took_ms").unwrap_or(0.0),
+        })
+        .collect();
+
+    Ok(Json(terms))
+}
+
+/// POST /api/admin/search/reindex
+/// Triggers a full re-index of all contracts into Elasticsearch.
+pub async fn reindex_contracts(
+    State(state): State<AppState>,
+) -> Result<Json<Value>, ApiError> {
+    // Fetch all contracts and index them into ES
+    let contracts = sqlx::query_as::<_, shared::models::Contract>(
+        "SELECT * FROM contracts ORDER BY created_at DESC",
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("REINDEX_FETCH_ERROR", e.to_string()))?;
+
+    // Ensure the ES index exists before writing
+    if let Err(e) = state.search.ensure_index().await {
+        tracing::warn!(error = %e, "Failed to ensure ES index during reindex");
+    }
+
+    let total = contracts.len();
+    let mut indexed = 0usize;
+    let mut failed = 0usize;
+
+    for contract in &contracts {
+        match state.search.index_contract(contract, None).await {
+            Ok(_) => indexed += 1,
+            Err(e) => {
+                failed += 1;
+                tracing::warn!(
+                    contract_id = %contract.contract_id,
+                    error = %e,
+                    "Failed to index contract into Elasticsearch"
+                );
+            }
+        }
+    }
+
+    tracing::info!(total, indexed, failed, "Elasticsearch reindex complete");
+
+    Ok(Json(json!({
+        "total":   total,
+        "indexed": indexed,
+        "failed":  failed,
+        "completed_at": Utc::now()
+    })))
+}
+
+/// GET /api/admin/search/synonyms
+/// Returns all synonym entries.
+pub async fn get_synonyms(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<SearchSynonym>>, ApiError> {
+    let rows = sqlx::query_as::<_, SearchSynonym>(
+        "SELECT id, term, synonyms, is_active, created_at, updated_at FROM search_synonyms ORDER BY term",
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("SYNONYM_FETCH_ERROR", e.to_string()))?;
+
+    Ok(Json(rows))
+}
+
+/// PUT /api/admin/search/synonyms
+/// Creates or updates a synonym entry.
+pub async fn upsert_synonym(
+    State(state): State<AppState>,
+    Json(req): Json<UpsertSynonymRequest>,
+) -> Result<Json<SearchSynonym>, ApiError> {
+    if req.term.trim().is_empty() {
+        return Err(ApiError::bad_request("INVALID_TERM", "term cannot be empty"));
+    }
+
+    let row = sqlx::query_as::<_, SearchSynonym>(
+        r#"
+        INSERT INTO search_synonyms (term, synonyms, is_active)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (term) DO UPDATE
+            SET synonyms   = EXCLUDED.synonyms,
+                is_active  = COALESCE($3, search_synonyms.is_active),
+                updated_at = NOW()
+        RETURNING id, term, synonyms, is_active, created_at, updated_at
+        "#,
+    )
+    .bind(req.term.trim().to_lowercase())
+    .bind(&req.synonyms)
+    .bind(req.is_active.unwrap_or(true))
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("SYNONYM_UPSERT_ERROR", e.to_string()))?;
+
+    Ok(Json(row))
+}

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -105,3 +105,7 @@ pub mod state_monitor;
 pub mod stats;
 pub mod webhook_delivery;
 pub mod db_resilience;
+pub mod archival;
+pub mod elasticsearch_handlers;
+pub mod partition_manager;
+pub mod query_monitor;

--- a/backend/api/src/partition_manager.rs
+++ b/backend/api/src/partition_manager.rs
@@ -1,0 +1,412 @@
+// Issue #879: Data partitioning strategy for contract tables.
+//
+// Manages the lifecycle of declarative PostgreSQL partitions created by the
+// migration.  A background task pre-creates the next month's interaction
+// partition and the next year's audit-log partition so queries never fall
+// into the DEFAULT catch-all.
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use chrono::{DateTime, Datelike, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::time::Duration as StdDuration;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+// ── Response types ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct PartitionInfo {
+    pub id: i64,
+    pub parent_table: String,
+    pub partition_name: String,
+    pub partition_key: String,
+    pub range_start: Option<DateTime<Utc>>,
+    pub range_end: Option<DateTime<Utc>>,
+    pub list_value: Option<String>,
+    pub row_count: Option<i64>,
+    pub size_bytes: Option<i64>,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub archived_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartitionStatus {
+    pub total_partitions: i64,
+    pub active_partitions: i64,
+    pub archived_partitions: i64,
+    pub tables: Vec<TablePartitionSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TablePartitionSummary {
+    pub parent_table: String,
+    pub partition_count: i64,
+    pub oldest_partition: Option<DateTime<Utc>>,
+    pub newest_partition: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreatePartitionRequest {
+    pub parent_table: String,
+    pub partition_name: String,
+    pub range_start: Option<DateTime<Utc>>,
+    pub range_end: Option<DateTime<Utc>>,
+    pub list_value: Option<String>,
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// GET /api/admin/partitions
+pub async fn list_partitions(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<PartitionInfo>>, ApiError> {
+    let rows = sqlx::query_as::<_, PartitionInfo>(
+        r#"
+        SELECT
+            id, parent_table, partition_name, partition_key,
+            range_start, range_end, list_value,
+            row_count, size_bytes, status, created_at, archived_at
+        FROM partition_registry
+        ORDER BY parent_table, created_at DESC
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("PARTITION_LIST_ERROR", e.to_string()))?;
+
+    Ok(Json(rows))
+}
+
+/// GET /api/admin/partitions/status
+pub async fn get_partition_status(
+    State(state): State<AppState>,
+) -> Result<Json<PartitionStatus>, ApiError> {
+    let total: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM partition_registry")
+            .fetch_one(&state.db)
+            .await
+            .unwrap_or(0);
+
+    let active: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM partition_registry WHERE status = 'active'",
+    )
+    .fetch_one(&state.db)
+    .await
+    .unwrap_or(0);
+
+    let archived: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM partition_registry WHERE status = 'archived'",
+    )
+    .fetch_one(&state.db)
+    .await
+    .unwrap_or(0);
+
+    let table_rows = sqlx::query(
+        r#"
+        SELECT
+            parent_table,
+            COUNT(*)        AS partition_count,
+            MIN(range_start) AS oldest_partition,
+            MAX(range_start) AS newest_partition
+        FROM partition_registry
+        WHERE status = 'active'
+        GROUP BY parent_table
+        ORDER BY parent_table
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    use sqlx::Row as _;
+    let tables = table_rows
+        .into_iter()
+        .map(|r| TablePartitionSummary {
+            parent_table: r.try_get("parent_table").unwrap_or_default(),
+            partition_count: r.try_get("partition_count").unwrap_or(0),
+            oldest_partition: r.try_get("oldest_partition").ok(),
+            newest_partition: r.try_get("newest_partition").ok(),
+        })
+        .collect();
+
+    Ok(Json(PartitionStatus {
+        total_partitions: total,
+        active_partitions: active,
+        archived_partitions: archived,
+        tables,
+    }))
+}
+
+/// POST /api/admin/partitions/create
+/// Creates a new partition for interactions_partitioned or audit_logs_partitioned.
+pub async fn create_partition(
+    State(state): State<AppState>,
+    Json(req): Json<CreatePartitionRequest>,
+) -> Result<Json<PartitionInfo>, ApiError> {
+    let allowed_parents = [
+        "interactions_partitioned",
+        "audit_logs_partitioned",
+    ];
+    if !allowed_parents.contains(&req.parent_table.as_str()) {
+        return Err(ApiError::bad_request(
+            "INVALID_PARENT",
+            format!(
+                "parent_table must be one of: {}",
+                allowed_parents.join(", ")
+            ),
+        ));
+    }
+
+    // Build the CREATE TABLE … PARTITION OF DDL
+    let ddl = match (&req.range_start, &req.range_end, &req.list_value) {
+        (Some(start), Some(end), _) => format!(
+            "CREATE TABLE IF NOT EXISTS {} PARTITION OF {} FOR VALUES FROM ('{}') TO ('{}')",
+            req.partition_name,
+            req.parent_table,
+            start.to_rfc3339(),
+            end.to_rfc3339(),
+        ),
+        (_, _, Some(val)) => format!(
+            "CREATE TABLE IF NOT EXISTS {} PARTITION OF {} FOR VALUES IN ('{}')",
+            req.partition_name, req.parent_table, val,
+        ),
+        _ => {
+            return Err(ApiError::bad_request(
+                "INVALID_PARTITION_SPEC",
+                "Provide either range_start+range_end or list_value",
+            ))
+        }
+    };
+
+    sqlx::query(&ddl)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal_error("PARTITION_CREATE_ERROR", e.to_string()))?;
+
+    // Register in the catalogue
+    let row = sqlx::query_as::<_, PartitionInfo>(
+        r#"
+        INSERT INTO partition_registry (
+            parent_table, partition_name, partition_key,
+            range_start, range_end, list_value, status
+        )
+        VALUES ($1, $2, 'created_at', $3, $4, $5, 'active')
+        RETURNING
+            id, parent_table, partition_name, partition_key,
+            range_start, range_end, list_value,
+            row_count, size_bytes, status, created_at, archived_at
+        "#,
+    )
+    .bind(&req.parent_table)
+    .bind(&req.partition_name)
+    .bind(req.range_start)
+    .bind(req.range_end)
+    .bind(&req.list_value)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("PARTITION_REGISTER_ERROR", e.to_string()))?;
+
+    tracing::info!(
+        partition = %req.partition_name,
+        parent = %req.parent_table,
+        "Partition created"
+    );
+
+    Ok(Json(row))
+}
+
+/// DELETE /api/admin/partitions/:name
+/// Marks a partition as archived and detaches it from the parent table.
+pub async fn archive_partition(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    // Detach the partition so the parent no longer routes to it
+    let info = sqlx::query_as::<_, PartitionInfo>(
+        "SELECT id, parent_table, partition_name, partition_key, range_start, range_end, list_value, row_count, size_bytes, status, created_at, archived_at FROM partition_registry WHERE partition_name = $1",
+    )
+    .bind(&name)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("PARTITION_FETCH_ERROR", e.to_string()))?
+    .ok_or_else(|| ApiError::not_found("PARTITION_NOT_FOUND", format!("Partition '{name}' not found")))?;
+
+    let ddl = format!(
+        "ALTER TABLE {} DETACH PARTITION {}",
+        info.parent_table, info.partition_name
+    );
+    sqlx::query(&ddl)
+        .execute(&state.db)
+        .await
+        .map_err(|e| ApiError::internal_error("PARTITION_DETACH_ERROR", e.to_string()))?;
+
+    sqlx::query(
+        "UPDATE partition_registry SET status = 'archived', archived_at = NOW() WHERE partition_name = $1",
+    )
+    .bind(&name)
+    .execute(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("PARTITION_ARCHIVE_ERROR", e.to_string()))?;
+
+    tracing::info!(partition = %name, "Partition archived and detached");
+
+    Ok(Json(serde_json::json!({
+        "partition": name,
+        "status": "archived"
+    })))
+}
+
+// ── Background lifecycle task ─────────────────────────────────────────────────
+
+/// Spawns a task that pre-creates the next monthly interaction partition and
+/// the next yearly audit-log partition if they do not already exist.
+pub fn spawn_partition_manager_task(pool: PgPool) {
+    tokio::spawn(async move {
+        // Check once per hour
+        let mut interval = tokio::time::interval(StdDuration::from_secs(3600));
+        loop {
+            interval.tick().await;
+            ensure_upcoming_interaction_partition(&pool).await;
+            ensure_upcoming_audit_log_partition(&pool).await;
+        }
+    });
+}
+
+async fn ensure_upcoming_interaction_partition(pool: &PgPool) {
+    let next_month_start = {
+        let now = Utc::now();
+        let y = if now.month() == 12 {
+            now.year() + 1
+        } else {
+            now.year()
+        };
+        let m = if now.month() == 12 {
+            1
+        } else {
+            now.month() + 1
+        };
+        DateTime::<Utc>::from_naive_utc_and_offset(
+            chrono::NaiveDate::from_ymd_opt(y, m, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+            Utc,
+        )
+    };
+    let next_month_end = next_month_start + Duration::days(32);
+    let next_month_end = DateTime::<Utc>::from_naive_utc_and_offset(
+        chrono::NaiveDate::from_ymd_opt(next_month_end.year(), next_month_end.month(), 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        Utc,
+    );
+    let partition_name = format!(
+        "interactions_p_{:04}_{:02}",
+        next_month_start.year(),
+        next_month_start.month()
+    );
+
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM pg_class WHERE relname = $1)",
+    )
+    .bind(&partition_name)
+    .fetch_one(pool)
+    .await
+    .unwrap_or(false);
+
+    if exists {
+        return;
+    }
+
+    let ddl = format!(
+        "CREATE TABLE IF NOT EXISTS {} PARTITION OF interactions_partitioned FOR VALUES FROM ('{}') TO ('{}')",
+        partition_name,
+        next_month_start.to_rfc3339(),
+        next_month_end.to_rfc3339(),
+    );
+
+    if let Err(e) = sqlx::query(&ddl).execute(pool).await {
+        tracing::warn!(error = %e, partition = %partition_name, "Failed to auto-create interaction partition");
+        return;
+    }
+
+    let _ = sqlx::query(
+        r#"
+        INSERT INTO partition_registry (parent_table, partition_name, partition_key, range_start, range_end, status)
+        VALUES ('interactions_partitioned', $1, 'created_at', $2, $3, 'active')
+        ON CONFLICT (partition_name) DO NOTHING
+        "#,
+    )
+    .bind(&partition_name)
+    .bind(next_month_start)
+    .bind(next_month_end)
+    .execute(pool)
+    .await;
+
+    tracing::info!(partition = %partition_name, "Auto-created upcoming interaction partition");
+}
+
+async fn ensure_upcoming_audit_log_partition(pool: &PgPool) {
+    let next_year = Utc::now().year() + 1;
+    let partition_name = format!("audit_logs_p_{next_year:04}");
+
+    let exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM pg_class WHERE relname = $1)")
+            .bind(&partition_name)
+            .fetch_one(pool)
+            .await
+            .unwrap_or(false);
+
+    if exists {
+        return;
+    }
+
+    let year_start = DateTime::<Utc>::from_naive_utc_and_offset(
+        chrono::NaiveDate::from_ymd_opt(next_year, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        Utc,
+    );
+    let year_end = DateTime::<Utc>::from_naive_utc_and_offset(
+        chrono::NaiveDate::from_ymd_opt(next_year + 1, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        Utc,
+    );
+
+    let ddl = format!(
+        "CREATE TABLE IF NOT EXISTS {} PARTITION OF audit_logs_partitioned FOR VALUES FROM ('{}') TO ('{}')",
+        partition_name,
+        year_start.to_rfc3339(),
+        year_end.to_rfc3339(),
+    );
+
+    if let Err(e) = sqlx::query(&ddl).execute(pool).await {
+        tracing::warn!(error = %e, partition = %partition_name, "Failed to auto-create audit-log partition");
+        return;
+    }
+
+    let _ = sqlx::query(
+        r#"
+        INSERT INTO partition_registry (parent_table, partition_name, partition_key, range_start, range_end, status)
+        VALUES ('audit_logs_partitioned', $1, 'created_at', $2, $3, 'active')
+        ON CONFLICT (partition_name) DO NOTHING
+        "#,
+    )
+    .bind(&partition_name)
+    .bind(year_start)
+    .bind(year_end)
+    .execute(pool)
+    .await;
+
+    tracing::info!(partition = %partition_name, "Auto-created upcoming audit-log partition");
+}

--- a/backend/api/src/query_monitor.rs
+++ b/backend/api/src/query_monitor.rs
@@ -1,0 +1,415 @@
+// Issue #878: Database query monitoring and performance analysis tools.
+//
+// Reads from pg_stat_statements (requires the extension) and from the
+// query_performance_log table populated by the background task.  All
+// pg_stat_statements queries degrade gracefully when the extension is absent.
+
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::time::Duration;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+const DEFAULT_SLOW_THRESHOLD_MS: f64 = 1000.0;
+const SNAPSHOT_INTERVAL_SECS: u64 = 60;
+
+// ── Request params ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct SlowQueryParams {
+    pub threshold_ms: Option<f64>,
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TrendParams {
+    pub hours: Option<i64>,
+}
+
+// ── Response types ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct SlowQuery {
+    pub query: Option<String>,
+    pub calls: Option<i64>,
+    pub mean_exec_time_ms: Option<f64>,
+    pub max_exec_time_ms: Option<f64>,
+    pub total_exec_time_ms: Option<f64>,
+    pub rows: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct IndexStat {
+    pub schema_name: Option<String>,
+    pub table_name: Option<String>,
+    pub index_name: Option<String>,
+    pub index_scans: Option<i64>,
+    pub tuples_read: Option<i64>,
+    pub tuples_fetched: Option<i64>,
+    pub index_size: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LockInfo {
+    pub pid: Option<i32>,
+    pub relation: Option<String>,
+    pub lock_type: Option<String>,
+    pub lock_mode: Option<String>,
+    pub granted: Option<bool>,
+    pub query: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct PerformanceTrend {
+    pub hour: Option<DateTime<Utc>>,
+    pub total_calls: Option<i64>,
+    pub avg_exec_time_ms: Option<f64>,
+    pub slow_query_count: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerformanceReport {
+    pub generated_at: DateTime<Utc>,
+    pub slow_query_threshold_ms: f64,
+    pub slow_queries: Vec<SlowQuery>,
+    pub index_stats: Vec<IndexStat>,
+    pub top_queries_by_frequency: Vec<SlowQuery>,
+    pub recommendations: Vec<String>,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn build_recommendations(slow: &[SlowQuery], indexes: &[IndexStat]) -> Vec<String> {
+    let mut recs = Vec::new();
+
+    for idx in indexes {
+        if idx.index_scans == Some(0) {
+            recs.push(format!(
+                "Index '{}' on table '{}' has 0 scans. Consider dropping it to reduce write overhead.",
+                idx.index_name.as_deref().unwrap_or("?"),
+                idx.table_name.as_deref().unwrap_or("?"),
+            ));
+        }
+    }
+
+    for sq in slow {
+        if sq.mean_exec_time_ms.unwrap_or(0.0) > 5000.0 {
+            recs.push(format!(
+                "Query with mean execution time {:.0} ms exceeds 5 s. Review for missing index or query rewrite.",
+                sq.mean_exec_time_ms.unwrap_or(0.0),
+            ));
+        }
+    }
+
+    if recs.is_empty() {
+        recs.push(
+            "No immediate optimization recommendations. Continue monitoring query patterns."
+                .to_string(),
+        );
+    }
+
+    recs
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// GET /api/admin/db/slow-queries
+/// Lists queries whose mean execution time exceeds the threshold.
+/// Requires pg_stat_statements extension; returns empty list if unavailable.
+pub async fn get_slow_queries(
+    State(state): State<AppState>,
+    Query(params): Query<SlowQueryParams>,
+) -> Result<Json<Vec<SlowQuery>>, ApiError> {
+    let threshold = params.threshold_ms.unwrap_or(DEFAULT_SLOW_THRESHOLD_MS);
+    let limit = params.limit.unwrap_or(50).clamp(1, 200);
+
+    let rows = sqlx::query_as::<_, SlowQuery>(
+        r#"
+        SELECT
+            query,
+            calls,
+            mean_exec_time    AS mean_exec_time_ms,
+            max_exec_time     AS max_exec_time_ms,
+            total_exec_time   AS total_exec_time_ms,
+            rows
+        FROM pg_stat_statements
+        WHERE calls > 0
+          AND mean_exec_time >= $1
+        ORDER BY mean_exec_time DESC
+        LIMIT $2
+        "#,
+    )
+    .bind(threshold)
+    .bind(limit)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    Ok(Json(rows))
+}
+
+/// GET /api/admin/db/index-stats
+/// Returns index scan counts and sizes for all user indexes.
+pub async fn get_index_stats(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<IndexStat>>, ApiError> {
+    let rows = sqlx::query_as::<_, IndexStat>(
+        r#"
+        SELECT
+            schemaname                                    AS schema_name,
+            relname                                       AS table_name,
+            indexrelname                                  AS index_name,
+            idx_scan                                      AS index_scans,
+            idx_tup_read                                  AS tuples_read,
+            idx_tup_fetch                                 AS tuples_fetched,
+            pg_size_pretty(pg_relation_size(indexrelid))  AS index_size
+        FROM pg_stat_user_indexes
+        ORDER BY idx_scan DESC
+        LIMIT 100
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("INDEX_STATS_ERROR", e.to_string()))?;
+
+    Ok(Json(rows))
+}
+
+/// GET /api/admin/db/lock-monitor
+/// Returns current locks and any contention visible in pg_locks.
+pub async fn get_lock_monitor(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<LockInfo>>, ApiError> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            l.pid,
+            c.relname   AS relation,
+            l.locktype  AS lock_type,
+            l.mode      AS lock_mode,
+            l.granted,
+            a.query
+        FROM pg_locks l
+        LEFT JOIN pg_class c        ON l.relation = c.oid
+        LEFT JOIN pg_stat_activity a ON l.pid     = a.pid
+        WHERE l.pid != pg_backend_pid()
+        ORDER BY l.granted, l.pid
+        LIMIT 50
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("LOCK_MONITOR_ERROR", e.to_string()))?;
+
+    use sqlx::Row as _;
+    let locks = rows
+        .into_iter()
+        .map(|r| LockInfo {
+            pid: r.try_get("pid").ok(),
+            relation: r.try_get("relation").ok(),
+            lock_type: r.try_get("lock_type").ok(),
+            lock_mode: r.try_get("lock_mode").ok(),
+            granted: r.try_get("granted").ok(),
+            query: r.try_get("query").ok(),
+        })
+        .collect();
+
+    Ok(Json(locks))
+}
+
+/// GET /api/admin/db/performance-trends
+/// Returns hourly aggregated call counts and mean exec times from the
+/// query_performance_log snapshot table.
+pub async fn get_performance_trends(
+    State(state): State<AppState>,
+    Query(params): Query<TrendParams>,
+) -> Result<Json<Vec<PerformanceTrend>>, ApiError> {
+    let hours = params.hours.unwrap_or(24).clamp(1, 168) as f64;
+
+    let rows = sqlx::query_as::<_, PerformanceTrend>(
+        r#"
+        SELECT
+            date_trunc('hour', recorded_at)            AS hour,
+            SUM(calls_delta)                           AS total_calls,
+            AVG(mean_exec_time_ms)                     AS avg_exec_time_ms,
+            COUNT(*) FILTER (WHERE is_slow = true)     AS slow_query_count
+        FROM query_performance_log
+        WHERE recorded_at >= NOW() - ($1 * INTERVAL '1 hour')
+        GROUP BY date_trunc('hour', recorded_at)
+        ORDER BY date_trunc('hour', recorded_at) ASC
+        "#,
+    )
+    .bind(hours)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| ApiError::internal_error("TREND_ERROR", e.to_string()))?;
+
+    Ok(Json(rows))
+}
+
+/// GET /api/admin/db/performance-report
+/// Aggregate report: slow queries, index stats, top queries, and recommendations.
+pub async fn get_performance_report(
+    State(state): State<AppState>,
+    Query(params): Query<SlowQueryParams>,
+) -> Result<Json<PerformanceReport>, ApiError> {
+    let threshold = params.threshold_ms.unwrap_or(DEFAULT_SLOW_THRESHOLD_MS);
+
+    let slow_queries = sqlx::query_as::<_, SlowQuery>(
+        r#"
+        SELECT
+            query,
+            calls,
+            mean_exec_time  AS mean_exec_time_ms,
+            max_exec_time   AS max_exec_time_ms,
+            total_exec_time AS total_exec_time_ms,
+            rows
+        FROM pg_stat_statements
+        WHERE calls > 0
+          AND mean_exec_time >= $1
+        ORDER BY mean_exec_time DESC
+        LIMIT 20
+        "#,
+    )
+    .bind(threshold)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let top_queries = sqlx::query_as::<_, SlowQuery>(
+        r#"
+        SELECT
+            query,
+            calls,
+            mean_exec_time  AS mean_exec_time_ms,
+            max_exec_time   AS max_exec_time_ms,
+            total_exec_time AS total_exec_time_ms,
+            rows
+        FROM pg_stat_statements
+        WHERE calls > 0
+        ORDER BY calls DESC
+        LIMIT 10
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let index_stats = sqlx::query_as::<_, IndexStat>(
+        r#"
+        SELECT
+            schemaname                                    AS schema_name,
+            relname                                       AS table_name,
+            indexrelname                                  AS index_name,
+            idx_scan                                      AS index_scans,
+            idx_tup_read                                  AS tuples_read,
+            idx_tup_fetch                                 AS tuples_fetched,
+            pg_size_pretty(pg_relation_size(indexrelid))  AS index_size
+        FROM pg_stat_user_indexes
+        ORDER BY idx_scan ASC
+        LIMIT 20
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let recommendations = build_recommendations(&slow_queries, &index_stats);
+
+    Ok(Json(PerformanceReport {
+        generated_at: Utc::now(),
+        slow_query_threshold_ms: threshold,
+        slow_queries,
+        index_stats,
+        top_queries_by_frequency: top_queries,
+        recommendations,
+    }))
+}
+
+/// POST /api/admin/db/performance-report/export
+/// Returns the full performance report as an exportable JSON envelope.
+pub async fn export_performance_report(
+    state: State<AppState>,
+    query: Query<SlowQueryParams>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let Json(report) = get_performance_report(state, query).await?;
+    let json = serde_json::to_value(&report)
+        .map_err(|e| ApiError::internal_error("EXPORT_ERROR", e.to_string()))?;
+
+    Ok(Json(serde_json::json!({
+        "format": "json",
+        "exported_at": Utc::now(),
+        "report": json
+    })))
+}
+
+// ── Background snapshot task ──────────────────────────────────────────────────
+
+/// Spawns a background task that periodically snapshots pg_stat_statements into
+/// query_performance_log and logs a warning when slow queries are detected.
+pub fn spawn_query_monitor_task(pool: PgPool, threshold_ms: f64) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(SNAPSHOT_INTERVAL_SECS));
+        loop {
+            interval.tick().await;
+
+            let snapshot_result = sqlx::query(
+                r#"
+                INSERT INTO query_performance_log (
+                    query_hash,
+                    query_sample,
+                    calls_delta,
+                    mean_exec_time_ms,
+                    max_exec_time_ms,
+                    total_rows,
+                    is_slow,
+                    recorded_at
+                )
+                SELECT
+                    md5(query)        AS query_hash,
+                    LEFT(query, 500)  AS query_sample,
+                    calls             AS calls_delta,
+                    mean_exec_time    AS mean_exec_time_ms,
+                    max_exec_time     AS max_exec_time_ms,
+                    rows              AS total_rows,
+                    mean_exec_time >= $1 AS is_slow,
+                    NOW()
+                FROM pg_stat_statements
+                WHERE calls > 0
+                ON CONFLICT DO NOTHING
+                "#,
+            )
+            .bind(threshold_ms)
+            .execute(&pool)
+            .await;
+
+            if let Err(e) = snapshot_result {
+                tracing::debug!(error = %e, "pg_stat_statements snapshot skipped (extension may be unavailable)");
+                continue;
+            }
+
+            let slow_count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM pg_stat_statements WHERE mean_exec_time >= $1 AND calls > 0",
+            )
+            .bind(threshold_ms)
+            .fetch_one(&pool)
+            .await
+            .unwrap_or(0);
+
+            if slow_count > 0 {
+                tracing::warn!(
+                    slow_query_count = slow_count,
+                    threshold_ms = threshold_ms,
+                    "Slow queries detected above threshold"
+                );
+                crate::metrics::DB_QUERY_ERRORS.inc();
+            }
+        }
+    });
+}

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -2,7 +2,7 @@
 use crate::openapi;
 use crate::{
     ab_test_handlers, abi_versioning_handlers, ai::handlers as ai_handlers, analytics_handlers,
-    auth, auth_handlers, batch_verify_handlers, breaking_changes, bulk_operations_handlers,
+    archival, auth, auth_handlers, batch_verify_handlers, breaking_changes, bulk_operations_handlers,
     canary_handlers, category_handlers, client_observability_handlers, clone_federation_handlers,
     collaborative_reviews, compatibility_testing_handlers, contract_events,
     contract_stats_handlers, contributor_handlers, custom_metrics_handlers, dependency_handlers,
@@ -11,8 +11,9 @@ use crate::{
     marketplace::{license_handlers as mp_license, metering as mp_metering,
                   pricing_handlers as mp_pricing, stripe_handlers as mp_stripe,
                   usdc_handlers as mp_usdc},
-    metrics_handler, migration_handlers, mutation_testing_handlers, org_handlers, patch_handlers,
-    performance_handlers, plugin_marketplace_handlers, publisher_verification_handlers,
+    elasticsearch_handlers, metrics_handler, migration_handlers, mutation_testing_handlers,
+    org_handlers, partition_manager, patch_handlers, performance_handlers,
+    plugin_marketplace_handlers, publisher_verification_handlers, query_monitor,
     recommendation_handlers, resource_handlers, search_postgres, security_scan_handlers,
     similarity_handlers, simulation_handlers, state::AppState,
     state_monitor::handlers as state_monitor_handlers, stats, subscription_handlers,
@@ -78,6 +79,10 @@ pub fn application_routes(_schema: crate::graphql::schema::RegistrySchema) -> Ro
         .merge(validator_routes())
         .merge(openapi_routes())
         .nest("/api", crate::activity_feed_routes::routes())
+        .merge(query_monitor_routes())
+        .merge(partition_routes())
+        .merge(archival_routes())
+        .merge(elasticsearch_search_routes())
 }
 
 fn multisig_routes_group() -> Router<AppState> {
@@ -1212,5 +1217,114 @@ pub fn collaborative_review_routes() -> Router<AppState> {
         .route(
             "/api/reviews/collaborative/:id/status",
             patch(collaborative_reviews::update_reviewer_status),
+        )
+}
+
+// ── Issue #878: Database query monitoring ────────────────────────────────────
+
+pub fn query_monitor_routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/admin/db/slow-queries",
+            get(query_monitor::get_slow_queries),
+        )
+        .route(
+            "/api/admin/db/index-stats",
+            get(query_monitor::get_index_stats),
+        )
+        .route(
+            "/api/admin/db/lock-monitor",
+            get(query_monitor::get_lock_monitor),
+        )
+        .route(
+            "/api/admin/db/performance-trends",
+            get(query_monitor::get_performance_trends),
+        )
+        .route(
+            "/api/admin/db/performance-report",
+            get(query_monitor::get_performance_report),
+        )
+        .route(
+            "/api/admin/db/performance-report/export",
+            post(query_monitor::export_performance_report),
+        )
+}
+
+// ── Issue #879: Data partitioning ────────────────────────────────────────────
+
+pub fn partition_routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/admin/partitions",
+            get(partition_manager::list_partitions),
+        )
+        .route(
+            "/api/admin/partitions/status",
+            get(partition_manager::get_partition_status),
+        )
+        .route(
+            "/api/admin/partitions/create",
+            post(partition_manager::create_partition),
+        )
+        .route(
+            "/api/admin/partitions/:name",
+            delete(partition_manager::archive_partition),
+        )
+}
+
+// ── Issue #881: Data archival ────────────────────────────────────────────────
+
+pub fn archival_routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/admin/archival/status",
+            get(archival::get_archival_status),
+        )
+        .route(
+            "/api/admin/archival/policies",
+            get(archival::get_archival_policies),
+        )
+        .route(
+            "/api/admin/archival/policies/:data_type",
+            patch(archival::update_archival_policy),
+        )
+        .route(
+            "/api/admin/archival/run",
+            post(archival::trigger_archival),
+        )
+        .route(
+            "/api/admin/archival/audit-trail",
+            get(archival::get_archival_audit_trail),
+        )
+        .route(
+            "/api/admin/archival/restore",
+            post(archival::restore_archived_record),
+        )
+}
+
+// ── Issue #880: Elasticsearch / full-text search ─────────────────────────────
+
+pub fn elasticsearch_search_routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/search/elasticsearch",
+            get(elasticsearch_handlers::elasticsearch_search),
+        )
+        .route(
+            "/api/search/analytics",
+            get(elasticsearch_handlers::get_search_analytics),
+        )
+        .route(
+            "/api/search/trending",
+            get(elasticsearch_handlers::get_trending_searches),
+        )
+        .route(
+            "/api/admin/search/reindex",
+            post(elasticsearch_handlers::reindex_contracts),
+        )
+        .route(
+            "/api/admin/search/synonyms",
+            get(elasticsearch_handlers::get_synonyms)
+                .put(elasticsearch_handlers::upsert_synonym),
         )
 }

--- a/database/migrations/20260530000000_issue878_query_monitoring.sql
+++ b/database/migrations/20260530000000_issue878_query_monitoring.sql
@@ -1,0 +1,30 @@
+-- Issue #878: Database query monitoring and performance analysis
+-- Creates tables for persisting query performance snapshots and slow query history.
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+CREATE TABLE IF NOT EXISTS query_performance_log (
+    id              BIGSERIAL PRIMARY KEY,
+    query_hash      TEXT        NOT NULL,
+    query_sample    TEXT        NOT NULL,
+    calls_delta     BIGINT      NOT NULL DEFAULT 0,
+    mean_exec_time_ms DOUBLE PRECISION NOT NULL DEFAULT 0,
+    max_exec_time_ms  DOUBLE PRECISION NOT NULL DEFAULT 0,
+    total_rows      BIGINT      NOT NULL DEFAULT 0,
+    is_slow         BOOLEAN     NOT NULL DEFAULT false,
+    recorded_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_query_perf_log_recorded_at
+    ON query_performance_log (recorded_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_query_perf_log_hash
+    ON query_performance_log (query_hash);
+
+CREATE INDEX IF NOT EXISTS idx_query_perf_log_slow
+    ON query_performance_log (is_slow, recorded_at DESC)
+    WHERE is_slow = true;
+
+-- Retention: keep rolling 90 days; older rows are archived by the archival job.
+COMMENT ON TABLE query_performance_log IS
+    'Periodic snapshots of pg_stat_statements for historical query performance analysis (issue #878).';

--- a/database/migrations/20260530000100_issue879_data_partitioning.sql
+++ b/database/migrations/20260530000100_issue879_data_partitioning.sql
@@ -1,0 +1,140 @@
+-- Issue #879: Data partitioning strategy for contract tables.
+--
+-- Creates declarative-partitioned variants alongside existing tables:
+--   contracts_partitioned      — LIST partitioned by network
+--   interactions_partitioned   — RANGE partitioned by month
+--   audit_logs_partitioned     — RANGE partitioned by year
+--
+-- Existing tables are left untouched.  The partition_manager service creates
+-- child partitions automatically as new periods arrive.
+
+-- ── contracts_partitioned (LIST by network) ────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS contracts_partitioned (
+    id                  UUID            NOT NULL DEFAULT gen_random_uuid(),
+    contract_id         TEXT            NOT NULL,
+    name                TEXT            NOT NULL,
+    description         TEXT,
+    category            TEXT,
+    network             TEXT            NOT NULL,
+    is_verified         BOOLEAN         NOT NULL DEFAULT false,
+    verification_status TEXT,
+    current_version     TEXT,
+    slug                TEXT,
+    publisher_id        UUID,
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (id, network)
+) PARTITION BY LIST (network);
+
+CREATE TABLE IF NOT EXISTS contracts_partitioned_mainnet
+    PARTITION OF contracts_partitioned FOR VALUES IN ('mainnet');
+
+CREATE TABLE IF NOT EXISTS contracts_partitioned_testnet
+    PARTITION OF contracts_partitioned FOR VALUES IN ('testnet');
+
+CREATE TABLE IF NOT EXISTS contracts_partitioned_futurenet
+    PARTITION OF contracts_partitioned FOR VALUES IN ('futurenet');
+
+CREATE TABLE IF NOT EXISTS contracts_partitioned_default
+    PARTITION OF contracts_partitioned DEFAULT;
+
+-- ── interactions_partitioned (RANGE by month) ─────────────────────────────
+
+CREATE TABLE IF NOT EXISTS interactions_partitioned (
+    id              BIGSERIAL,
+    contract_id     UUID            NOT NULL,
+    caller          TEXT,
+    method          TEXT,
+    args            JSONB,
+    result          JSONB,
+    gas_used        BIGINT,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (created_at);
+
+-- Seed two initial monthly partitions (current month and next month).
+-- The partition_manager background task creates additional partitions automatically.
+DO $$
+DECLARE
+    cur_start TIMESTAMPTZ := date_trunc('month', NOW());
+    cur_end   TIMESTAMPTZ := date_trunc('month', NOW()) + INTERVAL '1 month';
+    nxt_end   TIMESTAMPTZ := date_trunc('month', NOW()) + INTERVAL '2 months';
+    tbl       TEXT;
+BEGIN
+    tbl := 'interactions_p_' || to_char(cur_start, 'YYYY_MM');
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_class WHERE relname = tbl
+    ) THEN
+        EXECUTE format(
+            'CREATE TABLE %I PARTITION OF interactions_partitioned FOR VALUES FROM (%L) TO (%L)',
+            tbl, cur_start, cur_end
+        );
+    END IF;
+
+    tbl := 'interactions_p_' || to_char(cur_end, 'YYYY_MM');
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_class WHERE relname = tbl
+    ) THEN
+        EXECUTE format(
+            'CREATE TABLE %I PARTITION OF interactions_partitioned FOR VALUES FROM (%L) TO (%L)',
+            tbl, cur_end, nxt_end
+        );
+    END IF;
+END
+$$;
+
+-- ── audit_logs_partitioned (RANGE by year) ────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS audit_logs_partitioned (
+    id              BIGSERIAL,
+    table_name      TEXT            NOT NULL,
+    record_id       UUID,
+    action          TEXT            NOT NULL,
+    actor           TEXT,
+    old_data        JSONB,
+    new_data        JSONB,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (created_at);
+
+DO $$
+DECLARE
+    yr_start TIMESTAMPTZ := date_trunc('year', NOW());
+    yr_end   TIMESTAMPTZ := date_trunc('year', NOW()) + INTERVAL '1 year';
+    tbl      TEXT;
+BEGIN
+    tbl := 'audit_logs_p_' || to_char(yr_start, 'YYYY');
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_class WHERE relname = tbl
+    ) THEN
+        EXECUTE format(
+            'CREATE TABLE %I PARTITION OF audit_logs_partitioned FOR VALUES FROM (%L) TO (%L)',
+            tbl, yr_start, yr_end
+        );
+    END IF;
+END
+$$;
+
+-- ── Partition registry ────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS partition_registry (
+    id              BIGSERIAL       PRIMARY KEY,
+    parent_table    TEXT            NOT NULL,
+    partition_name  TEXT            NOT NULL UNIQUE,
+    partition_key   TEXT            NOT NULL,
+    range_start     TIMESTAMPTZ,
+    range_end       TIMESTAMPTZ,
+    list_value      TEXT,
+    row_count       BIGINT,
+    size_bytes      BIGINT,
+    status          TEXT            NOT NULL DEFAULT 'active',
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    archived_at     TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_partition_registry_parent
+    ON partition_registry (parent_table, status);
+
+COMMENT ON TABLE partition_registry IS
+    'Catalogue of all managed partitions for automated lifecycle management (issue #879).';

--- a/database/migrations/20260530000200_issue881_data_archival.sql
+++ b/database/migrations/20260530000200_issue881_data_archival.sql
@@ -1,0 +1,67 @@
+-- Issue #881: Data archival and cleanup strategy for old records.
+--
+-- Creates the tables that track archival policies, run history, and
+-- the audit trail of every archived record.
+
+-- ── Retention policies (configurable per data type) ───────────────────────
+
+CREATE TABLE IF NOT EXISTS archival_policies (
+    id              BIGSERIAL       PRIMARY KEY,
+    data_type       TEXT            NOT NULL UNIQUE,
+    source_table    TEXT            NOT NULL,
+    retention_days  INT             NOT NULL DEFAULT 365,
+    archive_storage TEXT            NOT NULL DEFAULT 'database',
+    is_enabled      BOOLEAN         NOT NULL DEFAULT true,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+-- Default policies
+INSERT INTO archival_policies (data_type, source_table, retention_days, archive_storage)
+VALUES
+    ('interactions',    'contract_interactions', 365,  'database'),
+    ('audit_logs',      'audit_log',             1825, 'database'),
+    ('query_perf_log',  'query_performance_log',  90,  'database')
+ON CONFLICT (data_type) DO NOTHING;
+
+-- ── Archival run log ──────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS archival_runs (
+    id              BIGSERIAL       PRIMARY KEY,
+    policy_id       BIGINT          REFERENCES archival_policies(id),
+    data_type       TEXT            NOT NULL,
+    status          TEXT            NOT NULL DEFAULT 'pending',
+    rows_archived   BIGINT          NOT NULL DEFAULT 0,
+    rows_deleted    BIGINT          NOT NULL DEFAULT 0,
+    error_message   TEXT,
+    started_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    completed_at    TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_archival_runs_policy
+    ON archival_runs (policy_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_archival_runs_status
+    ON archival_runs (status, started_at DESC);
+
+-- ── Archived record trail (audit trail of what was archived) ──────────────
+
+CREATE TABLE IF NOT EXISTS archival_audit_trail (
+    id              BIGSERIAL       PRIMARY KEY,
+    run_id          BIGINT          REFERENCES archival_runs(id),
+    source_table    TEXT            NOT NULL,
+    source_id       TEXT            NOT NULL,
+    archived_data   JSONB,
+    archive_ref     TEXT,
+    archived_at     TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_archival_trail_run
+    ON archival_audit_trail (run_id);
+
+CREATE INDEX IF NOT EXISTS idx_archival_trail_source
+    ON archival_audit_trail (source_table, source_id);
+
+COMMENT ON TABLE archival_policies     IS 'Configurable retention policies per data type (issue #881).';
+COMMENT ON TABLE archival_runs         IS 'Execution history of archival jobs (issue #881).';
+COMMENT ON TABLE archival_audit_trail  IS 'Per-record archive audit trail enabling restore (issue #881).';

--- a/database/migrations/20260530000300_issue880_search_analytics.sql
+++ b/database/migrations/20260530000300_issue880_search_analytics.sql
@@ -1,0 +1,47 @@
+-- Issue #880: Full-text search integration with Elasticsearch.
+--
+-- Adds the search_analytics table for tracking query popularity and
+-- the search_synonyms table for the synonym dictionary.
+
+-- ── Search event log ──────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS search_analytics (
+    id              BIGSERIAL       PRIMARY KEY,
+    query_text      TEXT            NOT NULL,
+    backend         TEXT            NOT NULL DEFAULT 'postgres',
+    result_count    INT             NOT NULL DEFAULT 0,
+    took_ms         INT             NOT NULL DEFAULT 0,
+    filters         JSONB,
+    user_agent      TEXT,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_analytics_created
+    ON search_analytics (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_search_analytics_query
+    ON search_analytics (query_text, created_at DESC);
+
+-- ── Synonym dictionary ────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS search_synonyms (
+    id              BIGSERIAL       PRIMARY KEY,
+    term            TEXT            NOT NULL UNIQUE,
+    synonyms        TEXT[]          NOT NULL DEFAULT '{}',
+    is_active       BOOLEAN         NOT NULL DEFAULT true,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+-- Seed a handful of domain-relevant synonyms
+INSERT INTO search_synonyms (term, synonyms) VALUES
+    ('token',    ARRAY['coin', 'asset', 'currency']),
+    ('nft',      ARRAY['non-fungible', 'collectible']),
+    ('dex',      ARRAY['exchange', 'swap', 'amm']),
+    ('defi',     ARRAY['decentralized finance', 'yield', 'liquidity']),
+    ('oracle',   ARRAY['price feed', 'data feed']),
+    ('bridge',   ARRAY['cross-chain', 'interop'])
+ON CONFLICT (term) DO NOTHING;
+
+COMMENT ON TABLE search_analytics IS 'Per-query analytics log for popular-term tracking and performance measurement (issue #880).';
+COMMENT ON TABLE search_synonyms  IS 'User-maintained synonym dictionary applied at search time (issue #880).';


### PR DESCRIPTION
closes #878
closes #879
closes #880
closes #881

This PR implements four backend infrastructure improvements across query observability, storage scalability, data lifecycle management, and search.

Issue #878 — Database query monitoring and performance analysis
New files: backend/api/src/query_monitor.rs, database/migrations/20260530000000_issue878_query_monitoring.sql

Reads pg_stat_statements (degrades gracefully when the extension is absent) to surface slow queries, per-query call frequency, mean and max execution times.
Exposes index usage statistics from pg_stat_user_indexes including scan counts and index sizes.
Monitors active locks and contention via pg_locks.
Persists 60-second snapshots of pg_stat_statements into query_performance_log via a background Tokio task; rows older than 90 days are pruned by the archival job.
Aggregates historical hourly trends from the snapshot table.
Produces a full performance report with auto-generated optimization recommendations (unused indexes, queries exceeding 5 s mean time).
POST /api/admin/db/performance-report/export returns a JSON envelope suitable for external consumption.
API endpoints added:

GET /api/admin/db/slow-queries
GET /api/admin/db/index-stats
GET /api/admin/db/lock-monitor
GET /api/admin/db/performance-trends
GET /api/admin/db/performance-report
POST /api/admin/db/performance-report/export
Issue #879 — Data partitioning strategy for contract tables
New files: backend/api/src/partition_manager.rs, database/migrations/20260530000100_issue879_data_partitioning.sql

Creates three declarative partitioned tables alongside the existing ones (existing tables are untouched):
contracts_partitioned — LIST partitioned by network (mainnet, testnet, futurenet, default catch-all).
interactions_partitioned — RANGE partitioned monthly by created_at; the migration seeds the current and next month's partitions.
audit_logs_partitioned — RANGE partitioned yearly by created_at; the migration seeds the current year.
partition_registry catalogue table tracks every managed partition with range bounds, row counts, and archival status.
A background Tokio task runs hourly to pre-create the next month's interaction partition and the next year's audit-log partition so queries never fall into the DEFAULT catch-all.
Admin API to list, create, and detach (archive) partitions.
API endpoints added:

GET /api/admin/partitions
GET /api/admin/partitions/status
POST /api/admin/partitions/create
DELETE /api/admin/partitions/:name
Issue #881 — Data archival and cleanup strategy for old records
New files: backend/api/src/archival.rs, database/migrations/20260530000200_issue881_data_archival.sql

archival_policies table stores configurable retention periods per data type; seeded with defaults for interactions (1 year), audit_logs (5 years), and query_perf_log (90 days).
archival_runs table records every execution with row counts, status, and error messages.
archival_audit_trail stores a full JSON snapshot of each archived row enabling point-record restore.
A background Tokio task runs every 24 hours processing all enabled policies in sequence.
The restore_archived_record handler returns the stored JSON snapshot so operators can re-insert a specific record.
Policy retention periods and storage target are updatable at runtime via PATCH without a redeploy.
API endpoints added:

GET /api/admin/archival/status
GET /api/admin/archival/policies
PATCH /api/admin/archival/policies/:data_type
POST /api/admin/archival/run
GET /api/admin/archival/audit-trail
POST /api/admin/archival/restore
Issue #880 — Full-text search integration with Elasticsearch
New files: backend/api/src/elasticsearch_handlers.rs, database/migrations/20260530000300_issue880_search_analytics.sql

elasticsearch_search handler attempts Elasticsearch first (via the existing SearchClient) and transparently falls back to PostgresSearchService when ES is unavailable, logging a warning in either case.
Every search event is recorded to search_analytics with query text, backend used, result count, and latency for trend analysis.
get_trending_searches aggregates search_analytics into a ranked list of popular terms over a configurable time window.
search_synonyms table holds a user-maintained synonym dictionary (seeded with common DeFi/Stellar terms); the upsert_synonym handler lets admins extend it without a schema change.
reindex_contracts iterates all contracts and pushes them into the ES index, calling ensure_index first to guarantee the mapping exists.
API endpoints added:

GET /api/search/elasticsearch
GET /api/search/analytics
GET /api/search/trending
POST /api/admin/search/reindex
GET /api/admin/search/synonyms
PUT /api/admin/search/synonyms
Test plan
 Run database migrations in a local PostgreSQL 16 container and verify all tables and indexes are created without errors.
 Enable pg_stat_statements extension and hit GET /api/admin/db/slow-queries — confirm results return correctly; disable extension and confirm empty list is returned without 500.
 POST /api/admin/partitions/create with a range spec for interactions_partitioned — verify partition appears in partition_registry and pg_class.
 DELETE /api/admin/partitions/:name — verify the partition is detached and marked archived.
 POST /api/admin/archival/run with data_type: "query_perf_log" — verify rows older than 90 days are moved to archival_audit_trail and deleted from query_performance_log.
 POST /api/admin/archival/restore — verify the JSON snapshot is returned for a known archived record.
 With Elasticsearch running: GET /api/search/elasticsearch?q=token — confirm backend: "elasticsearch" in response.
 Stop Elasticsearch container: same request — confirm backend: "postgres_fallback" and results still returned.
 GET /api/search/trending?hours=1 after running several searches — confirm query_text entries appear ranked by count.
 PUT /api/admin/search/synonyms — upsert a new synonym and confirm retrieval via GET.