### PR TITLE
Unified search filters, CLI format/dependency improvements, config-driven feature flags

### DIFF
--- a/backend/api/src/config.rs
+++ b/backend/api/src/config.rs
@@ -1,6 +1,13 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct FeatureFlagEntry {
+    pub key: String,
+    pub is_enabled: bool,
+    pub rollout_percentage: u8,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct AppConfig {
     pub database_url: String,
@@ -11,6 +18,10 @@ pub struct AppConfig {
     pub log_level: String,
     #[serde(default = "default_cache_url")]
     pub redis_url: String,
+    /// JSON-encoded feature flags configuration.
+    /// Format: [{"key":"flag_name","is_enabled":true,"rollout_percentage":100}]
+    #[serde(default)]
+    pub feature_flags_json: String,
 }
 
 fn default_cache_url() -> String {
@@ -26,6 +37,16 @@ pub fn load_config() -> Result<AppConfig> {
     validate_config(&config)?;
 
     Ok(config)
+}
+
+pub fn parse_feature_flags(json_str: &str) -> Vec<FeatureFlagEntry> {
+    if json_str.is_empty() {
+        return Vec::new();
+    }
+    serde_json::from_str(json_str).unwrap_or_else(|e| {
+        tracing::warn!("Failed to parse FEATURE_FLAGS_JSON: {}. Using defaults.", e);
+        Vec::new()
+    })
 }
 
 fn validate_config(config: &AppConfig) -> Result<()> {

--- a/backend/api/src/feature_flags.rs
+++ b/backend/api/src/feature_flags.rs
@@ -1,3 +1,21 @@
+//! Feature flag system for the registry API (#1007)
+//!
+//! Flags can be loaded from configuration (FEATURE_FLAGS_JSON env var) or
+//! managed at runtime through the admin API. Each flag supports:
+//! - Global on/off toggle
+//! - Gradual rollout percentage
+//! - Per-user targeting
+//! - Evaluation metrics
+
+use crate::config::FeatureFlagEntry;
+use crate::state::AppState;
+use axum::{
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Json, Response},
+};
+use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -19,6 +37,15 @@ pub struct FeatureFlagMetrics {
     pub hits: AtomicU64,
 }
 
+#[derive(Serialize)]
+pub struct FlagStatus {
+    pub key: String,
+    pub is_enabled: bool,
+    pub rollout_percentage: u8,
+    pub evaluations: u64,
+    pub hits: u64,
+}
+
 pub struct FeatureFlagManager {
     flags: RwLock<HashMap<String, FeatureFlag>>,
     metrics: RwLock<HashMap<String, Arc<FeatureFlagMetrics>>>,
@@ -26,17 +53,34 @@ pub struct FeatureFlagManager {
 
 impl FeatureFlagManager {
     pub fn new() -> Self {
+        Self::from_config(&[])
+    }
+
+    /// Create a manager initialized from configuration entries.
+    /// Falls back to safe defaults for any flags not present in config.
+    pub fn from_config(entries: &[FeatureFlagEntry]) -> Self {
         let mut flags = HashMap::new();
-        // Initialize with some safe defaults
-        flags.insert(
-            "new_dashboard".to_string(),
-            FeatureFlag {
-                key: "new_dashboard".to_string(),
-                is_enabled: false,
-                rollout_percentage: 0,
-                targeted_users: vec![],
-            },
-        );
+
+        // Apply config entries
+        for entry in entries {
+            flags.insert(
+                entry.key.clone(),
+                FeatureFlag {
+                    key: entry.key.clone(),
+                    is_enabled: entry.is_enabled,
+                    rollout_percentage: entry.rollout_percentage,
+                    targeted_users: vec![],
+                },
+            );
+        }
+
+        // Ensure safe defaults for known flags if not in config
+        flags.entry("new_dashboard".to_string()).or_insert(FeatureFlag {
+            key: "new_dashboard".to_string(),
+            is_enabled: false,
+            rollout_percentage: 0,
+            targeted_users: vec![],
+        });
 
         Self {
             flags: RwLock::new(flags),
@@ -45,7 +89,6 @@ impl FeatureFlagManager {
     }
 
     pub async fn is_enabled(&self, key: &str, user_id: Option<Uuid>) -> bool {
-        // Record evaluation metrics
         let metrics_arc = {
             let mut metrics_guard = self.metrics.write().await;
             if !metrics_guard.contains_key(key) {
@@ -62,7 +105,6 @@ impl FeatureFlagManager {
                 return false;
             }
 
-            // Check specific user targeting
             if let Some(uid) = user_id {
                 if flag.targeted_users.contains(&uid) {
                     metrics_arc.hits.fetch_add(1, Ordering::Relaxed);
@@ -70,17 +112,14 @@ impl FeatureFlagManager {
                 }
             }
 
-            // Check rollout percentage (deterministic based on user_id or random)
             let enabled = if flag.rollout_percentage >= 100 {
                 true
             } else if flag.rollout_percentage == 0 {
                 false
             } else if let Some(uid) = user_id {
-                // Deterministic rollout based on user id
                 let hash = self.hash_uuid(uid);
                 (hash % 100) < (flag.rollout_percentage as u64)
             } else {
-                // If no user ID is provided, randomly sample
                 rand::random::<u8>() % 100 < flag.rollout_percentage
             };
 
@@ -91,7 +130,6 @@ impl FeatureFlagManager {
             return enabled;
         }
 
-        // Safe default for undefined flags
         false
     }
 
@@ -116,6 +154,28 @@ impl FeatureFlagManager {
         result
     }
 
+    /// Return all registered flags with their current status and evaluation metrics
+    pub async fn get_all_status(&self) -> Vec<FlagStatus> {
+        let flags = self.flags.read().await;
+        let metrics = self.metrics.read().await;
+        let mut result = Vec::with_capacity(flags.len());
+        for (key, flag) in flags.iter() {
+            let (evaluations, hits) = metrics
+                .get(key)
+                .map(|m| (m.evaluations.load(Ordering::Relaxed), m.hits.load(Ordering::Relaxed)))
+                .unwrap_or((0, 0));
+            result.push(FlagStatus {
+                key: key.clone(),
+                is_enabled: flag.is_enabled,
+                rollout_percentage: flag.rollout_percentage,
+                evaluations,
+                hits,
+            });
+        }
+        result.sort_by(|a, b| a.key.cmp(&b.key));
+        result
+    }
+
     fn hash_uuid(&self, uid: Uuid) -> u64 {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
@@ -123,4 +183,37 @@ impl FeatureFlagManager {
         uid.hash(&mut hasher);
         hasher.finish()
     }
+}
+
+/// Axum middleware that rejects a request when the named feature flag is disabled.
+/// Use for routes that should only be accessible when a feature flag is active.
+pub async fn require_feature_flag<B>(
+    State(state): State<AppState>,
+    req: Request<B>,
+    next: Next<B>,
+) -> Response {
+    // Extract the feature flag key from an extension set by the router
+    let flag_key = match req.extensions().get::<String>() {
+        Some(key) => key.clone(),
+        None => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, "No feature flag key set").into_response();
+        }
+    };
+
+    if state.feature_flags.is_enabled(&flag_key, None).await {
+        next.run(req).await
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            format!("This endpoint requires the '{}' feature flag to be enabled", flag_key),
+        )
+            .into_response()
+    }
+}
+
+/// GET /api/feature-flags — return status of all registered feature flags
+pub async fn get_flag_status_handler(
+    State(state): State<AppState>,
+) -> Json<Vec<FlagStatus>> {
+    Json(state.feature_flags.get_all_status().await)
 }

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -2026,6 +2026,33 @@ pub async fn list_contracts(
 
     let mut response = PaginatedResponse::new(contracts, total, page, limit);
 
+    // Populate active filter metadata
+    {
+        let mut networks: Option<Vec<String>> = None;
+        if let Some(n) = &params.networks {
+            if !n.is_empty() {
+                networks = Some(n.iter().map(|net| net.to_string()).collect());
+            }
+        } else if let Some(n) = &params.network {
+            networks = Some(vec![n.to_string()]);
+        }
+        let categories = params.categories.clone().filter(|c| !c.is_empty());
+        let tags = params.tags.clone().filter(|t| !t.is_empty());
+        let verified_only = params.verified_only;
+        let verification_status = params.verification_status.as_ref().map(|s| s.to_string());
+
+        let filters = shared::SearchFilterMetadata {
+            networks,
+            categories,
+            verified_only,
+            verification_status,
+            tags,
+            maturity: params.maturity.as_ref().map(|m| format!("{:?}", m)),
+            query: params.query.clone(),
+        };
+        response = response.with_filters(filters);
+    }
+
     if has_more {
         if let Some(last_item) = response.items.last() {
             let next_cursor = shared::pagination::Cursor::new(last_item.created_at, last_item.id);

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -246,8 +246,12 @@ async fn main() -> Result<()> {
         Duration::from_secs(2), // Ping every 2 seconds
         Duration::from_secs(1), // Timeout after 1 second
     );
-    // Initialize feature flags manager
-    let feature_flags = Arc::new(api::feature_flags::FeatureFlagManager::new());
+    // Initialize feature flags manager from configuration (#1007)
+    let flag_entries = api::config::parse_feature_flags(&config.feature_flags_json);
+    let feature_flags = Arc::new(api::feature_flags::FeatureFlagManager::from_config(&flag_entries));
+    if !flag_entries.is_empty() {
+        tracing::info!(count = flag_entries.len(), "Feature flags loaded from configuration");
+    }
 
     // Create app state
     let is_shutting_down = Arc::new(AtomicBool::new(false));

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -7,7 +7,7 @@ use crate::{
     collaborative_reviews, compatibility_testing_handlers, contract_events,
     contract_stats_handlers, contributor_handlers, custom_metrics_handlers, dependency_handlers,
     deprecated_contracts_handlers, deprecation_handlers, error_logging,
-    formal_verification_handlers, gas_estimation_handlers,
+    feature_flags, formal_verification_handlers, gas_estimation_handlers,
     governance_handlers, graph_analysis_handlers, handlers, interoperability_handlers,
     marketplace::{license_handlers as mp_license, metering as mp_metering,
                   pricing_handlers as mp_pricing, stripe_handlers as mp_stripe,
@@ -91,6 +91,8 @@ pub fn application_routes(_schema: crate::graphql::schema::RegistrySchema) -> Ro
         .merge(discovery_reporting_routes())
         // Contract signature verification system (issue #888)
         .merge(signature_verification_routes())
+        // Backend feature flag management (issue #1007)
+        .merge(feature_flag_routes())
 }
 
 // ── Issue #888: contract signature verification system ───────────────────────
@@ -1546,5 +1548,14 @@ pub fn discovery_reporting_routes() -> Router<AppState> {
         .route(
             "/api/v1/trending",
             get(v1_trending_handlers::get_trending_v1),
+        )
+}
+
+// ── Issue #1007: Backend feature flag management ───────────────────────────
+pub fn feature_flag_routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/feature-flags",
+            get(crate::feature_flags::get_flag_status_handler),
         )
 }

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -1429,7 +1429,32 @@ pub struct PaginatedVersionResponse {
     pub prev_cursor: Option<String>,
 }
 
-/// Paginated response
+/// Active search/list filter metadata included in paginated responses
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct SearchFilterMetadata {
+    /// Applied network filters
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub networks: Option<Vec<String>>,
+    /// Applied category filters
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub categories: Option<Vec<String>>,
+    /// Whether only verified contracts are shown
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verified_only: Option<bool>,
+    /// Verification status filter
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_status: Option<String>,
+    /// Applied tag filters
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    /// Maturity level filter
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maturity: Option<String>,
+    /// Text query
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct PaginatedResponse<T> {
     pub items: Vec<T>,
@@ -1445,6 +1470,9 @@ pub struct PaginatedResponse<T> {
     pub next_cursor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prev_cursor: Option<String>,
+    /// Active filters applied to this result set (only present for search/list endpoints)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filters: Option<SearchFilterMetadata>,
 }
 
 impl<T> PaginatedResponse<T> {
@@ -1462,7 +1490,13 @@ impl<T> PaginatedResponse<T> {
             total_pages,
             next_cursor: None,
             prev_cursor: None,
+            filters: None,
         }
+    }
+
+    pub fn with_filters(mut self, filters: SearchFilterMetadata) -> Self {
+        self.filters = Some(filters);
+        self
     }
 
     pub fn with_cursors(mut self, next: Option<String>, prev: Option<String>) -> Self {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use crate::net::RequestBuilderExt;
+use crate::output_format;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -3998,6 +3999,8 @@ pub async fn stats(
     format: &str,
     output: Option<&str>,
 ) -> Result<()> {
+    let fmt = output_format::validate_format(format).unwrap_or(output_format::OutputFormat::Table);
+
     let client = crate::net::client();
     let url = format!("{}/api/stats?timeframe={}", api_url, timeframe);
 
@@ -4017,11 +4020,14 @@ pub async fn stats(
     let stats: serde_json::Value = response.json().await?;
 
     // Format output
-    let output_str = match format {
-        "json" => serde_json::to_string_pretty(&stats)?,
-        "yaml" => serde_yaml::to_string(&stats)?,
-        "table" => format_stats_table(&stats),
-        _ => anyhow::bail!("Invalid format: {}. Use table, json, or yaml", format),
+    let output_str = match fmt {
+        output_format::OutputFormat::Json => serde_json::to_string_pretty(&stats)?,
+        output_format::OutputFormat::Yaml => serde_yaml::to_string(&stats)?,
+        output_format::OutputFormat::Table => format_stats_table(&stats),
+        output_format::OutputFormat::Csv => {
+            let flat = serde_json::json!([stats]);
+            output_format::render_csv(&flat)?
+        }
     };
 
     if let Some(path) = output {

--- a/cli/src/contract_dependency.rs
+++ b/cli/src/contract_dependency.rs
@@ -1,15 +1,29 @@
-//! contract_dependency.rs — `soroban-registry contract dependency <ADDRESS>` (#836)
+//! contract_dependency.rs — `soroban-registry contract dependency <ADDRESS>` (#836, #1008)
 //!
 //! Analyze a contract's dependencies: contracts it depends on, contracts that
-//! depend on it, and a dependency tree with a configurable `--depth`.
+//! depend on it, and a dependency tree with configurable `--depth`.
+//!
+//! Supports human-readable table output, JSON output, and a compact `--summary`
+//! mode that shows only aggregate counts for large dependency graphs.
 
 use crate::net::RequestBuilderExt;
+use crate::output_format::{self, OutputFormat};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde_json::Value;
 
-/// `soroban-registry contract dependency <ADDRESS> [--depth N] [--json]`
-pub async fn run(api_url: &str, address: &str, depth: u32, json: bool) -> Result<()> {
+/// `soroban-registry contract dependency <ADDRESS> [--depth N] [--format json|table] [--summary]`
+///
+/// Analyzes a contract's on-chain dependencies and dependents. When `--summary`
+/// is set, output is condensed to aggregate counts (useful for contracts with
+/// hundreds of dependents). The `--format` flag controls machine-readable output.
+pub async fn run(
+    api_url: &str,
+    address: &str,
+    depth: u32,
+    format: OutputFormat,
+    summary: bool,
+) -> Result<()> {
     let client = crate::net::client();
     let url = format!(
         "{}/api/contracts/{}/dependencies?depth={}",
@@ -33,11 +47,37 @@ pub async fn run(api_url: &str, address: &str, depth: u32, json: bool) -> Result
         anyhow::bail!("contract dependency failed ({}): {}", status, value);
     }
 
-    if json {
-        println!("{}", serde_json::to_string_pretty(&value)?);
+    // Machine-readable formats: dump the full API response
+    if matches!(format, OutputFormat::Json | OutputFormat::Yaml | OutputFormat::Csv) {
+        let rendered = match format {
+            OutputFormat::Json => output_format::render_json(&value)?,
+            OutputFormat::Yaml => output_format::render_yaml(&value)?,
+            OutputFormat::Csv => {
+                // For CSV, extract the flat lists
+                let flat = flatten_for_csv(&value);
+                output_format::render_csv(&flat)?
+            }
+            _ => unreachable!(),
+        };
+        println!("{}", rendered);
         return Ok(());
     }
 
+    // ── Summary mode: aggregate counts only ──────────────────────────────
+    if summary {
+        let depends_on = value.get("dependsOn").and_then(Value::as_array).map(Vec::len).unwrap_or(0);
+        let dependents = value.get("dependents").and_then(Value::as_array).map(Vec::len).unwrap_or(0);
+        let tree_nodes = count_tree_nodes(value.get("tree"));
+        println!("{} {}", "Dependencies for".bold(), address.cyan());
+        println!("  Depends on:   {} contracts", depends_on.to_string().bold());
+        println!("  Depended by:  {} contracts", dependents.to_string().bold());
+        if tree_nodes > 0 {
+            println!("  Tree nodes:   {} (depth {})", tree_nodes.to_string().bold(), depth);
+        }
+        return Ok(());
+    }
+
+    // ── Full table mode ──────────────────────────────────────────────────
     println!("{} {}", "Dependencies for".bold(), address.cyan());
 
     let depends_on = value.get("dependsOn").and_then(Value::as_array).cloned().unwrap_or_default();
@@ -72,4 +112,43 @@ fn print_tree(node: &Value, indent: usize) {
             print_tree(child, indent + 1);
         }
     }
+}
+
+/// Count all nodes in a recursive dependency tree.
+fn count_tree_nodes(node: Option<&Value>) -> usize {
+    let node = match node {
+        Some(n) => n,
+        None => return 0,
+    };
+    let mut count = 1;
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for child in children {
+            count += count_tree_nodes(Some(child));
+        }
+    }
+    count
+}
+
+/// Flatten the dependency API response into an array of uniform objects for CSV rendering.
+fn flatten_for_csv(value: &Value) -> Value {
+    let mut rows = Vec::new();
+    if let Some(depends_on) = value.get("dependsOn").and_then(Value::as_array) {
+        for d in depends_on {
+            let mut row = serde_json::Map::new();
+            row.insert("relation".into(), Value::String("depends_on".into()));
+            row.insert("address".into(), d.get("address").cloned().unwrap_or(Value::Null));
+            row.insert("name".into(), d.get("name").cloned().unwrap_or(Value::Null));
+            rows.push(Value::Object(row));
+        }
+    }
+    if let Some(dependents) = value.get("dependents").and_then(Value::as_array) {
+        for d in dependents {
+            let mut row = serde_json::Map::new();
+            row.insert("relation".into(), Value::String("depended_by".into()));
+            row.insert("address".into(), d.get("address").cloned().unwrap_or(Value::Null));
+            row.insert("name".into(), d.get("name").cloned().unwrap_or(Value::Null));
+            rows.push(Value::Object(row));
+        }
+    }
+    Value::Array(rows)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4299,6 +4299,8 @@ pub enum Commands {
     Cache {
         #[command(subcommand)]
         action: CacheCommands,
+    },
+
     /// Manage environment variable sets for different deployments (#843)
     Env {
         #[command(subcommand)]
@@ -5087,15 +5089,25 @@ pub enum ContractCommands {
         json: bool,
     },
 
-    /// Analyze a contract's dependencies and relationships (#836)
+    /// Analyze a contract's dependencies and relationships (#836, #1008)
+    ///
+    /// Retrieves the full dependency graph: contracts this address depends on,
+    /// contracts that depend on it, and a recursive dependency tree.
+    ///
+    /// Use `--summary` for a compact view when dealing with large graphs.
+    /// Use `--format json` to get the raw API response for scripting.
     Dependency {
         /// On-chain contract address
         address: String,
-        /// Dependency tree depth
+        /// Dependency tree depth (0 = direct dependencies only)
         #[arg(long, default_value_t = 1)]
         depth: u32,
+        /// Output format: table, json, csv, yaml
+        #[arg(long, default_value = "table")]
+        format: String,
+        /// Compact summary mode: show aggregate counts without the full tree
         #[arg(long)]
-        json: bool,
+        summary: bool,
     },
 
     /// Import contracts into the registry from an external file (#831)
@@ -7019,6 +7031,10 @@ pub async fn dispatch_command(
                     &address,
                     &network,
                     threshold.as_deref(),
+                    json,
+                )
+                .await?;
+            }
             ContractCommands::Stats {
                 network,
                 category,
@@ -7075,6 +7091,7 @@ pub async fn dispatch_command(
                     page_size,
                 )
                 .await?;
+            }
             ContractCommands::Highlight {
                 address,
                 action,
@@ -7102,10 +7119,13 @@ pub async fn dispatch_command(
             ContractCommands::Dependency {
                 address,
                 depth,
-                json,
+                format,
+                summary,
             } => {
                 log::debug!("Command: contract dependency | address={} depth={}", address, depth);
-                contract_dependency::run(&cli.api_url, &address, depth, json).await?;
+                let fmt = crate::output_format::validate_format(&format)
+                    .unwrap_or(crate::output_format::OutputFormat::Table);
+                contract_dependency::run(&cli.api_url, &address, depth, fmt, summary).await?;
             }
             ContractCommands::Import {
                 input_file,
@@ -9532,15 +9552,25 @@ pub enum ContractCommands {
         json: bool,
     },
 
-    /// Analyze a contract's dependencies and relationships (#836)
+    /// Analyze a contract's dependencies and relationships (#836, #1008)
+    ///
+    /// Retrieves the full dependency graph: contracts this address depends on,
+    /// contracts that depend on it, and a recursive dependency tree.
+    ///
+    /// Use `--summary` for a compact view when dealing with large graphs.
+    /// Use `--format json` to get the raw API response for scripting.
     Dependency {
         /// On-chain contract address
         address: String,
-        /// Dependency tree depth
+        /// Dependency tree depth (0 = direct dependencies only)
         #[arg(long, default_value_t = 1)]
         depth: u32,
+        /// Output format: table, json, csv, yaml
+        #[arg(long, default_value = "table")]
+        format: String,
+        /// Compact summary mode: show aggregate counts without the full tree
         #[arg(long)]
-        json: bool,
+        summary: bool,
     },
 
     /// Update contract metadata after registration (#828)
@@ -11708,10 +11738,13 @@ pub async fn dispatch_command(
             ContractCommands::Dependency {
                 address,
                 depth,
-                json,
+                format,
+                summary,
             } => {
                 log::debug!("Command: contract dependency | address={} depth={}", address, depth);
-                contract_dependency::run(&cli.api_url, &address, depth, json).await?;
+                let fmt = crate::output_format::validate_format(&format)
+                    .unwrap_or(crate::output_format::OutputFormat::Table);
+                contract_dependency::run(&cli.api_url, &address, depth, fmt, summary).await?;
             }
             ContractCommands::Update {
                 address,


### PR DESCRIPTION
## Changes

### Issue #946 — Unified contract search filters
- Added `SearchFilterMetadata` struct to paginated contract list responses
- Response now includes `filters` field showing active network, category, verified-only, tag, maturity, and query filters
- Filters metadata is serialized only when filters are active (`skip_serializing_if = "Option::is_none"`)

### Issue #1006 — CLI output format control
- `soroban-registry stats` command now uses the centralized `OutputFormat` enum (supports table, json, yaml, csv)
- `soroban-registry contract dependency` now uses `--format` flag (table, json, csv, yaml) instead of `--json` boolean
- CSV output added for both `stats` and `dependency` commands

### Issue #1007 — Backend feature flags
- Feature flags can now be loaded from `FEATURE_FLAGS_JSON` environment variable
- Format: `[{"key":"flag_name","is_enabled":true,"rollout_percentage":100}]`
- Added `GET /api/feature-flags` endpoint returning all flag statuses with evaluation metrics
- Added `require_feature_flag` middleware for route-level gating
- Safe defaults maintained: `new_dashboard` defaults to disabled if not in config

### Issue #1008 — CLI dependency inspection
- Added `--summary` flag: compact output showing aggregate counts (depends_on count, depended_by count, tree node count)
- Added CSV output support via `--format csv`
- JSON output now uses shared `output_format::render_json` for consistency
- Improved help text with usage examples

### Pre-existing bug fixes in CLI (encountered during development)
- Fixed missing closing brace after `Cache` enum variant in Commands enum
- Fixed missing closing brace after Export handler match arm
- Fixed missing `json` parameter and `.await` in contract_risk handler
