### PR TITLE
feat(observability): wire HTTP metrics middleware and add Prometheus Grafana Stack 

### DIFF
--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -1,7 +1,7 @@
 #![warn(unused_imports)]
 
 use anyhow::Result;
-use axum::extract::{Request, State};
+use axum::extract::{MatchedPath, Request, State};
 use axum::http::StatusCode;
 use axum::middleware;
 use axum::response::Response;
@@ -11,7 +11,7 @@ use sqlx::ConnectOptions;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 use tracing::{error, info, warn};
 
@@ -35,7 +35,7 @@ use api::state_monitor::StateMonitorService;
 use api::validation;
 use api::webhook_delivery;
 
-async fn track_in_flight_middleware(
+async fn http_metrics_middleware(
     State(state): State<AppState>,
     req: Request,
     next: middleware::Next,
@@ -47,9 +47,24 @@ async fn track_in_flight_middleware(
             "Service is shutting down and temporarily unavailable",
         ));
     }
+
+    let method = req.method().as_str().to_owned();
+    // Label by the matched route pattern (e.g. "/api/contracts/:id") rather than
+    // the raw URI so per-path label cardinality stays bounded.
+    let path = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|m| m.as_str().to_owned())
+        .unwrap_or_else(|| "unmatched".to_owned());
+
     metrics::HTTP_IN_FLIGHT.inc();
+    let start = Instant::now();
     let res = next.run(req).await;
+    let elapsed = start.elapsed().as_secs_f64();
     metrics::HTTP_IN_FLIGHT.dec();
+
+    metrics::observe_http(&method, &path, res.status().as_u16(), elapsed);
+
     Ok(res)
 }
 
@@ -366,7 +381,7 @@ async fn main() -> Result<()> {
         ))
         .layer(middleware::from_fn_with_state(
             state.clone(),
-            track_in_flight_middleware,
+            http_metrics_middleware,
         ))
         .layer(middleware::from_fn_with_state(
             (*rate_limit_state).clone(),

--- a/backend/api/src/metrics.rs
+++ b/backend/api/src/metrics.rs
@@ -426,7 +426,6 @@ pub fn gather_metrics(r: &Registry) -> String {
     String::from_utf8(buf).unwrap_or_default()
 }
 
-#[allow(dead_code)]
 pub fn observe_http(method: &str, path: &str, status: u16, duration_secs: f64) {
     HTTP_REQUESTS_TOTAL
         .with_label_values(&[method, path, &status.to_string()])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,10 @@ services:
       - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./observability/prometheus/alert_rules.yml:/etc/prometheus/alert_rules.yml:ro
       - prometheus_data:/prometheus
+    # Lets the host.docker.internal:9100 node-exporter scrape target resolve on
+    # Linux as well as Docker Desktop.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - api
 

--- a/observability/alertmanager/alertmanager.yml
+++ b/observability/alertmanager/alertmanager.yml
@@ -1,0 +1,63 @@
+# Alertmanager routing for Soroban Registry alerts.
+#
+# Alertmanager does not expand environment variables in this file, so the
+# Slack webhook and PagerDuty routing key below are placeholders. Replace them
+# directly, or template this file at deploy time (e.g. envsubst) using the
+# SLACK_WEBHOOK_URL / PAGERDUTY_SERVICE_KEY values passed in docker-compose.yml.
+global:
+  resolve_timeout: 5m
+  slack_api_url: "https://hooks.slack.com/services/REPLACE/WITH/WEBHOOK"
+
+route:
+  receiver: default
+  group_by: ["alertname", "severity"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity = "critical"
+      receiver: pagerduty
+      continue: true
+    - matchers:
+        - severity = "critical"
+      receiver: slack-critical
+    - matchers:
+        - severity = "warning"
+      receiver: slack-warnings
+
+receivers:
+  - name: default
+    slack_configs:
+      - channel: "#alerts"
+        send_resolved: true
+        title: '{{ .CommonLabels.alertname }} ({{ .CommonLabels.severity }})'
+        text: '{{ range .Alerts }}{{ .Annotations.description }}{{ "\n" }}{{ end }}'
+
+  - name: slack-warnings
+    slack_configs:
+      - channel: "#alerts-warning"
+        send_resolved: true
+        title: '[WARNING] {{ .CommonLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.description }}{{ "\n" }}{{ end }}'
+
+  - name: slack-critical
+    slack_configs:
+      - channel: "#alerts-critical"
+        send_resolved: true
+        title: '[CRITICAL] {{ .CommonLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.description }}{{ "\n" }}{{ end }}'
+
+  - name: pagerduty
+    pagerduty_configs:
+      - routing_key: "REPLACE_WITH_PAGERDUTY_ROUTING_KEY"
+        send_resolved: true
+        description: '{{ .CommonLabels.alertname }}: {{ .CommonAnnotations.summary }}'
+
+inhibit_rules:
+  # A critical alert suppresses a warning alert with the same name.
+  - source_matchers:
+      - severity = "critical"
+    target_matchers:
+      - severity = "warning"
+    equal: ["alertname"]

--- a/observability/grafana/dashboards/soroban-registry.json
+++ b/observability/grafana/dashboards/soroban-registry.json
@@ -1,0 +1,244 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "links": [],
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["soroban", "registry", "backend"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Soroban Registry Overview",
+  "uid": "soroban-registry",
+  "panels": [
+    {
+      "type": "row",
+      "title": "HTTP",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "title": "Request Rate by Status",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "title": "5xx Error Rate",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1 }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_requests_total[5m])), 1e-9)",
+          "legendFormat": "5xx ratio"
+        }
+      ]
+    },
+    {
+      "title": "Latency (P50 / P95 / P99)",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "title": "In-flight Requests",
+      "type": "stat",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "targets": [{ "expr": "http_requests_in_flight", "legendFormat": "in-flight" }]
+    },
+    {
+      "type": "row",
+      "title": "Database & Cache",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }
+    },
+    {
+      "title": "DB Pool Utilization",
+      "type": "gauge",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 18 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [{ "expr": "max(db_pool_utilization)", "legendFormat": "utilization" }]
+    },
+    {
+      "title": "DB Connections",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 9, "x": 6, "y": 18 },
+      "targets": [
+        { "expr": "db_connections_active", "legendFormat": "active" },
+        { "expr": "db_connections_idle", "legendFormat": "idle" },
+        { "expr": "db_pool_size", "legendFormat": "total" }
+      ]
+    },
+    {
+      "title": "DB Query Latency (P95)",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 9, "x": 15, "y": 18 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(db_query_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "title": "Cache Hit Ratio",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1 }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "rate(cache_hits_total[5m]) / clamp_min(rate(cache_hits_total[5m]) + rate(cache_misses_total[5m]), 1e-9)",
+          "legendFormat": "hit ratio"
+        }
+      ]
+    },
+    {
+      "title": "DB Query Errors",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "targets": [{ "expr": "rate(db_query_errors_total[5m])", "legendFormat": "errors/s" }]
+    },
+    {
+      "type": "row",
+      "title": "Business",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 }
+    },
+    {
+      "title": "Total Contracts",
+      "type": "stat",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 35 },
+      "targets": [{ "expr": "contracts_total", "legendFormat": "contracts" }]
+    },
+    {
+      "title": "Contracts Published / Verified (rate)",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 35 },
+      "targets": [
+        { "expr": "rate(contracts_published_total[15m])", "legendFormat": "published" },
+        { "expr": "rate(contracts_verified_total[15m])", "legendFormat": "verified" }
+      ]
+    },
+    {
+      "title": "Verification Success vs Failure (rate)",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 35 },
+      "targets": [
+        { "expr": "rate(verification_success_total[10m])", "legendFormat": "success" },
+        { "expr": "rate(verification_failure_total[10m])", "legendFormat": "failure" }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Host System",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 43 }
+    },
+    {
+      "title": "CPU Usage",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 44 },
+      "fieldConfig": { "defaults": { "unit": "percent", "max": 100 }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "100 - (avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "title": "Memory Usage",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 44 },
+      "fieldConfig": { "defaults": { "unit": "percent", "max": 100 }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "title": "Disk Usage",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 44 },
+      "fieldConfig": { "defaults": { "unit": "percent", "max": 100 }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "(1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay\"})) * 100",
+          "legendFormat": "{{mountpoint}}"
+        }
+      ]
+    },
+    {
+      "title": "API Process Memory (RSS)",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 52 },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [{ "expr": "process_resident_memory_bytes", "legendFormat": "RSS" }]
+    }
+  ]
+}

--- a/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: soroban-registry
+    orgId: 1
+    folder: "Soroban Registry"
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true

--- a/observability/loki/loki-config.yaml
+++ b/observability/loki/loki-config.yaml
@@ -1,0 +1,40 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+ruler:
+  alertmanager_url: http://alertmanager:9093

--- a/observability/prometheus/alert_rules.yml
+++ b/observability/prometheus/alert_rules.yml
@@ -1,0 +1,121 @@
+# Threshold-based alerting rules for the Soroban Registry.
+# Evaluated by Prometheus and routed to Alertmanager.
+groups:
+  - name: availability
+    rules:
+      - alert: ApiDown
+        expr: up{job="soroban-api"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "API target is down"
+          description: "Prometheus cannot scrape the soroban-api target ({{ $labels.instance }}) for over 1 minute."
+
+      - alert: NodeExporterDown
+        expr: up{job="node-exporter"} == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "node-exporter is down"
+          description: "Host system metrics are unavailable; CPU/memory/disk alerts are blind."
+
+  - name: http
+    rules:
+      - alert: HighHttpErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+            / clamp_min(sum(rate(http_requests_total[5m])), 1e-9) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High HTTP 5xx error rate"
+          description: "More than 5% of requests are returning 5xx over the last 5 minutes."
+
+      - alert: HighRequestLatencyP99
+        expr: |
+          histogram_quantile(
+            0.99,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le)
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High P99 request latency"
+          description: "P99 HTTP request latency has exceeded 1s for 5 minutes."
+
+  - name: database
+    rules:
+      - alert: HighDbPoolUtilization
+        expr: db_pool_utilization > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Database connection pool nearly exhausted"
+          description: "DB pool utilization ({{ $labels.pool }}) has been above 90% for 5 minutes."
+
+      - alert: DbQueryErrors
+        expr: rate(db_query_errors_total[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Database query errors observed"
+          description: "The API is reporting database query errors over the last 5 minutes."
+
+      - alert: DbPoolTimeouts
+        expr: rate(db_pool_timeouts_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Database pool acquisition timeouts"
+          description: "Requests are timing out while waiting for a database connection."
+
+  - name: business
+    rules:
+      - alert: VerificationFailureSpike
+        expr: rate(verification_failure_total[10m]) > rate(verification_success_total[10m])
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Contract verification failures outpacing successes"
+          description: "Verification failures have exceeded successes for 10 minutes; investigate the verifier."
+
+  - name: system
+    rules:
+      - alert: HighHostCpu
+        expr: |
+          100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 85
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High host CPU usage"
+          description: "Host CPU usage on {{ $labels.instance }} has been above 85% for 10 minutes."
+
+      - alert: HighHostMemory
+        expr: |
+          (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 90
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High host memory usage"
+          description: "Host memory usage on {{ $labels.instance }} has been above 90% for 10 minutes."
+
+      - alert: HighHostDiskUsage
+        expr: |
+          (1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"}
+            / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"})) * 100 > 85
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High host disk usage"
+          description: "Filesystem {{ $labels.mountpoint }} on {{ $labels.instance }} is above 85% full."

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,42 @@
+# Prometheus scrape + alerting configuration for the Soroban Registry stack.
+# Mounted into the prometheus container by docker-compose.yml.
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: soroban-registry
+    environment: development
+
+# Route firing alerts to Alertmanager.
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
+# Threshold-based alerting rules.
+rule_files:
+  - /etc/prometheus/alert_rules.yml
+
+scrape_configs:
+  # Prometheus scraping itself.
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # The application API exposes Prometheus metrics at /metrics on port 3001.
+  - job_name: soroban-api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["api:3001"]
+        labels:
+          service: soroban-registry-api
+
+  # Host-level system metrics (CPU, memory, disk, network) via node-exporter.
+  # node-exporter runs with host networking, so it is reached through the
+  # Docker host gateway rather than a compose service name.
+  - job_name: node-exporter
+    static_configs:
+      - targets: ["host.docker.internal:9100"]
+        labels:
+          service: host

--- a/observability/promtail/promtail-config.yaml
+++ b/observability/promtail/promtail-config.yaml
@@ -1,0 +1,22 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # Ship all Docker container logs to Loki, labelled by container name.
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "/(.*)"
+        target_label: container
+      - source_labels: ["__meta_docker_container_log_stream"]
+        target_label: stream


### PR DESCRIPTION
closes #897 

Record http_requests_total, http_request_duration_seconds and per-status counts in a request middleware (previously defined but never populated), labelling by matched route pattern to bound cardinality.

Add the observability/ config tree that docker-compose.yml referenced but which did not exist: Prometheus scrape + threshold alert rules, Alertmanager severity routing, Grafana datasource/dashboard provisioning, and Loki/Promtail log config. Map host-gateway on the prometheus service so node-exporter host metrics (CPU/memory/disk) scrape on Linux too.