### PR TITLE
feat(api): make verification cache capacity and TTL configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,8 @@ MARKETPLACE_INDEXER_API_TOKEN=
 # ABI_CACHE_TTL=86400         # ABI TTL in seconds (default: 24h)
 # SEARCH_CACHE_TTL=300        # search results TTL in seconds (default: 5m)
 # STATS_CACHE_TTL=300         # stats/analytics TTL in seconds (default: 5m)
+# VERIFICATION_CACHE_MAX_CAPACITY=10000  # verification cache max capacity (default: CACHE_MAX_CAPACITY)
+# VERIFICATION_CACHE_TTL=604800          # verification result TTL in seconds (default: 7d)
 
 # Alertmanager (optional)
 # SLACK_WEBHOOK_URL=

--- a/backend/api/src/cache.rs
+++ b/backend/api/src/cache.rs
@@ -21,6 +21,12 @@ pub struct CacheConfig {
     pub search_ttl_secs: u64,
     /// TTL for stats/analytics in Redis (seconds). Default: 300 (5 minutes)
     pub stats_ttl_secs: u64,
+    /// Optional override for the verification cache max capacity (weighted bytes).
+    /// When unset, defaults to `max_capacity`, preserving prior behavior.
+    pub verification_max_capacity: Option<u64>,
+    /// Optional override for the verification cache time-to-live, in seconds.
+    /// When unset, defaults to 7 days (604800), preserving prior behavior.
+    pub verification_ttl_secs: Option<u64>,
 }
 
 impl Default for CacheConfig {
@@ -35,6 +41,8 @@ impl Default for CacheConfig {
             abi_ttl_secs: 86400,
             search_ttl_secs: 300,
             stats_ttl_secs: 300,
+            verification_max_capacity: None,
+            verification_ttl_secs: None,
         }
     }
 }
@@ -82,6 +90,18 @@ impl CacheConfig {
             }
         }
 
+        if let Ok(cap_str) = std::env::var("VERIFICATION_CACHE_MAX_CAPACITY") {
+            if let Ok(cap) = cap_str.parse::<u64>() {
+                config.verification_max_capacity = Some(cap);
+            }
+        }
+
+        if let Ok(ttl_str) = std::env::var("VERIFICATION_CACHE_TTL") {
+            if let Ok(ttl) = ttl_str.parse::<u64>() {
+                config.verification_ttl_secs = Some(ttl);
+            }
+        }
+
         config.redis_url = std::env::var("REDIS_URL").ok();
 
         tracing::info!(
@@ -114,11 +134,18 @@ impl CacheLayer {
             .time_to_live(Duration::from_secs(24 * 3600))
             .build();
 
-        // 7-day TTL for verification result cache, keyed by bytecode_hash
+        // Verification result cache, keyed by bytecode_hash.
+        // Capacity and TTL are operationally configurable (VERIFICATION_CACHE_MAX_CAPACITY,
+        // VERIFICATION_CACHE_TTL); the defaults preserve prior behavior — capacity follows
+        // `max_capacity` and the TTL stays at 7 days.
+        let verification_max_capacity = config
+            .verification_max_capacity
+            .unwrap_or(config.max_capacity);
+        let verification_ttl_secs = config.verification_ttl_secs.unwrap_or(7 * 24 * 3600);
         let verification_cache = MokaCache::builder()
-            .max_capacity(config.max_capacity)
+            .max_capacity(verification_max_capacity)
             .weigher(|_k, v: &String| -> u32 { v.len().try_into().unwrap_or(u32::MAX) })
-            .time_to_live(Duration::from_secs(7 * 24 * 3600))
+            .time_to_live(Duration::from_secs(verification_ttl_secs))
             .build();
 
         // Generic cache for namespace-keyed entries (e.g., contract graphs)
@@ -718,6 +745,75 @@ mod tests {
 
         let val2 = cache.get_verification("hash_1").await;
         assert!(val2.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_verification_cache_honors_configured_capacity_and_ttl() {
+        // Explicit overrides are reflected in the resolved config, and the
+        // cache serves hits within the configured TTL window.
+        let config = CacheConfig {
+            enabled: true,
+            max_capacity: 100,
+            verification_max_capacity: Some(42),
+            verification_ttl_secs: Some(3600),
+            ..Default::default()
+        };
+        assert_eq!(config.verification_max_capacity, Some(42));
+        assert_eq!(config.verification_ttl_secs, Some(3600));
+
+        let cache = CacheLayer::new(config).await;
+        cache
+            .put_verification("hash_hit", "result_hit".to_string())
+            .await;
+        assert_eq!(
+            cache.get_verification("hash_hit").await,
+            Some("result_hit".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_verification_cache_defaults_preserve_previous_behavior() {
+        // With no overrides the verification cache keeps the historical
+        // defaults (capacity follows `max_capacity`, 7-day TTL).
+        let config = CacheConfig {
+            enabled: true,
+            max_capacity: 100,
+            ..Default::default()
+        };
+        assert_eq!(config.verification_max_capacity, None);
+        assert_eq!(config.verification_ttl_secs, None);
+
+        let cache = CacheLayer::new(config).await;
+        cache
+            .put_verification("hash_default", "result_default".to_string())
+            .await;
+        assert_eq!(
+            cache.get_verification("hash_default").await,
+            Some("result_default".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_verification_cache_evicts_after_configured_ttl() {
+        // A short configured TTL causes entries to expire.
+        let config = CacheConfig {
+            enabled: true,
+            max_capacity: 100,
+            verification_ttl_secs: Some(1),
+            ..Default::default()
+        };
+        let cache = CacheLayer::new(config).await;
+        cache
+            .put_verification("hash_expire", "result_expire".to_string())
+            .await;
+        assert_eq!(
+            cache.get_verification("hash_expire").await,
+            Some("result_expire".to_string())
+        );
+
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        cache.verification_cache.run_pending_tasks().await;
+        assert!(cache.get_verification("hash_expire").await.is_none());
     }
 
     #[tokio::test]

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -6684,11 +6684,11 @@ pub async fn get_contract_audits(
 
     let audits = rows.into_iter().map(|(scan_id, total, crit, high, med, low, completed_at)| {
         let status = if crit > 0 {
-            shared::AuditStatus::Failed
+            shared::AuditScanStatus::Failed
         } else if high > 0 || med > 0 {
-            shared::AuditStatus::Issues
+            shared::AuditScanStatus::Issues
         } else {
-            shared::AuditStatus::Passed
+            shared::AuditScanStatus::Passed
         };
 
         let mut findings = vec![];

--- a/backend/api/src/openapi.rs
+++ b/backend/api/src/openapi.rs
@@ -178,7 +178,7 @@ use utoipa::OpenApi;
             UpdateReviewerStatusRequest,
             CollaborativeReviewDetails,
             CollaborativeReviewStatus,
-            AuditStatus,
+            AuditScanStatus,
             AuditType,
             ContractAuditFinding,
             ContractAuditResponse,

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -4233,7 +4233,7 @@ pub struct SecurityScanHistoryResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type, utoipa::ToSchema)]
 #[sqlx(type_name = "audit_status", rename_all = "snake_case")]
-pub enum AuditStatus {
+pub enum AuditScanStatus {
     Passed,
     Issues,
     Failed,
@@ -4257,7 +4257,7 @@ pub struct ContractAuditResponse {
     pub id: Uuid,
     pub contract_id: Uuid,
     pub audit_type: AuditType,
-    pub status: AuditStatus,
+    pub status: AuditScanStatus,
     pub auditor: Option<String>,
     pub audit_date: DateTime<Utc>,
     pub findings_summary: Vec<ContractAuditFinding>,


### PR DESCRIPTION
> **Blocked on a buildable base** — opened as a normal PR, but CI will be red until the base compiles (see "Verification status" below).

## Summary

Closes #1003. Makes the signature/bytecode **verification cache** capacity and TTL operationally configurable, so operators can tune it for larger environments. Previously the verification cache used a hardcoded 7-day TTL and silently shared `max_capacity` with the other caches, with no dedicated knobs.

## What Was Changed (`backend/api/src/cache.rs`)

- Added two **optional** fields to `CacheConfig`:
  - `verification_max_capacity: Option<u64>` → env `VERIFICATION_CACHE_MAX_CAPACITY`
  - `verification_ttl_secs: Option<u64>` → env `VERIFICATION_CACHE_TTL` (seconds)
- `CacheLayer::new` now resolves them with **behavior-preserving fallbacks**: capacity falls back to `max_capacity`, TTL falls back to `7 * 24 * 3600` (7 days). With no env set, the cache is byte-for-byte the same as before.
- Documented both variables in `.env.example`.

## Tests

Added three `#[tokio::test]` cases:
- `test_verification_cache_honors_configured_capacity_and_ttl` — overrides are applied; entries hit within the window.
- `test_verification_cache_defaults_preserve_previous_behavior` — no overrides → `None` config, entries still served.
- `test_verification_cache_evicts_after_configured_ttl` — a 1s TTL expires the entry.

## Why `Option<u64>` (not plain fields)

So the verification capacity keeps **following `max_capacity`** by default (its prior behavior) while still being independently tunable — a plain field with a fixed default would silently decouple it from `CACHE_MAX_CAPACITY`.

## ⚠️ Verification status (please read)

This PR is opened as a **Draft** because **`main` does not currently build**, for reasons unrelated to this change:

- The `api` crate has an incomplete **axum 0.8 migration** (`axum::async_trait` removed, missing `DateTime`/`Utc` imports, `Handler` trait-bound cascades) — ~29 pre-existing compile errors that block `cargo test -p api`.
- This branch is therefore **stacked on #1029** (the `shared` duplicate-`AuditStatus` fix) so `shared` at least compiles; the first commit here is that fix and will drop out on rebase once #1029 lands.

What I **could** verify: `cargo build -p api` produces the **exact same error set** with and without this change (no new errors, none in `cache.rs`) — i.e. this change is internally consistent and adds zero breakage. The added tests cannot be executed until the `api` crate compiles again.

## How to Test (once the base builds)

```bash
cd backend
cargo test -p api cache::tests::test_verification_cache
```