### PR TITLE
feat(api): log throttle events in the rate-limit middleware

### DIFF
--- a/backend/api/src/rate_limit.rs
+++ b/backend/api/src/rate_limit.rs
@@ -603,6 +603,17 @@ pub async fn rate_limit_middleware(
 
     if !decision.allowed {
         let is_write = is_write_method(request.method());
+        // Observability: surface throttle events so operators can spot abuse or
+        // accidental overload of public endpoints (issue #1005).
+        tracing::warn!(
+            client_ip = %extract_client_ip(&request),
+            tier = tier.as_str(),
+            limit_type = if is_write { "write" } else { "read" },
+            limit = decision.limit,
+            remaining = decision.remaining,
+            retry_after_seconds = decision.reset_seconds,
+            "Request throttled by rate limiter"
+        );
         let detail = if is_write {
             "Write quota exhausted. Reduce request frequency or wait for the window to reset."
         } else {


### PR DESCRIPTION
## Summary

Closes #1005. Adds **observability logging** to the public-endpoint rate limiter.

While implementing this I found that the substantive parts of #1005 are **already implemented and wired in** (`main.rs` layers `rate_limit::rate_limit_middleware` over the router):

- ✅ Per-IP throttling for public/anonymous routes (`anon:read:{ip}`, `anon:write:{ip}`)
- ✅ Clear `429` / `RATE_LIMITED` responses with `Retry-After` and `x-ratelimit-*` headers
- ✅ Env-tunable limits (`RATE_LIMIT_IP_PER_MINUTE`, `RATE_LIMIT_ANON_PER_MINUTE`, per-endpoint `RATE_LIMIT_ENDPOINT_*`, trusted-IP bypass, …)

The **one unmet acceptance criterion** was *"Throttle events are visible in logs"* — the middleware returned the 429 silently. This PR closes that gap only, without duplicating the existing limiter.

## What Was Changed (`backend/api/src/rate_limit.rs`)

On a throttle decision, emit a structured `tracing::warn!` with `client_ip`, `tier`, `limit_type` (read/write), `limit`, `remaining`, and `retry_after_seconds`. The client IP is taken from the existing `extract_client_ip` (x-forwarded-for / x-real-ip / connect-info). The happy path is untouched — the log only fires when a request is actually throttled.

## ⚠️ Verification status

`main` does not currently build: the `api` crate has an incomplete **axum 0.8 migration** (~29 pre-existing errors unrelated to this change), so `cargo test -p api` can't run. This branch is stacked on #1029 (the `shared` duplicate-`AuditStatus` fix) so `shared` compiles; that commit drops out on rebase once #1029 lands.

What I could verify: `cargo build -p api` produces the **identical pre-existing error set** with and without this change (no new errors, none in `rate_limit.rs`). The existing rate-limit tests already cover the 429 throttling behavior; this change adds an observability log on that same path.
