### PR TITLE
fix(shared): rename duplicate AuditStatus enum to AuditScanStatus

### DIFF
--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -6684,11 +6684,11 @@ pub async fn get_contract_audits(
 
     let audits = rows.into_iter().map(|(scan_id, total, crit, high, med, low, completed_at)| {
         let status = if crit > 0 {
-            shared::AuditStatus::Failed
+            shared::AuditScanStatus::Failed
         } else if high > 0 || med > 0 {
-            shared::AuditStatus::Issues
+            shared::AuditScanStatus::Issues
         } else {
-            shared::AuditStatus::Passed
+            shared::AuditScanStatus::Passed
         };
 
         let mut findings = vec![];

--- a/backend/api/src/openapi.rs
+++ b/backend/api/src/openapi.rs
@@ -178,7 +178,7 @@ use utoipa::OpenApi;
             UpdateReviewerStatusRequest,
             CollaborativeReviewDetails,
             CollaborativeReviewStatus,
-            AuditStatus,
+            AuditScanStatus,
             AuditType,
             ContractAuditFinding,
             ContractAuditResponse,

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -4233,7 +4233,7 @@ pub struct SecurityScanHistoryResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type, utoipa::ToSchema)]
 #[sqlx(type_name = "audit_status", rename_all = "snake_case")]
-pub enum AuditStatus {
+pub enum AuditScanStatus {
     Passed,
     Issues,
     Failed,
@@ -4257,7 +4257,7 @@ pub struct ContractAuditResponse {
     pub id: Uuid,
     pub contract_id: Uuid,
     pub audit_type: AuditType,
-    pub status: AuditStatus,
+    pub status: AuditScanStatus,
     pub auditor: Option<String>,
     pub audit_date: DateTime<Utc>,
     pub findings_summary: Vec<ContractAuditFinding>,


### PR DESCRIPTION
## Summary

Removes a duplicate `AuditStatus` enum in `backend/shared/src/models.rs` that broke compilation of the `shared` crate (`E0428` duplicate definition + a cascade of `E0119` conflicting-trait-impl errors), which blocked every downstream crate.

## Related Issue

Closes #1026

## What Was Changed

- Renamed the **per-scan summary** enum (`models.rs:4236` — `Passed/Issues/Failed`, sqlx `audit_status`) to `AuditScanStatus`.
- Updated its references: `ContractAuditResponse.status` (`models.rs:4260`), the audit-summary mapping in `api/src/handlers.rs` (3 lines), and the OpenAPI component list (`openapi.rs:181`).
- Left the **canonical** `AuditStatus` (`models.rs:511` — the persisted contract audit status, "Issue #401") completely untouched.

## Why rename instead of merge/delete

The two enums model different concepts, and the per-scan one is used where the canonical enum has no matching variant (`Issues`). Merging them would require a Postgres enum migration. Renaming is the minimal, migration-free disambiguation — the sqlx `audit_status` type name is unchanged, so there is no DB or API-serialization change.

## How to Test

```bash
cd backend
cargo build -p shared   # compiles
cargo test  -p shared   # all tests pass
```

## Scope

This PR restores the `shared` crate only. Fixing it surfaced two **separate, pre-existing** breakages on `main` that this PR intentionally does **not** touch (so it stays atomic): the `api` crate has an incomplete axum 0.8 migration, and the `cli` crate has significant drift from the current `shared` API. Those are larger efforts best handled on their own.
