### PR TITLE
feat(api): add data encryption at rest and in transit (#895)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,34 @@ RUST_LOG=info
 JWT_SECRET=changeme_use_at_least_32_chars_of_random_data
 PORT=3001
 
+# Data encryption (#895)
+# -----------------------------------------------------------------------------
+# At-rest field encryption uses AES-256-GCM. Keys are loaded from the
+# environment ONLY (never committed to config files) so they can be injected by
+# a secrets manager (Vault, AWS Secrets Manager, GCP Secret Manager, etc.).
+#
+# ENCRYPTION_KEYS is a comma-separated list of `id:base64key` entries. Each key
+# must decode to exactly 32 bytes. Generate one with:
+#   openssl rand -base64 32
+#
+# Keep retired keys in the list after a rotation so previously-encrypted rows
+# stay readable; ENCRYPTION_ACTIVE_KEY_ID selects which key signs new writes.
+# If ENCRYPTION_KEYS is unset, field encryption runs in pass-through mode
+# (development only) and logs a warning.
+# ENCRYPTION_KEYS=key-2026-06:BASE64_32_BYTE_KEY,key-2026-01:OLD_BASE64_KEY
+# ENCRYPTION_ACTIVE_KEY_ID=key-2026-06
+
+# HTTPS / TLS in transit (#895)
+# HSTS is enabled by default. Set FORCE_HTTPS=true behind a TLS-terminating
+# proxy/load balancer to redirect plaintext (X-Forwarded-Proto: http) requests.
+# HSTS_ENABLED=true
+# HSTS_MAX_AGE_SECS=63072000
+# HSTS_INCLUDE_SUBDOMAINS=true
+# FORCE_HTTPS=false
+#
+# Encrypt traffic to Postgres by appending sslmode to DATABASE_URL in non-local
+# deployments, e.g. ...?sslmode=verify-full
+
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:3001
 

--- a/backend/api/src/backup_handlers.rs
+++ b/backend/api/src/backup_handlers.rs
@@ -12,6 +12,7 @@ use sqlx::Row;
 use uuid::Uuid;
 
 use crate::{
+    crypto::EncryptionService,
     disaster_recovery_models::{
         CreateDisasterRecoveryPlanRequest, DisasterRecoveryPlan, ExecuteRecoveryRequest,
         RecoveryMetrics,
@@ -19,6 +20,38 @@ use crate::{
     error::{ApiError, ApiResult},
     state::AppState,
 };
+
+/// Encrypt a backup JSON field into a stored JSON string envelope (#895).
+/// Encrypted backups keep sensitive contract metadata and state snapshots
+/// unreadable at rest; in pass-through mode (no keys configured) the value is
+/// stored unchanged.
+fn encrypt_backup_field(
+    enc: &EncryptionService,
+    value: &serde_json::Value,
+) -> ApiResult<serde_json::Value> {
+    let envelope = enc
+        .encrypt_json(value)
+        .map_err(|e| ApiError::internal(format!("Failed to encrypt backup field: {e}")))?;
+    Ok(serde_json::Value::String(envelope))
+}
+
+/// Decrypt an encrypted backup field in place, leaving legacy plaintext rows
+/// untouched. Transparent to API consumers.
+fn decrypt_backup_field(enc: &EncryptionService, field: &mut Option<serde_json::Value>) -> ApiResult<()> {
+    if let Some(serde_json::Value::String(stored)) = field.as_ref() {
+        let decrypted = enc
+            .decrypt_json(stored)
+            .map_err(|e| ApiError::internal(format!("Failed to decrypt backup field: {e}")))?;
+        *field = Some(decrypted);
+    }
+    Ok(())
+}
+
+fn decrypt_backup(enc: &EncryptionService, backup: &mut ContractBackup) -> ApiResult<()> {
+    decrypt_backup_field(enc, &mut backup.metadata)?;
+    decrypt_backup_field(enc, &mut backup.state_snapshot)?;
+    Ok(())
+}
 
 pub async fn create_backup(
     State(state): State<AppState>,
@@ -48,7 +81,14 @@ pub async fn create_backup(
         None
     };
 
-    let backup = sqlx::query_as::<_, ContractBackup>(
+    // Encrypt sensitive backup contents at rest (#895).
+    let metadata = encrypt_backup_field(&state.encryption, &metadata)?;
+    let state_snapshot = match state_snapshot {
+        Some(snapshot) => Some(encrypt_backup_field(&state.encryption, &snapshot)?),
+        None => None,
+    };
+
+    let mut backup = sqlx::query_as::<_, ContractBackup>(
         r#"
         INSERT INTO contract_backups 
         (contract_id, backup_date, wasm_hash, metadata, state_snapshot, storage_size_bytes, primary_region, backup_regions)
@@ -70,6 +110,9 @@ pub async fn create_backup(
     .await
     .map_err(|e| ApiError::internal(format!("Failed to create backup: {}", e)))?;
 
+    // Return decrypted contents so encryption stays transparent to callers.
+    decrypt_backup(&state.encryption, &mut backup)?;
+
     Ok(Json(backup))
 }
 
@@ -77,13 +120,17 @@ pub async fn list_backups(
     State(state): State<AppState>,
     Path(contract_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<ContractBackup>>> {
-    let backups = sqlx::query_as::<_, ContractBackup>(
+    let mut backups = sqlx::query_as::<_, ContractBackup>(
         "SELECT * FROM contract_backups WHERE contract_id = $1 ORDER BY backup_date DESC LIMIT 30",
     )
     .bind(contract_id)
     .fetch_all(&state.db)
     .await
     .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
+
+    for backup in backups.iter_mut() {
+        decrypt_backup(&state.encryption, backup)?;
+    }
 
     Ok(Json(backups))
 }

--- a/backend/api/src/config.rs
+++ b/backend/api/src/config.rs
@@ -60,5 +60,27 @@ fn validate_config(config: &AppConfig) -> Result<()> {
         anyhow::bail!("DATABASE_URL must be a valid postgres connection string");
     }
 
+    warn_if_database_tls_disabled(&config.database_url);
+
     Ok(())
+}
+
+/// Encryption in transit to the database (#895): Postgres connections should use
+/// TLS in any non-local deployment. We can't force it here without breaking local
+/// dev, but we surface a clear warning so misconfiguration is visible in logs.
+fn warn_if_database_tls_disabled(database_url: &str) {
+    let is_local = database_url.contains("@localhost")
+        || database_url.contains("@127.0.0.1")
+        || database_url.contains("@db")
+        || database_url.contains("@postgres");
+    let requests_tls = database_url.contains("sslmode=require")
+        || database_url.contains("sslmode=verify-ca")
+        || database_url.contains("sslmode=verify-full");
+
+    if !is_local && !requests_tls {
+        tracing::warn!(
+            "DATABASE_URL does not request TLS (sslmode=require/verify-full). \
+             Enable TLS so data in transit to Postgres is encrypted (#895)."
+        );
+    }
 }

--- a/backend/api/src/crypto/cipher.rs
+++ b/backend/api/src/crypto/cipher.rs
@@ -1,0 +1,176 @@
+//! AES-256-GCM authenticated encryption with a self-describing envelope (#895).
+//!
+//! Envelope format (ASCII): `enc:v1:<key_id>:<base64(nonce(12) || ciphertext||tag)>`
+//!
+//! Storing the key id alongside the ciphertext lets us decrypt with the right
+//! key after a rotation, and the `enc:v1:` prefix lets callers distinguish
+//! already-encrypted values from legacy plaintext during a migration.
+
+use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::{AeadCore, Aes256Gcm, Key, Nonce};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+use super::key_manager::{EncryptionKey, KeyManager, KEY_BYTES};
+
+/// Marker prefix identifying a value produced by [`encrypt`].
+pub const ENVELOPE_PREFIX: &str = "enc:v1:";
+
+const NONCE_BYTES: usize = 12;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CryptoError {
+    #[error("AES-GCM encryption failed")]
+    EncryptFailed,
+    #[error("AES-GCM decryption failed (wrong key or tampered ciphertext)")]
+    DecryptFailed,
+    #[error("value is not a recognized encryption envelope")]
+    NotAnEnvelope,
+    #[error("malformed encryption envelope")]
+    MalformedEnvelope,
+    #[error("ciphertext is shorter than the nonce")]
+    CiphertextTooShort,
+    #[error("envelope references unknown key id `{0}`")]
+    UnknownKeyId(String),
+    #[error("envelope payload is not valid base64")]
+    InvalidBase64,
+}
+
+/// Encrypt `plaintext` with the key manager's active key, returning an envelope
+/// string safe to store in a `TEXT` column.
+pub fn encrypt(keys: &KeyManager, plaintext: &[u8]) -> Result<String, CryptoError> {
+    let key = keys.active_key();
+    let cipher = cipher_for(key);
+
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext)
+        .map_err(|_| CryptoError::EncryptFailed)?;
+
+    let mut payload = Vec::with_capacity(NONCE_BYTES + ciphertext.len());
+    payload.extend_from_slice(nonce.as_slice());
+    payload.extend_from_slice(&ciphertext);
+
+    Ok(format!(
+        "{ENVELOPE_PREFIX}{}:{}",
+        key.id(),
+        STANDARD.encode(payload)
+    ))
+}
+
+/// Decrypt an envelope produced by [`encrypt`], selecting the key referenced in
+/// the envelope so rotated/retired keys still work.
+pub fn decrypt(keys: &KeyManager, envelope: &str) -> Result<Vec<u8>, CryptoError> {
+    let body = envelope
+        .strip_prefix(ENVELOPE_PREFIX)
+        .ok_or(CryptoError::NotAnEnvelope)?;
+
+    let (key_id, b64) = body.split_once(':').ok_or(CryptoError::MalformedEnvelope)?;
+    let key = keys
+        .key(key_id)
+        .ok_or_else(|| CryptoError::UnknownKeyId(key_id.to_string()))?;
+
+    let payload = STANDARD
+        .decode(b64.as_bytes())
+        .map_err(|_| CryptoError::InvalidBase64)?;
+    if payload.len() <= NONCE_BYTES {
+        return Err(CryptoError::CiphertextTooShort);
+    }
+
+    let (nonce_bytes, ciphertext) = payload.split_at(NONCE_BYTES);
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    cipher_for(key)
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| CryptoError::DecryptFailed)
+}
+
+fn cipher_for(key: &EncryptionKey) -> Aes256Gcm {
+    let key = Key::<Aes256Gcm>::from_slice(key.bytes());
+    Aes256Gcm::new(key)
+}
+
+// Compile-time check that the constant matches the cipher's key size.
+const _: () = assert!(KEY_BYTES == 32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::STANDARD as B64;
+
+    fn key_manager() -> KeyManager {
+        let spec = format!("k1:{}", B64.encode([7u8; KEY_BYTES]));
+        KeyManager::from_keys_spec(&spec, None).unwrap()
+    }
+
+    #[test]
+    fn round_trips_plaintext() {
+        let km = key_manager();
+        let env = encrypt(&km, b"super secret value").unwrap();
+        assert!(env.starts_with(ENVELOPE_PREFIX));
+        assert!(env.contains(":k1:"));
+        let out = decrypt(&km, &env).unwrap();
+        assert_eq!(out, b"super secret value");
+    }
+
+    #[test]
+    fn ciphertext_is_nondeterministic() {
+        let km = key_manager();
+        let a = encrypt(&km, b"same input").unwrap();
+        let b = encrypt(&km, b"same input").unwrap();
+        assert_ne!(a, b, "random nonce should make ciphertext differ");
+        assert_eq!(decrypt(&km, &a).unwrap(), decrypt(&km, &b).unwrap());
+    }
+
+    #[test]
+    fn tampering_is_detected() {
+        let km = key_manager();
+        let env = encrypt(&km, b"integrity matters").unwrap();
+        // Flip the final base64 char to corrupt the tag/ciphertext.
+        let mut chars: Vec<char> = env.chars().collect();
+        let last = chars.len() - 1;
+        chars[last] = if chars[last] == 'A' { 'B' } else { 'A' };
+        let tampered: String = chars.into_iter().collect();
+        assert!(matches!(
+            decrypt(&km, &tampered),
+            Err(CryptoError::DecryptFailed) | Err(CryptoError::InvalidBase64)
+        ));
+    }
+
+    #[test]
+    fn rejects_non_envelope() {
+        let km = key_manager();
+        assert!(matches!(
+            decrypt(&km, "plain text value"),
+            Err(CryptoError::NotAnEnvelope)
+        ));
+    }
+
+    #[test]
+    fn decrypts_with_retired_key_after_rotation() {
+        // Encrypt under k1, then rotate so k2 is active but k1 is retained.
+        let old = format!("k1:{}", B64.encode([1u8; KEY_BYTES]));
+        let old_km = KeyManager::from_keys_spec(&old, None).unwrap();
+        let env = encrypt(&old_km, b"written before rotation").unwrap();
+
+        let rotated = format!(
+            "k1:{},k2:{}",
+            B64.encode([1u8; KEY_BYTES]),
+            B64.encode([2u8; KEY_BYTES])
+        );
+        let new_km = KeyManager::from_keys_spec(&rotated, Some("k2")).unwrap();
+
+        // New writes use k2, but the old k1 ciphertext still decrypts.
+        assert_eq!(new_km.active_key_id(), "k2");
+        assert_eq!(decrypt(&new_km, &env).unwrap(), b"written before rotation");
+    }
+
+    #[test]
+    fn unknown_key_id_is_reported() {
+        let km = key_manager();
+        let env = encrypt(&km, b"x").unwrap().replace(":k1:", ":kX:");
+        assert!(matches!(
+            decrypt(&km, &env),
+            Err(CryptoError::UnknownKeyId(_))
+        ));
+    }
+}

--- a/backend/api/src/crypto/key_manager.rs
+++ b/backend/api/src/crypto/key_manager.rs
@@ -1,0 +1,261 @@
+//! Versioned key management for at-rest encryption (#895).
+
+use std::collections::HashMap;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+/// Length of an AES-256 key in bytes.
+pub const KEY_BYTES: usize = 32;
+
+const ENV_KEYS: &str = "ENCRYPTION_KEYS";
+const ENV_ACTIVE_KEY: &str = "ENCRYPTION_ACTIVE_KEY_ID";
+
+#[derive(Debug, thiserror::Error)]
+pub enum KeyManagerError {
+    #[error("ENCRYPTION_KEYS is not set; configure at least one encryption key")]
+    Missing,
+    #[error("malformed entry in ENCRYPTION_KEYS: expected `id:base64key`")]
+    MalformedEntry,
+    #[error("encryption key id must not be empty")]
+    EmptyId,
+    #[error("key `{0}` is not valid base64")]
+    InvalidBase64(String),
+    #[error("key `{0}` must decode to exactly 32 bytes (AES-256)")]
+    WrongLength(String),
+    #[error("duplicate key id `{0}`")]
+    DuplicateId(String),
+    #[error("ENCRYPTION_ACTIVE_KEY_ID (`{0}`) does not match any configured key id")]
+    UnknownActiveKey(String),
+    #[error("no keys were configured")]
+    NoKeys,
+}
+
+/// A single named AES-256 key held in memory.
+#[derive(Clone)]
+pub struct EncryptionKey {
+    id: String,
+    bytes: [u8; KEY_BYTES],
+}
+
+impl EncryptionKey {
+    pub fn new(id: impl Into<String>, bytes: [u8; KEY_BYTES]) -> Self {
+        Self {
+            id: id.into(),
+            bytes,
+        }
+    }
+
+    /// Decode a base64-encoded 32-byte key.
+    pub fn from_base64(id: impl Into<String>, b64: &str) -> Result<Self, KeyManagerError> {
+        let id = id.into();
+        let raw = STANDARD
+            .decode(b64.trim())
+            .map_err(|_| KeyManagerError::InvalidBase64(id.clone()))?;
+        let bytes: [u8; KEY_BYTES] = raw
+            .try_into()
+            .map_err(|_| KeyManagerError::WrongLength(id.clone()))?;
+        Ok(Self { id, bytes })
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn bytes(&self) -> &[u8; KEY_BYTES] {
+        &self.bytes
+    }
+}
+
+// Never leak key material through debug formatting.
+impl std::fmt::Debug for EncryptionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionKey")
+            .field("id", &self.id)
+            .field("bytes", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Zero key material on drop so it does not linger in freed memory.
+impl Drop for EncryptionKey {
+    fn drop(&mut self) {
+        for byte in self.bytes.iter_mut() {
+            // `write_volatile` is not elided by the optimizer.
+            unsafe {
+                std::ptr::write_volatile(byte, 0);
+            }
+        }
+    }
+}
+
+/// Holds the active key (used for new encryptions) plus retired keys retained
+/// for decrypting previously-written data. This is what enables rotation without
+/// downtime or a bulk re-encryption pass.
+#[derive(Debug)]
+pub struct KeyManager {
+    keys: HashMap<String, EncryptionKey>,
+    active_key_id: String,
+}
+
+impl KeyManager {
+    /// Build a key manager from explicit keys and an active key id.
+    pub fn new(
+        keys: Vec<EncryptionKey>,
+        active_key_id: impl Into<String>,
+    ) -> Result<Self, KeyManagerError> {
+        let active_key_id = active_key_id.into();
+        if keys.is_empty() {
+            return Err(KeyManagerError::NoKeys);
+        }
+
+        let mut map = HashMap::with_capacity(keys.len());
+        for key in keys {
+            if map.contains_key(key.id()) {
+                return Err(KeyManagerError::DuplicateId(key.id().to_string()));
+            }
+            map.insert(key.id().to_string(), key);
+        }
+
+        if !map.contains_key(&active_key_id) {
+            return Err(KeyManagerError::UnknownActiveKey(active_key_id));
+        }
+
+        Ok(Self {
+            keys: map,
+            active_key_id,
+        })
+    }
+
+    /// Load keys from the environment.
+    ///
+    /// `ENCRYPTION_KEYS` is a comma-separated list of `id:base64key` entries.
+    /// `ENCRYPTION_ACTIVE_KEY_ID` selects which id signs new ciphertext; when
+    /// unset and exactly one key is configured, that key is used.
+    pub fn from_env() -> Result<Self, KeyManagerError> {
+        let raw = std::env::var(ENV_KEYS).map_err(|_| KeyManagerError::Missing)?;
+        Self::from_keys_spec(&raw, std::env::var(ENV_ACTIVE_KEY).ok().as_deref())
+    }
+
+    /// Parse the `ENCRYPTION_KEYS` specification. Exposed for testing.
+    pub fn from_keys_spec(
+        spec: &str,
+        active_key_id: Option<&str>,
+    ) -> Result<Self, KeyManagerError> {
+        let mut keys = Vec::new();
+        for entry in spec.split(',').map(str::trim).filter(|e| !e.is_empty()) {
+            let (id, b64) = entry.split_once(':').ok_or(KeyManagerError::MalformedEntry)?;
+            let id = id.trim();
+            if id.is_empty() {
+                return Err(KeyManagerError::EmptyId);
+            }
+            keys.push(EncryptionKey::from_base64(id, b64)?);
+        }
+
+        if keys.is_empty() {
+            return Err(KeyManagerError::NoKeys);
+        }
+
+        let active = match active_key_id.map(str::trim).filter(|s| !s.is_empty()) {
+            Some(id) => id.to_string(),
+            None if keys.len() == 1 => keys[0].id().to_string(),
+            None => {
+                return Err(KeyManagerError::UnknownActiveKey(
+                    "<unset, multiple keys configured>".to_string(),
+                ))
+            }
+        };
+
+        Self::new(keys, active)
+    }
+
+    /// The key used to encrypt new values.
+    pub fn active_key(&self) -> &EncryptionKey {
+        // Existence guaranteed by the constructor invariant.
+        &self.keys[&self.active_key_id]
+    }
+
+    pub fn active_key_id(&self) -> &str {
+        &self.active_key_id
+    }
+
+    /// Look up a key by id for decryption.
+    pub fn key(&self, id: &str) -> Option<&EncryptionKey> {
+        self.keys.get(id)
+    }
+
+    pub fn key_ids(&self) -> impl Iterator<Item = &str> {
+        self.keys.keys().map(String::as_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b64_key(byte: u8) -> String {
+        STANDARD.encode([byte; KEY_BYTES])
+    }
+
+    #[test]
+    fn parses_single_key_and_defaults_active() {
+        let spec = format!("k1:{}", b64_key(1));
+        let km = KeyManager::from_keys_spec(&spec, None).unwrap();
+        assert_eq!(km.active_key_id(), "k1");
+        assert_eq!(km.active_key().bytes(), &[1u8; KEY_BYTES]);
+    }
+
+    #[test]
+    fn parses_multiple_keys_with_explicit_active() {
+        let spec = format!("k1:{},k2:{}", b64_key(1), b64_key(2));
+        let km = KeyManager::from_keys_spec(&spec, Some("k2")).unwrap();
+        assert_eq!(km.active_key_id(), "k2");
+        assert!(km.key("k1").is_some());
+        assert!(km.key("k2").is_some());
+        assert!(km.key("k3").is_none());
+    }
+
+    #[test]
+    fn multiple_keys_without_active_id_is_rejected() {
+        let spec = format!("k1:{},k2:{}", b64_key(1), b64_key(2));
+        assert!(matches!(
+            KeyManager::from_keys_spec(&spec, None),
+            Err(KeyManagerError::UnknownActiveKey(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_length_key() {
+        let short = STANDARD.encode([0u8; 16]);
+        let spec = format!("k1:{short}");
+        assert!(matches!(
+            KeyManager::from_keys_spec(&spec, None),
+            Err(KeyManagerError::WrongLength(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_entry() {
+        assert!(matches!(
+            KeyManager::from_keys_spec("no-colon-here", None),
+            Err(KeyManagerError::MalformedEntry)
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_ids() {
+        let spec = format!("k1:{},k1:{}", b64_key(1), b64_key(2));
+        assert!(matches!(
+            KeyManager::from_keys_spec(&spec, Some("k1")),
+            Err(KeyManagerError::DuplicateId(_))
+        ));
+    }
+
+    #[test]
+    fn unknown_active_key_is_rejected() {
+        let spec = format!("k1:{}", b64_key(1));
+        assert!(matches!(
+            KeyManager::from_keys_spec(&spec, Some("missing")),
+            Err(KeyManagerError::UnknownActiveKey(_))
+        ));
+    }
+}

--- a/backend/api/src/crypto/mod.rs
+++ b/backend/api/src/crypto/mod.rs
@@ -1,0 +1,31 @@
+//! Application-level encryption (#895).
+//!
+//! Provides authenticated symmetric encryption for sensitive data at rest and a
+//! versioned key-management layer that supports zero-downtime key rotation.
+//!
+//! ## Algorithm choices
+//! - **Cipher:** AES-256-GCM (AEAD). 256-bit keys, 96-bit random nonces, 128-bit
+//!   authentication tags. AES-GCM is FIPS-approved, hardware-accelerated on
+//!   modern CPUs (AES-NI), and provides confidentiality + integrity in one pass.
+//! - **Nonce:** 96 bits drawn from the OS CSPRNG (`OsRng`) for every encryption.
+//!   A fresh random nonce per message keeps the (key, nonce) pair unique, which
+//!   is the safety requirement for GCM.
+//! - **Envelope:** ciphertext is stored as a self-describing string so values can
+//!   be decrypted with the correct key after rotation without external metadata.
+//!
+//! ## Key management
+//! Keys never live in config files. They are loaded from the process environment
+//! (or, in production, injected from a secrets manager into the environment) and
+//! held only in memory. Multiple keys can be registered at once: one *active* key
+//! used for new encryptions, plus any number of retired keys retained so that
+//! previously-encrypted data stays readable until it is re-encrypted.
+//!
+//! See `docs/ENCRYPTION.md` for the operational runbook.
+
+mod cipher;
+mod key_manager;
+mod service;
+
+pub use cipher::{decrypt, encrypt, CryptoError, ENVELOPE_PREFIX};
+pub use key_manager::{EncryptionKey, KeyManager, KeyManagerError, KEY_BYTES};
+pub use service::EncryptionService;

--- a/backend/api/src/crypto/service.rs
+++ b/backend/api/src/crypto/service.rs
@@ -1,0 +1,160 @@
+//! High-level encryption service shared via `AppState` (#895).
+//!
+//! This is the type handlers interact with. It hides key management behind two
+//! simple operations (`encrypt_str` / `decrypt_str`) so encryption stays
+//! transparent to application code.
+//!
+//! Decryption is migration-friendly: a value that is not an encryption envelope
+//! is treated as legacy plaintext and returned unchanged. This lets a column be
+//! switched to encrypted storage without a synchronous backfill — old rows keep
+//! reading while new writes are encrypted.
+
+use super::cipher::{self, CryptoError, ENVELOPE_PREFIX};
+use super::key_manager::{KeyManager, KeyManagerError};
+
+/// Wraps the key manager, or runs in a clearly-logged pass-through mode when no
+/// keys are configured (local development only).
+pub struct EncryptionService {
+    keys: Option<KeyManager>,
+}
+
+impl EncryptionService {
+    /// Initialize from the environment. If `ENCRYPTION_KEYS` is unset the
+    /// service runs in pass-through mode and emits a loud warning, so local dev
+    /// works without keys while production misconfiguration is obvious in logs.
+    pub fn from_env() -> Self {
+        match KeyManager::from_env() {
+            Ok(keys) => {
+                tracing::info!(
+                    active_key_id = keys.active_key_id(),
+                    configured_keys = keys.key_ids().count(),
+                    "Field encryption enabled (AES-256-GCM)"
+                );
+                Self { keys: Some(keys) }
+            }
+            Err(KeyManagerError::Missing) => {
+                tracing::warn!(
+                    "ENCRYPTION_KEYS is not set: field encryption is DISABLED (pass-through). \
+                     Set ENCRYPTION_KEYS in any non-development environment."
+                );
+                Self { keys: None }
+            }
+            Err(e) => {
+                // A present-but-invalid key config is a hard misconfiguration;
+                // fail fast rather than silently storing plaintext.
+                panic!("Invalid ENCRYPTION_KEYS configuration: {e}");
+            }
+        }
+    }
+
+    /// Construct an explicitly-configured service (used by callers/tests).
+    pub fn with_keys(keys: KeyManager) -> Self {
+        Self { keys: Some(keys) }
+    }
+
+    /// Construct a disabled (pass-through) service.
+    pub fn disabled() -> Self {
+        Self { keys: None }
+    }
+
+    /// Whether encryption keys are configured.
+    pub fn is_enabled(&self) -> bool {
+        self.keys.is_some()
+    }
+
+    /// Encrypt a UTF-8 string into a storable envelope. In pass-through mode the
+    /// input is returned unchanged.
+    pub fn encrypt_str(&self, plaintext: &str) -> Result<String, CryptoError> {
+        match &self.keys {
+            Some(keys) => cipher::encrypt(keys, plaintext.as_bytes()),
+            None => Ok(plaintext.to_string()),
+        }
+    }
+
+    /// Decrypt an envelope back to a UTF-8 string. Non-envelope (legacy
+    /// plaintext) values are returned unchanged.
+    pub fn decrypt_str(&self, stored: &str) -> Result<String, CryptoError> {
+        if !is_envelope(stored) {
+            return Ok(stored.to_string());
+        }
+        match &self.keys {
+            Some(keys) => {
+                let bytes = cipher::decrypt(keys, stored)?;
+                String::from_utf8(bytes).map_err(|_| CryptoError::DecryptFailed)
+            }
+            // Envelope present but no keys configured: cannot recover.
+            None => Err(CryptoError::DecryptFailed),
+        }
+    }
+
+    /// Encrypt arbitrary JSON, serializing it first. Useful for blob columns
+    /// such as backup metadata and state snapshots.
+    pub fn encrypt_json(&self, value: &serde_json::Value) -> Result<String, CryptoError> {
+        let serialized = serde_json::to_string(value).map_err(|_| CryptoError::EncryptFailed)?;
+        self.encrypt_str(&serialized)
+    }
+
+    /// Decrypt an envelope (or legacy JSON text) back into a JSON value.
+    pub fn decrypt_json(&self, stored: &str) -> Result<serde_json::Value, CryptoError> {
+        let plaintext = self.decrypt_str(stored)?;
+        serde_json::from_str(&plaintext).map_err(|_| CryptoError::DecryptFailed)
+    }
+}
+
+/// Whether a stored value looks like an encryption envelope.
+pub fn is_envelope(value: &str) -> bool {
+    value.starts_with(ENVELOPE_PREFIX)
+}
+
+impl std::fmt::Debug for EncryptionService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionService")
+            .field("enabled", &self.is_enabled())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::KEY_BYTES;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+    fn enabled_service() -> EncryptionService {
+        let spec = format!("k1:{}", STANDARD.encode([9u8; KEY_BYTES]));
+        EncryptionService::with_keys(KeyManager::from_keys_spec(&spec, None).unwrap())
+    }
+
+    #[test]
+    fn enabled_service_round_trips() {
+        let svc = enabled_service();
+        let env = svc.encrypt_str("hello@example.com").unwrap();
+        assert!(is_envelope(&env));
+        assert_eq!(svc.decrypt_str(&env).unwrap(), "hello@example.com");
+    }
+
+    #[test]
+    fn decrypt_passes_through_legacy_plaintext() {
+        let svc = enabled_service();
+        // A pre-encryption row stored raw text; reading it must not fail.
+        assert_eq!(svc.decrypt_str("legacy plaintext").unwrap(), "legacy plaintext");
+    }
+
+    #[test]
+    fn disabled_service_is_pass_through() {
+        let svc = EncryptionService::disabled();
+        assert!(!svc.is_enabled());
+        let stored = svc.encrypt_str("value").unwrap();
+        assert_eq!(stored, "value");
+        assert_eq!(svc.decrypt_str(&stored).unwrap(), "value");
+    }
+
+    #[test]
+    fn json_round_trips() {
+        let svc = enabled_service();
+        let value = serde_json::json!({"name": "alice", "secret": [1, 2, 3]});
+        let env = svc.encrypt_json(&value).unwrap();
+        assert!(is_envelope(&env));
+        assert_eq!(svc.decrypt_json(&env).unwrap(), value);
+    }
+}

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -23,6 +23,7 @@ pub mod contract_analytics_handlers;
 pub mod contract_events;
 pub mod contract_stats_handlers;
 pub mod contributor_handlers;
+pub mod crypto;
 pub mod custom_metrics_handlers;
 pub mod dependency_handlers;
 pub mod deprecation_handlers;

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -47,10 +47,41 @@ async fn track_in_flight_middleware(
             "Service is shutting down and temporarily unavailable",
         ));
     }
+    let method = req.method().as_str().to_owned();
+    // Use the matched route template (e.g. "/api/contracts/:id") rather than the
+    // concrete URI so per-id paths don't explode the metric label cardinality.
+    let path = req
+        .extensions()
+        .get::<axum::extract::MatchedPath>()
+        .map(|p| p.as_str().to_owned())
+        .unwrap_or_else(|| req.uri().path().to_owned());
+    let request_size = content_length_bytes(req.headers());
+
     metrics::HTTP_IN_FLIGHT.inc();
+    let start = std::time::Instant::now();
     let res = next.run(req).await;
+    let elapsed = start.elapsed().as_secs_f64();
     metrics::HTTP_IN_FLIGHT.dec();
+
+    metrics::observe_http(&method, &path, res.status().as_u16(), elapsed);
+    if let Some(bytes) = request_size {
+        metrics::HTTP_REQUEST_SIZE
+            .with_label_values(&[&method])
+            .observe(bytes);
+    }
+    if let Some(bytes) = content_length_bytes(res.headers()) {
+        metrics::HTTP_RESPONSE_SIZE
+            .with_label_values(&[&method])
+            .observe(bytes);
+    }
     Ok(res)
+}
+
+fn content_length_bytes(headers: &axum::http::HeaderMap) -> Option<f64> {
+    headers
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<f64>().ok())
 }
 
 #[tokio::main]
@@ -350,6 +381,7 @@ async fn main() -> Result<()> {
 
     let web_security = WebSecurityConfig::from_env();
     let cors = web_security.build_cors_layer();
+    let https_config = api::security::HttpsConfig::from_env();
 
     // Build router
     let app = routes::application_routes(schema)
@@ -377,6 +409,10 @@ async fn main() -> Result<()> {
             api::security::csrf_and_origin_middleware,
         ))
         .layer(cors)
+        .layer(middleware::from_fn_with_state(
+            https_config,
+            api::security::https_enforcement_middleware,
+        ))
         .layer(middleware::from_fn(request_tracing::tracing_middleware))
         .with_state(state.clone());
 

--- a/backend/api/src/security.rs
+++ b/backend/api/src/security.rs
@@ -134,6 +134,110 @@ impl WebSecurityConfig {
     }
 }
 
+/// HTTPS/TLS enforcement settings (#895).
+///
+/// The API is typically deployed behind a TLS-terminating load balancer or
+/// reverse proxy that forwards the original scheme in `X-Forwarded-Proto`. This
+/// layer adds HSTS to responses and (optionally) redirects plaintext requests to
+/// HTTPS so all client communication is encrypted in transit.
+#[derive(Debug, Clone)]
+pub struct HttpsConfig {
+    hsts_enabled: bool,
+    hsts_max_age_secs: u64,
+    hsts_include_subdomains: bool,
+    redirect_to_https: bool,
+}
+
+impl Default for HttpsConfig {
+    fn default() -> Self {
+        Self {
+            hsts_enabled: true,
+            hsts_max_age_secs: 63_072_000, // 2 years (HSTS preload minimum is 1 year)
+            hsts_include_subdomains: true,
+            redirect_to_https: false,
+        }
+    }
+}
+
+impl HttpsConfig {
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+        let bool_env = |key: &str, default: bool| {
+            std::env::var(key)
+                .map(|v| !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "no"))
+                .unwrap_or(default)
+        };
+
+        Self {
+            hsts_enabled: bool_env("HSTS_ENABLED", defaults.hsts_enabled),
+            hsts_max_age_secs: std::env::var("HSTS_MAX_AGE_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(defaults.hsts_max_age_secs),
+            hsts_include_subdomains: bool_env(
+                "HSTS_INCLUDE_SUBDOMAINS",
+                defaults.hsts_include_subdomains,
+            ),
+            redirect_to_https: bool_env("FORCE_HTTPS", defaults.redirect_to_https),
+        }
+    }
+
+    fn hsts_header_value(&self) -> String {
+        if self.hsts_include_subdomains {
+            format!("max-age={}; includeSubDomains", self.hsts_max_age_secs)
+        } else {
+            format!("max-age={}", self.hsts_max_age_secs)
+        }
+    }
+}
+
+/// True when the request reached us over plaintext HTTP, per the proxy's
+/// `X-Forwarded-Proto` header. Absent the header we assume HTTPS (the common
+/// case for direct TLS) and do not redirect.
+fn is_insecure_request(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .map(|proto| proto.split(',').next().unwrap_or("").trim().eq_ignore_ascii_case("http"))
+        .unwrap_or(false)
+}
+
+/// Enforce HTTPS in transit: optionally redirect plaintext requests and attach
+/// an HSTS header to every response (#895).
+pub async fn https_enforcement_middleware(
+    State(config): State<HttpsConfig>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    if config.redirect_to_https && is_insecure_request(request.headers()) {
+        if let Some(location) = https_redirect_location(request.headers(), request.uri()) {
+            if let Ok(value) = HeaderValue::from_str(&location) {
+                let mut response = StatusCode::PERMANENT_REDIRECT.into_response();
+                response.headers_mut().insert(header::LOCATION, value);
+                return response;
+            }
+        }
+    }
+
+    let mut response = next.run(request).await;
+
+    if config.hsts_enabled {
+        if let Ok(value) = HeaderValue::from_str(&config.hsts_header_value()) {
+            response
+                .headers_mut()
+                .insert(header::STRICT_TRANSPORT_SECURITY, value);
+        }
+    }
+
+    response
+}
+
+fn https_redirect_location(headers: &HeaderMap, uri: &axum::http::Uri) -> Option<String> {
+    let host = headers.get(header::HOST).and_then(|v| v.to_str().ok())?;
+    let path_and_query = uri.path_and_query().map(|p| p.as_str()).unwrap_or("/");
+    Some(format!("https://{host}{path_and_query}"))
+}
+
 fn parse_allowed_origins(raw: &str) -> HashSet<String> {
     raw.split(',')
         .map(str::trim)
@@ -301,6 +405,68 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(accepted.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn hsts_header_is_added_to_responses() {
+        let config = HttpsConfig::default();
+        let app = Router::new()
+            .route("/health", axum::routing::get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(
+                config,
+                https_enforcement_middleware,
+            ));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response
+            .headers()
+            .get(header::STRICT_TRANSPORT_SECURITY)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("max-age="));
+    }
+
+    #[tokio::test]
+    async fn insecure_request_is_redirected_when_forced() {
+        let config = HttpsConfig {
+            redirect_to_https: true,
+            ..HttpsConfig::default()
+        };
+        let app = Router::new()
+            .route("/data", axum::routing::get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(
+                config,
+                https_enforcement_middleware,
+            ));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/data?x=1")
+                    .header(header::HOST, "api.example.com")
+                    .header("x-forwarded-proto", "http")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            "https://api.example.com/data?x=1"
+        );
     }
 
     #[tokio::test]

--- a/backend/api/src/state.rs
+++ b/backend/api/src/state.rs
@@ -1,6 +1,7 @@
 use crate::ai::service::AIService;
 use crate::auth::AuthManager;
 use crate::cache::{CacheConfig, CacheLayer};
+use crate::crypto::EncryptionService;
 use crate::contract_events::ContractEventHub;
 use crate::feature_flags::FeatureFlagManager;
 use crate::health_monitor::HealthMonitorStatus;
@@ -98,6 +99,8 @@ pub struct AppState {
     pub db_breaker: Arc<crate::db_resilience::CircuitBreaker>,
     pub db_queue: Arc<crate::db_resilience::DbQueue>,
     pub feature_flags: Arc<FeatureFlagManager>,
+    /// At-rest field encryption service (#895).
+    pub encryption: Arc<EncryptionService>,
 }
 
 impl AppState {
@@ -171,6 +174,7 @@ impl AppState {
             db_breaker,
             db_queue,
             feature_flags,
+            encryption: Arc::new(EncryptionService::from_env()),
         })
     }
 }

--- a/docs/ENCRYPTION.md
+++ b/docs/ENCRYPTION.md
@@ -1,0 +1,155 @@
+# Data Encryption (Issue #895)
+
+This document describes how the Soroban Registry backend protects data **at rest**
+and **in transit**, the algorithms chosen and why, and the operational runbook for
+key and certificate management.
+
+## Summary
+
+| Requirement | Mechanism |
+| --- | --- |
+| HTTPS/TLS for all API traffic (TLS 1.2+) | TLS termination at proxy/LB + HSTS & HTTPS-redirect middleware |
+| Database encryption at rest | Volume/disk encryption + Postgres TDE (infra), see below |
+| Sensitive fields encrypted in DB | AES-256-GCM application-level field encryption |
+| Key management system | Versioned in-memory keyring with zero-downtime rotation |
+| Certificate management & rotation | Documented below (proxy-managed, automated) |
+| Encrypted backups | Backup metadata & state snapshots encrypted with field encryption |
+| Secure key storage (not in config files) | Keys loaded from environment only, injected by a secrets manager |
+| Algorithm choices documented | This document |
+
+## Algorithm choices
+
+### Field encryption — AES-256-GCM
+
+- **Why AES-256-GCM:** it is an AEAD cipher (authenticated encryption with
+  associated data), so it provides confidentiality **and** integrity in a single
+  pass. It is FIPS 140-approved and hardware-accelerated via AES-NI on modern
+  CPUs, giving strong security with negligible overhead.
+- **Key size:** 256-bit.
+- **Nonce:** 96-bit (12 bytes), drawn from the OS CSPRNG (`OsRng`) for **every**
+  encryption. A unique random nonce per message satisfies GCM's (key, nonce)
+  uniqueness requirement; nonces are never reused or derived from data.
+- **Authentication tag:** 128-bit, verified on decrypt. Any tampering with stored
+  ciphertext causes decryption to fail rather than return corrupted plaintext.
+
+### Envelope format
+
+Encrypted values are stored as a self-describing ASCII string:
+
+```
+enc:v1:<key_id>:<base64( nonce(12 bytes) || ciphertext || tag )>
+```
+
+- The `enc:v1:` prefix lets the application distinguish encrypted values from
+  legacy plaintext, enabling lazy migration (old rows keep reading, new writes
+  are encrypted).
+- The embedded `key_id` lets us decrypt with the correct key after a rotation
+  without any external metadata.
+
+Implementation: [`backend/api/src/crypto/`](../backend/api/src/crypto/).
+
+## Key management
+
+Keys are **never stored in config files or committed to the repository**. They are
+read from the process environment, which is populated by a secrets manager
+(HashiCorp Vault, AWS Secrets Manager, GCP Secret Manager, Kubernetes Secrets,
+etc.) at deploy time, and held only in memory. Key bytes are redacted from debug
+output and zeroed on drop.
+
+### Environment variables
+
+- `ENCRYPTION_KEYS` — comma-separated `id:base64key` entries; each key must decode
+  to exactly 32 bytes. Generate with `openssl rand -base64 32`.
+- `ENCRYPTION_ACTIVE_KEY_ID` — which key id signs new encryptions. May be omitted
+  when exactly one key is configured.
+
+If `ENCRYPTION_KEYS` is unset, the service runs in **pass-through mode** (no
+encryption) and logs a prominent warning. This keeps local development frictionless
+while making production misconfiguration obvious. A *present but invalid*
+configuration fails fast at startup rather than silently storing plaintext.
+
+### Key rotation (zero downtime)
+
+1. Generate a new key: `openssl rand -base64 32`.
+2. **Prepend** it to `ENCRYPTION_KEYS`, keeping the old key in the list:
+   `ENCRYPTION_KEYS=new-id:NEWKEY,old-id:OLDKEY`
+3. Set `ENCRYPTION_ACTIVE_KEY_ID=new-id`.
+4. Deploy. New writes use the new key; existing rows still decrypt with the
+   retained old key (selected via the `key_id` embedded in each envelope).
+5. (Optional) Re-encrypt old rows in the background, then drop the retired key
+   from `ENCRYPTION_KEYS` on the next deploy.
+
+Because the key id travels with each ciphertext, no bulk re-encryption is required
+to rotate, and retired keys can be removed once no ciphertext references them.
+
+## Encryption in transit
+
+### Client ↔ API (HTTPS/TLS 1.2+)
+
+The API is deployed behind a TLS-terminating reverse proxy / load balancer
+(nginx, Caddy, AWS ALB, GCP LB, Cloudflare). The application enforces transport
+security with middleware ([`backend/api/src/security.rs`](../backend/api/src/security.rs)):
+
+- **HSTS** (`Strict-Transport-Security`) is added to every response. Defaults:
+  `max-age=63072000; includeSubDomains`. Configurable via `HSTS_ENABLED`,
+  `HSTS_MAX_AGE_SECS`, `HSTS_INCLUDE_SUBDOMAINS`.
+- **HTTPS redirect:** set `FORCE_HTTPS=true` to 308-redirect plaintext requests
+  (detected via `X-Forwarded-Proto: http`) to `https://`.
+
+Configure the terminating proxy to allow **TLS 1.2 and 1.3 only** and a modern
+cipher suite list (e.g. Mozilla "intermediate"). TLS &lt; 1.2 must be disabled.
+
+### API ↔ Database (TLS)
+
+SQLx is built with `runtime-tokio-rustls`, so TLS to Postgres is available. In
+non-local deployments append an `sslmode` to `DATABASE_URL`
+(`...?sslmode=verify-full` is recommended). Startup logs a warning when a
+non-local `DATABASE_URL` does not request TLS.
+
+## Database encryption at rest
+
+Application-level field encryption (above) protects the most sensitive columns
+even from someone with raw table access. In addition, deploy with:
+
+- **Disk/volume encryption** for the database host (LUKS, AWS EBS encryption, GCP
+  CMEK persistent disks) — encrypts the entire data directory and WAL.
+- **Managed TDE** where available (e.g. RDS/Cloud SQL "encryption at rest"),
+  ideally with a customer-managed key (CMK) in the cloud KMS.
+
+These are infrastructure controls configured outside the application.
+
+## Encrypted backups
+
+Contract backups encrypt their sensitive contents at rest. In
+[`backup_handlers.rs`](../backend/api/src/backup_handlers.rs), the `metadata` and
+`state_snapshot` JSON blobs are run through the field-encryption service before
+being written to `contract_backups`, and decrypted transparently on read. With
+keys configured, a dump of the backup tables contains only ciphertext envelopes.
+
+Backups should additionally be written to encrypted object storage (e.g. S3 SSE-KMS).
+
+## Certificate management & rotation
+
+- **Issuance/renewal:** use ACME (Let's Encrypt) via the terminating proxy
+  (Caddy auto-HTTPS, nginx + certbot, or cloud-managed certificates). Certificates
+  auto-renew well before expiry (typically at ~30 days remaining).
+- **Rotation:** automated by the ACME client / cloud provider; no application
+  restart is required when the proxy reloads certificates.
+- **Monitoring:** alert on certificate expiry (&lt; 14 days) via the existing
+  alerting stack.
+- For service-to-service mTLS (DB, internal services), rotate CA-issued certs on
+  the provider's schedule and reload connection pools.
+
+## Testing
+
+Unit tests for the crypto layer live alongside the modules in
+`backend/api/src/crypto/` and cover round-trips, nonce non-determinism, tamper
+detection, rotation/retired-key decryption, and pass-through mode. HTTPS/HSTS
+middleware tests live in `backend/api/src/security.rs`.
+
+Run with:
+
+```bash
+cargo test -p api crypto
+cargo test -p api security
+```


### PR DESCRIPTION
closes #895 

## Summary

Implements data encryption for issue #895 — protecting sensitive data both at rest and in transit.

- **AES-256-GCM field encryption** (`backend/api/src/crypto/`): authenticated encryption with a self-describing envelope (`enc:v1:<key_id>:<base64(nonce‖ciphertext‖tag)>`), random 96-bit nonce per message, 128-bit auth tag.
- **Key management** with zero-downtime rotation: keys are loaded **only** from the environment (never config files), so they can be injected by a secrets manager. An active key signs new writes while retired keys are retained for decryption via the `key_id` embedded in each value. Unset keys → pass-through mode with a warning; invalid keys → fail fast.
- **Encrypted backups**: `contract_backups` `metadata` and `state_snapshot` are encrypted on write and decrypted transparently on read.
- **HTTPS / TLS in transit**: HSTS header on every response, optional `FORCE_HTTPS` redirect (via `X-Forwarded-Proto`), and a startup warning when `DATABASE_URL` lacks TLS in non-local deployments.
- **Docs**: `docs/ENCRYPTION.md` covers algorithm choices, key management/rotation, certificate rotation, at-rest, and encrypted backups. New env vars documented in `.env.example`.

## Configuration
