### PR TITLE
feat: add batch update command for bulk contract metadata updates (#849)

### DIFF
--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -1,4 +1,5 @@
 pub mod compatibility;
+pub mod contract_metadata;
 pub mod reviews;
 pub mod validators;
 
@@ -5597,6 +5598,295 @@ pub async fn bulk_update_contract_status(
 
     state.cache.invalidate_contracts().await;
     Ok(Json(json!({ "results": results })))
+}
+
+/// Batch metadata update — apply name/description/category/tag changes to multiple contracts (#849).
+/// Each item is processed in its own transaction so a per-item failure never rolls back prior items.
+/// A version snapshot is written to `contract_metadata_versions` before each update, enabling
+/// per-contract rollback via `POST /api/contracts/:id/metadata/rollback/:version_id`.
+pub async fn batch_update_contract_metadata(
+    State(state): State<AppState>,
+    ValidatedJson(req): ValidatedJson<shared::BatchMetadataUpdateRequest>,
+) -> ApiResult<Json<shared::BatchMetadataUpdateResponse>> {
+    let batch_id = req
+        .batch_id
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+    let user_id = req.user_id;
+
+    let mut results: Vec<shared::BatchMetadataUpdateItemResult> = Vec::new();
+    let mut succeeded = 0usize;
+    let mut failed = 0usize;
+
+    for item in req.items {
+        // Require at least one metadata field per item.
+        if item.name.is_none()
+            && item.description.is_none()
+            && item.category.is_none()
+            && item.tags.is_none()
+        {
+            results.push(shared::BatchMetadataUpdateItemResult {
+                contract_id: item.contract_id,
+                ok: false,
+                rollback_version_id: None,
+                error: Some("at_least_one_field_required".to_string()),
+            });
+            failed += 1;
+            continue;
+        }
+
+        let contract_uuid = match Uuid::parse_str(&item.contract_id) {
+            Ok(id) => id,
+            Err(_) => {
+                results.push(shared::BatchMetadataUpdateItemResult {
+                    contract_id: item.contract_id,
+                    ok: false,
+                    rollback_version_id: None,
+                    error: Some("invalid_contract_id".to_string()),
+                });
+                failed += 1;
+                continue;
+            }
+        };
+
+        // Fetch current contract for before-state.
+        let before: Contract = match sqlx::query_as("SELECT * FROM contracts WHERE id = $1")
+            .bind(contract_uuid)
+            .fetch_one(&state.db)
+            .await
+        {
+            Ok(c) => c,
+            Err(_) => {
+                results.push(shared::BatchMetadataUpdateItemResult {
+                    contract_id: item.contract_id,
+                    ok: false,
+                    rollback_version_id: None,
+                    error: Some("not_found".to_string()),
+                });
+                failed += 1;
+                continue;
+            }
+        };
+
+        // Fetch current tag names for the snapshot.
+        let before_tag_names: Vec<String> = match sqlx::query_scalar::<_, String>(
+            "SELECT t.name FROM tags t JOIN contract_tags ct ON t.id = ct.tag_id WHERE ct.contract_id = $1",
+        )
+        .bind(contract_uuid)
+        .fetch_all(&state.db)
+        .await
+        {
+            Ok(names) => names,
+            Err(e) => {
+                results.push(shared::BatchMetadataUpdateItemResult {
+                    contract_id: item.contract_id,
+                    ok: false,
+                    rollback_version_id: None,
+                    error: Some(format!("fetch_tags_failed: {}", e)),
+                });
+                failed += 1;
+                continue;
+            }
+        };
+
+        // Per-item transaction.
+        let mut tx = match state.db.begin().await {
+            Ok(tx) => tx,
+            Err(e) => {
+                results.push(shared::BatchMetadataUpdateItemResult {
+                    contract_id: item.contract_id,
+                    ok: false,
+                    rollback_version_id: None,
+                    error: Some(format!("begin_tx_failed: {}", e)),
+                });
+                failed += 1;
+                continue;
+            }
+        };
+
+        // Snapshot current metadata so callers can rollback to this version.
+        let snapshot_summary = item
+            .change_summary
+            .as_deref()
+            .map(|s| format!("Before batch update: {}", s));
+        let rollback_version_id: Uuid = match sqlx::query_scalar(
+            "INSERT INTO contract_metadata_versions
+                 (contract_id, user_id, name, description, category, tags, change_summary)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             RETURNING id",
+        )
+        .bind(contract_uuid)
+        .bind(user_id)
+        .bind(&before.name)
+        .bind(&before.description)
+        .bind(&before.category)
+        .bind(&before_tag_names)
+        .bind(snapshot_summary)
+        .fetch_one(&mut *tx)
+        .await
+        {
+            Ok(id) => id,
+            Err(e) => {
+                let _ = tx.rollback().await;
+                results.push(shared::BatchMetadataUpdateItemResult {
+                    contract_id: item.contract_id,
+                    ok: false,
+                    rollback_version_id: None,
+                    error: Some(format!("snapshot_failed: {}", e)),
+                });
+                failed += 1;
+                continue;
+            }
+        };
+
+        // Apply COALESCE UPDATE.
+        let mut after: Contract = match sqlx::query_as(
+            "UPDATE contracts
+             SET name        = COALESCE($2, name),
+                 description = COALESCE($3, description),
+                 category    = COALESCE($4, category),
+                 updated_at  = NOW()
+             WHERE id = $1
+             RETURNING *",
+        )
+        .bind(contract_uuid)
+        .bind(item.name.as_deref())
+        .bind(item.description.as_deref())
+        .bind(item.category.as_deref())
+        .fetch_one(&mut *tx)
+        .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = tx.rollback().await;
+                results.push(shared::BatchMetadataUpdateItemResult {
+                    contract_id: item.contract_id,
+                    ok: false,
+                    rollback_version_id: Some(rollback_version_id),
+                    error: Some(format!("update_failed: {}", e)),
+                });
+                failed += 1;
+                continue;
+            }
+        };
+
+        // Sync tags when the caller supplied a tag list.
+        let mut after_tag_names = before_tag_names.clone();
+        if let Some(tag_names) = &item.tags {
+            after_tag_names = tag_names.clone();
+
+            if let Err(e) = sqlx::query("DELETE FROM contract_tags WHERE contract_id = $1")
+                .bind(contract_uuid)
+                .execute(&mut *tx)
+                .await
+            {
+                let _ = tx.rollback().await;
+                results.push(shared::BatchMetadataUpdateItemResult {
+                    contract_id: item.contract_id,
+                    ok: false,
+                    rollback_version_id: Some(rollback_version_id),
+                    error: Some(format!("delete_tags_failed: {}", e)),
+                });
+                failed += 1;
+                continue;
+            }
+
+            let mut new_tags: Vec<shared::Tag> = Vec::new();
+            let mut tag_error: Option<String> = None;
+            for tag_name in tag_names {
+                let tag: Result<shared::Tag, _> = sqlx::query_as(
+                    "INSERT INTO tags (name) VALUES ($1)
+                     ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+                     RETURNING id, name, color",
+                )
+                .bind(tag_name)
+                .fetch_one(&mut *tx)
+                .await;
+
+                match tag {
+                    Ok(t) => {
+                        let link = sqlx::query(
+                            "INSERT INTO contract_tags (contract_id, tag_id)
+                             VALUES ($1, $2) ON CONFLICT DO NOTHING",
+                        )
+                        .bind(contract_uuid)
+                        .bind(t.id)
+                        .execute(&mut *tx)
+                        .await;
+                        if let Err(e) = link {
+                            tag_error = Some(format!("link_tag_failed: {}", e));
+                            break;
+                        }
+                        new_tags.push(t);
+                    }
+                    Err(e) => {
+                        tag_error = Some(format!("upsert_tag_failed: {}", e));
+                        break;
+                    }
+                }
+            }
+
+            if let Some(err) = tag_error {
+                let _ = tx.rollback().await;
+                results.push(shared::BatchMetadataUpdateItemResult {
+                    contract_id: item.contract_id,
+                    ok: false,
+                    rollback_version_id: Some(rollback_version_id),
+                    error: Some(err),
+                });
+                failed += 1;
+                continue;
+            }
+            after.tags = new_tags;
+        }
+
+        // Commit this item.
+        if let Err(e) = tx.commit().await {
+            results.push(shared::BatchMetadataUpdateItemResult {
+                contract_id: item.contract_id,
+                ok: false,
+                rollback_version_id: Some(rollback_version_id),
+                error: Some(format!("commit_failed: {}", e)),
+            });
+            failed += 1;
+            continue;
+        }
+
+        // Audit log (best-effort, after commit).
+        let changes = json!({
+            "name":        { "before": before.name,        "after": after.name },
+            "description": { "before": before.description, "after": after.description },
+            "category":    { "before": before.category,    "after": after.category },
+            "tags":        { "before": before_tag_names,   "after": after_tag_names },
+            "batch_id":    &batch_id,
+        });
+        let _ = write_contract_audit_log(
+            &state.db,
+            AuditActionType::MetadataUpdated,
+            contract_uuid,
+            user_id.unwrap_or(before.publisher_id),
+            changes,
+            "batch",
+        )
+        .await;
+
+        results.push(shared::BatchMetadataUpdateItemResult {
+            contract_id: item.contract_id,
+            ok: true,
+            rollback_version_id: Some(rollback_version_id),
+            error: None,
+        });
+        succeeded += 1;
+    }
+
+    state.cache.invalidate_contracts().await;
+
+    Ok(Json(shared::BatchMetadataUpdateResponse {
+        batch_id,
+        total: results.len(),
+        succeeded,
+        failed,
+        results,
+    }))
 }
 
 #[utoipa::path(

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -528,6 +528,24 @@ pub fn contract_routes() -> Router<AppState> {
             "/api/contracts/status/bulk",
             post(handlers::bulk_update_contract_status),
         )
+        // Batch metadata update (#849) — static route must precede parameterised :id routes
+        .route(
+            "/api/contracts/metadata/batch",
+            post(handlers::batch_update_contract_metadata),
+        )
+        // Metadata history & rollback (#729, wired here)
+        .route(
+            "/api/contracts/:id/metadata/versions",
+            get(handlers::contract_metadata::get_metadata_versions),
+        )
+        .route(
+            "/api/contracts/:id/metadata/versions/:version_id",
+            get(handlers::contract_metadata::get_metadata_version),
+        )
+        .route(
+            "/api/contracts/:id/metadata/rollback/:version_id",
+            post(handlers::contract_metadata::rollback_metadata),
+        )
         .route(
             "/api/contracts/:id/performance",
             get(performance_handlers::get_contract_performance_overview),

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -797,6 +797,45 @@ pub struct UpdateContractMetadataRequest {
     pub user_id: Option<Uuid>,
 }
 
+/// Item in a batch metadata update request (#849)
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct BatchMetadataUpdateItem {
+    pub contract_id: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub category: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub change_summary: Option<String>,
+}
+
+/// Request body for POST /api/contracts/metadata/batch (#849)
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct BatchMetadataUpdateRequest {
+    pub items: Vec<BatchMetadataUpdateItem>,
+    pub user_id: Option<Uuid>,
+    /// Client-supplied UUID for correlating audit log entries across the batch
+    pub batch_id: Option<String>,
+}
+
+/// Per-item result within a batch metadata update response (#849)
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct BatchMetadataUpdateItemResult {
+    pub contract_id: String,
+    pub ok: bool,
+    pub rollback_version_id: Option<Uuid>,
+    pub error: Option<String>,
+}
+
+/// Response body for POST /api/contracts/metadata/batch (#849)
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct BatchMetadataUpdateResponse {
+    pub batch_id: String,
+    pub total: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    pub results: Vec<BatchMetadataUpdateItemResult>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ChangePublisherRequest {
     pub publisher_address: String,

--- a/cli/src/batch_update.rs
+++ b/cli/src/batch_update.rs
@@ -1,0 +1,613 @@
+#![allow(dead_code)]
+
+use crate::net::RequestBuilderExt;
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use tokio::task::JoinSet;
+use uuid::Uuid;
+
+const MAX_BATCH_SIZE: usize = 50;
+const BATCH_TIMEOUT_SECS: u64 = 30;
+const CHUNK_CONCURRENCY: usize = 4;
+
+// ── Public entry point ─────────────────────────────────────────────────────────
+
+pub struct BatchUpdateArgs<'a> {
+    pub api_url: &'a str,
+    pub file: Option<&'a str>,
+    pub filter: Option<&'a str>,
+    pub preview: bool,
+    pub condition: Option<&'a str>,
+    pub user_id: Option<&'a str>,
+    pub rollback_on_error: bool,
+    pub json: bool,
+}
+
+// ── Manifest types ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, Default)]
+pub struct UpdateManifest {
+    #[serde(default)]
+    pub metadata: MetadataUpdate,
+    #[serde(default)]
+    pub contracts: Vec<ContractUpdateEntry>,
+    pub change_summary: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct MetadataUpdate {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub category: Option<String>,
+    pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ContractUpdateEntry {
+    pub contract_id: String,
+    // Per-contract overrides — win over global metadata.
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub category: Option<String>,
+    pub tags: Option<Vec<String>>,
+}
+
+// ── Request / response types ───────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Clone)]
+struct BatchUpdateItem {
+    contract_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    change_summary: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct BatchUpdateRequest {
+    items: Vec<BatchUpdateItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user_id: Option<String>,
+    batch_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BatchUpdateItemResult {
+    contract_id: String,
+    ok: bool,
+    rollback_version_id: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BackendBatchUpdateResponse {
+    batch_id: String,
+    total: usize,
+    succeeded: usize,
+    failed: usize,
+    results: Vec<BatchUpdateItemResult>,
+}
+
+// ── Report types ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct BatchUpdateResult {
+    pub contract_id: String,
+    pub status: String, // "updated" | "skipped" | "failed" | "preview" | "rolled_back"
+    pub rollback_version_id: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BatchUpdateReport {
+    pub batch_id: String,
+    pub preview: bool,
+    pub total: usize,
+    pub updated: usize,
+    pub skipped: usize,
+    pub failed: usize,
+    pub rolled_back: usize,
+    pub results: Vec<BatchUpdateResult>,
+}
+
+// ── Main entry point ───────────────────────────────────────────────────────────
+
+pub async fn run_batch_update(args: BatchUpdateArgs<'_>) -> Result<()> {
+    if args.file.is_none() && args.filter.is_none() {
+        anyhow::bail!("Provide --file and/or --filter to identify contracts to update");
+    }
+
+    let manifest = if let Some(path) = args.file {
+        load_manifest(path)?
+    } else {
+        UpdateManifest::default()
+    };
+
+    // Resolve IDs from manifest entries.
+    let mut contract_ids: Vec<String> = manifest
+        .contracts
+        .iter()
+        .map(|e| e.contract_id.clone())
+        .collect();
+
+    // Augment from filter if provided.
+    if let Some(filter) = args.filter {
+        let filter_ids = fetch_ids_by_filter(args.api_url, filter).await?;
+        contract_ids.extend(filter_ids);
+    }
+
+    // Deduplicate while preserving order.
+    let contract_ids = deduplicate_ids(contract_ids);
+
+    if contract_ids.is_empty() {
+        anyhow::bail!("No contract IDs resolved — check --file / --filter");
+    }
+
+    // Build per-contract payloads by merging global metadata with per-contract overrides.
+    let overrides: std::collections::HashMap<String, &ContractUpdateEntry> = manifest
+        .contracts
+        .iter()
+        .map(|e| (e.contract_id.clone(), e))
+        .collect();
+
+    let mut items: Vec<BatchUpdateItem> = contract_ids
+        .iter()
+        .map(|id| {
+            let ovr = overrides.get(id.as_str());
+            BatchUpdateItem {
+                contract_id: id.clone(),
+                name: ovr.and_then(|o| o.name.clone()).or_else(|| manifest.metadata.name.clone()),
+                description: ovr
+                    .and_then(|o| o.description.clone())
+                    .or_else(|| manifest.metadata.description.clone()),
+                category: ovr
+                    .and_then(|o| o.category.clone())
+                    .or_else(|| manifest.metadata.category.clone()),
+                tags: ovr
+                    .and_then(|o| o.tags.clone())
+                    .or_else(|| manifest.metadata.tags.clone()),
+                change_summary: manifest.change_summary.clone(),
+            }
+        })
+        .collect();
+
+    // Apply --if condition client-side: mark non-matching IDs to skip.
+    let mut skipped_ids: HashSet<String> = HashSet::new();
+    if let Some(condition) = args.condition {
+        let (field, value) = parse_condition(condition)?;
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
+        for id in &contract_ids {
+            let url = format!("{}/api/contracts/{}", args.api_url, id);
+            let resp = client.get(&url).send_with_retry().await;
+            if let Ok(r) = resp {
+                if let Ok(body) = r.json::<serde_json::Value>().await {
+                    let actual = body.get(&field).and_then(|v| v.as_str()).unwrap_or("");
+                    if actual != value {
+                        skipped_ids.insert(id.clone());
+                    }
+                }
+            }
+        }
+        items.retain(|i| !skipped_ids.contains(&i.contract_id));
+    }
+
+    let batch_id = Uuid::new_v4().to_string();
+
+    // Preview mode: show diff table without making any writes.
+    if args.preview {
+        let report = build_preview_report(&batch_id, &items, &skipped_ids);
+        if args.json {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        } else {
+            print_preview_table(&report);
+        }
+        return Ok(());
+    }
+
+    println!("\n{}", "Batch Metadata Update".bold().cyan());
+    println!("{}", "=".repeat(60).cyan());
+    println!("  {}: {}", "Contracts".bold(), items.len());
+    if !skipped_ids.is_empty() {
+        println!("  {}: {} (condition not met)", "Skipped".bold(), skipped_ids.len().to_string().yellow());
+    }
+    println!("  {}: {}", "Batch ID".bold(), batch_id.bright_black());
+    println!();
+
+    // Chunk and dispatch.
+    let request = BatchUpdateRequest {
+        items,
+        user_id: args.user_id.map(|s| s.to_string()),
+        batch_id: batch_id.clone(),
+    };
+
+    let backend_resp = dispatch_chunks(args.api_url, request).await?;
+
+    // Handle --rollback-on-error: rollback all successfully applied contracts on failure.
+    let mut rolled_back = 0usize;
+    if args.rollback_on_error && backend_resp.failed > 0 {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(BATCH_TIMEOUT_SECS))
+            .build()?;
+        for result in &backend_resp.results {
+            if result.ok {
+                if let Some(ref version_id) = result.rollback_version_id {
+                    let url = format!(
+                        "{}/api/contracts/{}/metadata/rollback/{}",
+                        args.api_url, result.contract_id, version_id
+                    );
+                    let _ = client.post(&url).send_with_retry().await;
+                    rolled_back += 1;
+                }
+            }
+        }
+        if rolled_back > 0 {
+            println!(
+                "  {} Rolled back {} contract(s) due to partial failure",
+                "⚠".yellow(),
+                rolled_back
+            );
+        }
+    }
+
+    let mut results: Vec<BatchUpdateResult> = Vec::new();
+    for r in &backend_resp.results {
+        results.push(BatchUpdateResult {
+            contract_id: r.contract_id.clone(),
+            status: if rolled_back > 0 && r.ok {
+                "rolled_back".to_string()
+            } else if r.ok {
+                "updated".to_string()
+            } else {
+                "failed".to_string()
+            },
+            rollback_version_id: r.rollback_version_id.clone(),
+            error: r.error.clone(),
+        });
+    }
+    for id in &skipped_ids {
+        results.push(BatchUpdateResult {
+            contract_id: id.clone(),
+            status: "skipped".to_string(),
+            rollback_version_id: None,
+            error: None,
+        });
+    }
+
+    let report = BatchUpdateReport {
+        batch_id: backend_resp.batch_id,
+        preview: false,
+        total: results.len(),
+        updated: backend_resp.succeeded,
+        skipped: skipped_ids.len(),
+        failed: backend_resp.failed,
+        rolled_back,
+        results,
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_report_table(&report);
+    }
+
+    if report.failed > 0 && !args.rollback_on_error {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+// ── Manifest loading ───────────────────────────────────────────────────────────
+
+fn load_manifest(path: &str) -> Result<UpdateManifest> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read manifest: {}", path))?;
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    match ext.as_str() {
+        "json" => serde_json::from_str(&content).context("Failed to parse JSON manifest"),
+        "yaml" | "yml" => {
+            serde_yaml::from_str(&content).context("Failed to parse YAML manifest")
+        }
+        _ => anyhow::bail!("Unsupported manifest format '{}' — use .yaml, .yml, or .json", ext),
+    }
+}
+
+// ── Filter-based ID discovery ──────────────────────────────────────────────────
+
+async fn fetch_ids_by_filter(api_url: &str, filter: &str) -> Result<Vec<String>> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
+
+    // filter format: "field=value[,field=value,...]"
+    let query_params = filter
+        .split(',')
+        .filter_map(|part| {
+            let mut kv = part.splitn(2, '=');
+            let k = kv.next()?.trim();
+            let v = kv.next()?.trim();
+            if k.is_empty() || v.is_empty() {
+                None
+            } else {
+                Some(format!("{}={}", k, v))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+
+    let mut ids = Vec::new();
+    let mut page = 1i64;
+
+    loop {
+        let url = format!("{}/api/contracts?limit=100&page={}&{}", api_url, page, query_params);
+        let resp = client
+            .get(&url)
+            .send_with_retry()
+            .await
+            .context("Failed to fetch contracts from API")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let err = resp.text().await.unwrap_or_else(|_| "unknown".to_string());
+            anyhow::bail!("API error fetching contracts (HTTP {}): {}", status, err);
+        }
+
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .context("Failed to parse contracts list response")?;
+
+        let items = body
+            .get("items")
+            .or_else(|| body.get("contracts"))
+            .or_else(|| body.get("data"))
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        if items.is_empty() {
+            break;
+        }
+
+        let total_pages = body.get("pages").and_then(|v| v.as_i64()).unwrap_or(1);
+
+        for item in &items {
+            if let Some(id) = item.get("id").or_else(|| item.get("contract_id")).and_then(|v| v.as_str()) {
+                if !id.is_empty() {
+                    ids.push(id.to_string());
+                }
+            }
+        }
+
+        if page >= total_pages {
+            break;
+        }
+        page += 1;
+    }
+
+    Ok(ids)
+}
+
+// ── Deduplication ──────────────────────────────────────────────────────────────
+
+fn deduplicate_ids(ids: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    ids.into_iter().filter(|id| seen.insert(id.clone())).collect()
+}
+
+// ── Condition parsing ──────────────────────────────────────────────────────────
+
+fn parse_condition(condition: &str) -> Result<(String, String)> {
+    let mut parts = condition.splitn(2, '=');
+    let field = parts
+        .next()
+        .filter(|s| !s.is_empty())
+        .context("Condition must be in the form field=value")?
+        .to_string();
+    let value = parts
+        .next()
+        .context("Condition must be in the form field=value")?
+        .to_string();
+    Ok((field, value))
+}
+
+// ── Chunked dispatch ───────────────────────────────────────────────────────────
+
+async fn dispatch_chunks(
+    api_url: &str,
+    req: BatchUpdateRequest,
+) -> Result<BackendBatchUpdateResponse> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(BATCH_TIMEOUT_SECS))
+        .build()?;
+
+    let chunks: Vec<Vec<BatchUpdateItem>> = req
+        .items
+        .chunks(MAX_BATCH_SIZE)
+        .map(|c| c.to_vec())
+        .collect();
+
+    let total_chunks = chunks.len();
+    if total_chunks > 1 {
+        println!(
+            "  {} {} chunks of up to {} contracts",
+            "Dispatching".bold(),
+            total_chunks,
+            MAX_BATCH_SIZE
+        );
+    }
+
+    let mut set: JoinSet<Result<BackendBatchUpdateResponse>> = JoinSet::new();
+    let mut merged = BackendBatchUpdateResponse {
+        batch_id: req.batch_id.clone(),
+        total: 0,
+        succeeded: 0,
+        failed: 0,
+        results: Vec::new(),
+    };
+    let user_id = req.user_id.clone();
+    let batch_id = req.batch_id.clone();
+    let mut chunks_iter = chunks.into_iter();
+
+    for chunk in chunks_iter.by_ref().take(CHUNK_CONCURRENCY) {
+        let c = client.clone();
+        let url = api_url.to_string();
+        let uid = user_id.clone();
+        let bid = batch_id.clone();
+        set.spawn(async move { send_chunk(&c, &url, chunk, uid, bid).await });
+    }
+
+    while let Some(result) = set.join_next().await {
+        let resp = result.context("Chunk task panicked")??;
+        merged.total += resp.total;
+        merged.succeeded += resp.succeeded;
+        merged.failed += resp.failed;
+        merged.results.extend(resp.results);
+
+        if let Some(chunk) = chunks_iter.next() {
+            let c = client.clone();
+            let url = api_url.to_string();
+            let uid = user_id.clone();
+            let bid = batch_id.clone();
+            set.spawn(async move { send_chunk(&c, &url, chunk, uid, bid).await });
+        }
+    }
+
+    Ok(merged)
+}
+
+async fn send_chunk(
+    client: &reqwest::Client,
+    api_url: &str,
+    items: Vec<BatchUpdateItem>,
+    user_id: Option<String>,
+    batch_id: String,
+) -> Result<BackendBatchUpdateResponse> {
+    let req = BatchUpdateRequest {
+        items,
+        user_id,
+        batch_id,
+    };
+
+    let resp = client
+        .post(format!("{}/api/contracts/metadata/batch", api_url))
+        .json(&req)
+        .send_with_retry()
+        .await
+        .context("Failed to reach registry API — is the server running?")?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let err = resp.text().await.unwrap_or_else(|_| "unknown".to_string());
+        anyhow::bail!("API error (HTTP {}): {}", status, err);
+    }
+
+    resp.json::<BackendBatchUpdateResponse>()
+        .await
+        .context("Failed to parse batch update response")
+}
+
+// ── Preview ────────────────────────────────────────────────────────────────────
+
+fn build_preview_report(
+    batch_id: &str,
+    items: &[BatchUpdateItem],
+    skipped_ids: &HashSet<String>,
+) -> BatchUpdateReport {
+    let mut results: Vec<BatchUpdateResult> = items
+        .iter()
+        .map(|i| BatchUpdateResult {
+            contract_id: i.contract_id.clone(),
+            status: "preview".to_string(),
+            rollback_version_id: None,
+            error: None,
+        })
+        .collect();
+    for id in skipped_ids {
+        results.push(BatchUpdateResult {
+            contract_id: id.clone(),
+            status: "skipped".to_string(),
+            rollback_version_id: None,
+            error: None,
+        });
+    }
+    BatchUpdateReport {
+        batch_id: batch_id.to_string(),
+        preview: true,
+        total: results.len(),
+        updated: 0,
+        skipped: skipped_ids.len(),
+        failed: 0,
+        rolled_back: 0,
+        results,
+    }
+}
+
+// ── Display helpers ────────────────────────────────────────────────────────────
+
+fn print_preview_table(report: &BatchUpdateReport) {
+    println!("\n{}", "Batch Metadata Update — Preview".bold().cyan());
+    println!("{}", "=".repeat(60).cyan());
+    println!("  {}: {}", "Total contracts".bold(), report.total);
+    println!("  {}: {}", "Would update".bold(), (report.total - report.skipped).to_string().green());
+    if report.skipped > 0 {
+        println!("  {}: {}", "Would skip".bold(), report.skipped.to_string().yellow());
+    }
+    println!();
+    println!("{:<40} {}", "Contract ID".bold(), "Action".bold());
+    println!("{}", "-".repeat(50));
+    for r in &report.results {
+        let action = match r.status.as_str() {
+            "preview" => "would update".green(),
+            "skipped" => "skip (condition)".yellow(),
+            _ => r.status.as_str().normal(),
+        };
+        println!("{:<40} {}", &r.contract_id[..r.contract_id.len().min(40)], action);
+    }
+    println!();
+    println!("{}", "(no writes were made — remove --preview to apply)".bright_black());
+}
+
+fn print_report_table(report: &BatchUpdateReport) {
+    println!("{}", "Results".bold().cyan());
+    println!("{}", "=".repeat(60).cyan());
+    println!("  {}: {}", "Updated".bold(), report.updated.to_string().green());
+    if report.skipped > 0 {
+        println!("  {}: {}", "Skipped".bold(), report.skipped.to_string().yellow());
+    }
+    if report.failed > 0 {
+        println!("  {}: {}", "Failed".bold(), report.failed.to_string().red());
+    }
+    if report.rolled_back > 0 {
+        println!("  {}: {}", "Rolled back".bold(), report.rolled_back.to_string().yellow());
+    }
+    println!("  {}: {}", "Batch ID".bold(), report.batch_id.bright_black());
+    println!();
+
+    let has_errors = report.results.iter().any(|r| r.error.is_some());
+    if has_errors {
+        println!("{}", "Failures:".bold().red());
+        for r in report.results.iter().filter(|r| r.error.is_some()) {
+            println!(
+                "  {} — {}",
+                r.contract_id.bright_red(),
+                r.error.as_deref().unwrap_or("unknown error").red()
+            );
+        }
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@ mod audit_command;
 mod backup;
 mod batch_ops;
 mod batch_register;
+mod batch_update;
 mod batch_verify;
 mod cicd;
 mod codegen;
@@ -840,6 +841,37 @@ pub enum Commands {
         /// Validate all entries and show what would be registered without submitting
         #[arg(long)]
         dry_run: bool,
+
+        /// Output results as machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Update metadata for multiple contracts in bulk (#849)
+    BatchUpdate {
+        /// Path to a YAML or JSON manifest file describing the updates
+        #[arg(long)]
+        file: Option<String>,
+
+        /// Filter contracts from the API (e.g. "category=defi" or "network=mainnet")
+        #[arg(long)]
+        filter: Option<String>,
+
+        /// Show what would change without making any writes
+        #[arg(long)]
+        preview: bool,
+
+        /// Only update contracts where this field=value condition is true
+        #[arg(long, value_name = "CONDITION")]
+        r#if: Option<String>,
+
+        /// User ID to attribute the update to
+        #[arg(long)]
+        user_id: Option<String>,
+
+        /// On partial failure, rollback all successfully applied contracts
+        #[arg(long)]
+        rollback_on_error: bool,
 
         /// Output results as machine-readable JSON
         #[arg(long)]
@@ -3049,6 +3081,27 @@ pub async fn dispatch_command(
                 dry_run,
                 json,
             )
+            .await?;
+        }
+        Commands::BatchUpdate {
+            file,
+            filter,
+            preview,
+            r#if: condition,
+            user_id,
+            rollback_on_error,
+            json,
+        } => {
+            batch_update::run_batch_update(batch_update::BatchUpdateArgs {
+                api_url: &cli.api_url,
+                file: file.as_deref(),
+                filter: filter.as_deref(),
+                preview,
+                condition: condition.as_deref(),
+                user_id: user_id.as_deref(),
+                rollback_on_error,
+                json,
+            })
             .await?;
         }
         Commands::Batch {


### PR DESCRIPTION
# Closes #849 

##  feat: Add `batch update` Command for Bulk Contract Metadata ([#849](#))

### Summary

Implements `soroban-registry batch-update` — a bulk metadata update command that applies `name`/`description`/`category`/`tag` changes to multiple contracts at once, with preview mode, conditional filtering, per-item rollback snapshots, and audit trail.

Also wires up the already-written metadata history & rollback routes from [#729](#) which were implemented but never registered.

---

###  Changes

#### `backend/shared/src/models.rs`
Added the following types:
- `BatchMetadataUpdateItem`
- `BatchMetadataUpdateRequest`
- `BatchMetadataUpdateItemResult`
- `BatchMetadataUpdateResponse`

#### `backend/api/src/handlers.rs`
- Declared `pub mod contract_metadata` to expose the `#729` handlers
- Added `batch_update_contract_metadata` handler:
  - **Per-item transactions** — a failure on one contract never rolls back others
  - **Pre-update snapshot** — inserts current state into `contract_metadata_versions` before each change, returning a `rollback_version_id` per item
  - **`COALESCE` UPDATE** — only overwrites fields explicitly provided
  - **Tag sync** — `DELETE` + upsert pattern, consistent with single-contract metadata update
  - **Audit logging** — writes `AuditActionType::MetadataUpdated` with `batch_id` in the JSONB payload for cross-item correlation

#### `backend/api/src/routes.rs`
| Route | Description |
|-------|-------------|
| `POST /api/contracts/metadata/batch` | Batch metadata update *(this PR)* |
| `GET /api/contracts/:id/metadata/versions` | Metadata history *([#729](#))* |
| `GET /api/contracts/:id/metadata/versions/:version_id` | Single version *([#729](#))* |
| `POST /api/contracts/:id/metadata/rollback/:version_id` | Rollback *([#729](#))* |

#### `cli/src/batch_update.rs` — New File
- **Manifest loading** — YAML or JSON, with global metadata fields and per-contract overrides *(override wins)*
- **`--filter`** — discovers contracts from the API via paginated `GET /api/contracts`
- **`--if field=value`** — client-side condition check; non-matching contracts are marked `skipped`
- **`--preview`** — prints a diff table with no writes made; exits `0`
- **Chunked concurrent dispatch** — groups of 50, 4 concurrent chunks *(matches `batch_verify` pattern)*
- **`--rollback-on-error`** — on partial failure, calls `POST /:id/metadata/rollback/:version_id` for all successfully applied contracts

#### `cli/src/main.rs`
Added `mod batch_update`, `Commands::BatchUpdate` variant, and dispatch arm *(first block only — second and third blocks are known dead-code artifacts)*

---

###  Usage

```bash
# Preview changes from a manifest (no writes)
soroban-registry batch-update --file updates.yaml --preview

# Apply to all DeFi contracts where is_verified=true
soroban-registry batch-update --file updates.yaml --filter "category=defi" --if "is_verified=true"

# Apply with rollback on any failure
soroban-registry batch-update --file updates.yaml --rollback-on-error --json
```

#### Manifest format (`updates.yaml`)

```yaml
metadata:
  category: "DeFi"
  tags: ["audited", "q2-2026"]
contracts:
  - contract_id: "CABC123..."
    name: "Override Name for this contract only"
change_summary: "Q2 audit batch reclassification"
```