### PR TITLE
feat: add uptime, error-rate, and latency monitoring/alerting for the registry

### DIFF
--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -5461,6 +5461,7 @@ pub async fn verify_contract(
     headers: HeaderMap,
     ValidatedJson(req): ValidatedJson<VerifyRequest>,
 ) -> ApiResult<Json<Value>> {
+    let verification_started = std::time::Instant::now();
     let contract: Contract = sqlx::query_as(
         "SELECT * FROM contracts WHERE contract_id = $1 ORDER BY created_at DESC LIMIT 1",
     )
@@ -5614,6 +5615,11 @@ pub async fn verify_contract(
             )
             .await;
 
+            crate::metrics::observe_verification_latency(
+                "success",
+                verification_started.elapsed().as_secs_f64(),
+            );
+
             Ok(Json(json!({
                 "verified": true,
                 "status": "verified",
@@ -5692,6 +5698,11 @@ pub async fn verify_contract(
                 .map_err(|err| db_internal_error("write failed status audit log", err))?;
             }
 
+            crate::metrics::observe_verification_latency(
+                "failure",
+                verification_started.elapsed().as_secs_f64(),
+            );
+
             Err(ApiError::unprocessable(
                 "VerificationFailed",
                 failure_message,
@@ -5746,6 +5757,11 @@ pub async fn verify_contract(
                     db_internal_error("write verifier error status audit log", db_err)
                 })?;
             }
+
+            crate::metrics::observe_verification_latency(
+                "failure",
+                verification_started.elapsed().as_secs_f64(),
+            );
 
             Err(ApiError::unprocessable(
                 "VerificationFailed",

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -79,6 +79,7 @@ pub mod resource_tracking;
 pub mod routes;
 pub mod search_client;
 pub mod security;
+pub mod service_health;
 pub mod security_scan_handlers;
 pub mod signing_handlers;
 pub mod similarity_handlers;

--- a/backend/api/src/metrics.rs
+++ b/backend/api/src/metrics.rs
@@ -456,7 +456,6 @@ pub fn observe_http(method: &str, path: &str, status: u16, duration_secs: f64) {
         .observe(duration_secs);
 }
 
-#[allow(dead_code)]
 pub fn observe_verification_latency(result: &str, duration_secs: f64) {
     VERIFICATION_LATENCY
         .with_label_values(&[result])

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -861,6 +861,10 @@ pub fn health_routes() -> Router<AppState> {
         .route("/health/live", get(handlers::health_check_live))
         .route("/health/ready", get(handlers::health_check_ready))
         .route("/health/detailed", get(handlers::health_check_detailed))
+        .route(
+            "/health/services",
+            get(crate::service_health::health_check_services),
+        )
         .route("/api/v1/health", get(v1_contract_handlers::health_v1))
         .route("/api/stats", get(stats::get_stats_handler))
         .route(

--- a/backend/api/src/search_postgres.rs
+++ b/backend/api/src/search_postgres.rs
@@ -9,6 +9,9 @@ use sqlx::PgPool;
 
 use crate::error::ApiError;
 use crate::state::AppState;
+
+/// Full-text search queries slower than this are counted as slow for alerting.
+const SEARCH_SLOW_QUERY_MS: u64 = 500;
 use axum::{
     extract::{Query, State},
     Json,
@@ -184,6 +187,15 @@ impl PostgresSearchService {
         let total = count_query.fetch_one(&self.db).await?;
 
         let took = start_time.elapsed().as_millis() as u64;
+
+        crate::metrics::SEARCH_QUERY_DURATION
+            .with_label_values(&["fulltext"])
+            .observe(took as f64 / 1000.0);
+        if took >= SEARCH_SLOW_QUERY_MS {
+            crate::metrics::SEARCH_SLOW_QUERIES
+                .with_label_values(&["fulltext"])
+                .inc();
+        }
 
         let contracts = rows
             .into_iter()

--- a/backend/api/src/service_health.rs
+++ b/backend/api/src/service_health.rs
@@ -1,0 +1,382 @@
+//! Per-service health checks for the registry's core request paths
+//! (publish, search, verification), exposed at `GET /health/services`.
+//!
+//! Unlike `/health/detailed` (which reports raw dependency status), this
+//! module classifies each core service as healthy/degraded/unhealthy using
+//! explicit latency and error-rate thresholds, so it can back uptime and
+//! error-rate alerting (see observability/prometheus/alert_rules.yml).
+
+use crate::metrics;
+use crate::state::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+/// Dependency checks that take longer than this are still "up" but degraded.
+const DEGRADED_LATENCY_MS: u128 = 200;
+/// Dependency checks that take longer than this are treated as failed.
+const CHECK_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Verification failure ratio (of success+failure since process start) above
+/// which the verification service is considered degraded / unhealthy.
+const VERIFICATION_FAILURE_RATIO_WARN: f64 = 0.10;
+const VERIFICATION_FAILURE_RATIO_CRIT: f64 = 0.30;
+/// Pending verification jobs above which the queue is considered backed up.
+const VERIFICATION_QUEUE_DEPTH_WARN: i64 = 50;
+const VERIFICATION_QUEUE_DEPTH_CRIT: i64 = 200;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+impl ServiceStatus {
+    /// Combines two statuses, keeping the more severe one.
+    fn worst(self, other: Self) -> Self {
+        use ServiceStatus::*;
+        match (self, other) {
+            (Unhealthy, _) | (_, Unhealthy) => Unhealthy,
+            (Degraded, _) | (_, Degraded) => Degraded,
+            (Healthy, Healthy) => Healthy,
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            ServiceStatus::Healthy => "healthy",
+            ServiceStatus::Degraded => "degraded",
+            ServiceStatus::Unhealthy => "unhealthy",
+        }
+    }
+}
+
+/// Classifies a timed dependency check into a service status.
+///
+/// `failed` covers both connection errors and query errors; `timed_out`
+/// covers checks that exceeded `CHECK_TIMEOUT`. Both are treated as
+/// unhealthy since the dependency did not answer successfully in time.
+fn classify_latency(elapsed_ms: u128, failed: bool, timed_out: bool) -> ServiceStatus {
+    if failed || timed_out {
+        ServiceStatus::Unhealthy
+    } else if elapsed_ms > DEGRADED_LATENCY_MS {
+        ServiceStatus::Degraded
+    } else {
+        ServiceStatus::Healthy
+    }
+}
+
+/// Classifies verification health from cumulative success/failure counters
+/// and the current queue depth. Returns the status plus the failure ratio
+/// so callers can surface it for debugging.
+fn classify_verification(success: u64, failure: u64, queue_depth: i64) -> (ServiceStatus, f64) {
+    let total = success + failure;
+    let failure_ratio = if total == 0 {
+        0.0
+    } else {
+        failure as f64 / total as f64
+    };
+
+    let status = if failure_ratio >= VERIFICATION_FAILURE_RATIO_CRIT
+        || queue_depth >= VERIFICATION_QUEUE_DEPTH_CRIT
+    {
+        ServiceStatus::Unhealthy
+    } else if failure_ratio >= VERIFICATION_FAILURE_RATIO_WARN
+        || queue_depth >= VERIFICATION_QUEUE_DEPTH_WARN
+    {
+        ServiceStatus::Degraded
+    } else {
+        ServiceStatus::Healthy
+    };
+
+    (status, failure_ratio)
+}
+
+async fn check_db_dependency(
+    pool: &sqlx::PgPool,
+    query: &str,
+) -> (ServiceStatus, u128, Option<String>) {
+    let start = Instant::now();
+    let outcome = tokio::time::timeout(CHECK_TIMEOUT, sqlx::query(query).execute(pool)).await;
+    let elapsed_ms = start.elapsed().as_millis();
+
+    match outcome {
+        Ok(Ok(_)) => (classify_latency(elapsed_ms, false, false), elapsed_ms, None),
+        Ok(Err(e)) => (
+            classify_latency(elapsed_ms, true, false),
+            elapsed_ms,
+            Some(e.to_string()),
+        ),
+        Err(_) => (
+            classify_latency(elapsed_ms, false, true),
+            elapsed_ms,
+            Some("dependency check timed out".to_string()),
+        ),
+    }
+}
+
+fn service_json(
+    status: ServiceStatus,
+    latency_ms: u128,
+    error: Option<String>,
+    extra: Value,
+) -> Value {
+    let mut obj = json!({
+        "status": status.as_str(),
+        "latency_ms": latency_ms,
+    });
+    if let Some(err) = error {
+        obj["error"] = json!(err);
+    }
+    if let Value::Object(extra_map) = extra {
+        if let Value::Object(obj_map) = &mut obj {
+            obj_map.extend(extra_map);
+        }
+    }
+    obj
+}
+
+/// `GET /health/services` — reports the health of the registry's core
+/// request paths (publish, search, verification) individually, so outages
+/// or degradation in one subsystem can be alerted on and diagnosed without
+/// digging through generic dependency checks.
+#[utoipa::path(
+    get,
+    path = "/health/services",
+    responses(
+        (status = 200, description = "All core services healthy or degraded", body = Object),
+        (status = 503, description = "One or more core services are unhealthy", body = Object)
+    ),
+    tag = "Observability"
+)]
+pub async fn health_check_services(State(state): State<AppState>) -> (StatusCode, Json<Value>) {
+    let now = chrono::Utc::now().to_rfc3339();
+
+    if state.is_shutting_down.load(Ordering::SeqCst) {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "status": "unhealthy",
+                "timestamp": now,
+                "reason": "shutting_down"
+            })),
+        );
+    }
+
+    // Publish depends on being able to write/read the registry's primary store.
+    let (publish_status, publish_latency, publish_err) =
+        check_db_dependency(&state.db, "SELECT 1 FROM contracts LIMIT 1").await;
+
+    // Search currently runs through PostgreSQL full-text search on the same store;
+    // checked separately so a slow search index doesn't get masked by a fast publish path.
+    let (search_status, search_latency, search_err) = check_db_dependency(
+        &state.db,
+        "SELECT 1 FROM contracts WHERE search_vector IS NOT NULL LIMIT 1",
+    )
+    .await;
+
+    // Verification health is derived from live counters rather than a synthetic
+    // check, since a real verification run is too expensive to do on every probe.
+    let verification_success = metrics::VERIFICATION_SUCCESS.get();
+    let verification_failure = metrics::VERIFICATION_FAILURE.get();
+    let verification_queue_depth = metrics::VERIFICATION_QUEUE_DEPTH.get();
+    let (verification_status, verification_failure_ratio) = classify_verification(
+        verification_success,
+        verification_failure,
+        verification_queue_depth,
+    );
+
+    let overall = publish_status
+        .worst(search_status)
+        .worst(verification_status);
+
+    let status_code = match overall {
+        ServiceStatus::Unhealthy => StatusCode::SERVICE_UNAVAILABLE,
+        ServiceStatus::Degraded | ServiceStatus::Healthy => StatusCode::OK,
+    };
+
+    (
+        status_code,
+        Json(json!({
+            "status": overall.as_str(),
+            "timestamp": now,
+            "services": {
+                "publish": service_json(publish_status, publish_latency, publish_err, json!({})),
+                "search": service_json(search_status, search_latency, search_err, json!({})),
+                "verification": service_json(
+                    verification_status,
+                    0,
+                    None,
+                    json!({
+                        "queue_depth": verification_queue_depth,
+                        "failure_ratio": verification_failure_ratio,
+                    })
+                ),
+            }
+        })),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_latency_healthy_when_fast() {
+        assert_eq!(classify_latency(10, false, false), ServiceStatus::Healthy);
+    }
+
+    #[test]
+    fn classify_latency_degraded_when_slow_but_ok() {
+        assert_eq!(
+            classify_latency(DEGRADED_LATENCY_MS + 1, false, false),
+            ServiceStatus::Degraded
+        );
+    }
+
+    #[test]
+    fn classify_latency_unhealthy_on_error() {
+        assert_eq!(classify_latency(5, true, false), ServiceStatus::Unhealthy);
+    }
+
+    #[test]
+    fn classify_latency_unhealthy_on_timeout() {
+        assert_eq!(classify_latency(500, false, true), ServiceStatus::Unhealthy);
+    }
+
+    #[test]
+    fn classify_verification_healthy_with_no_traffic() {
+        let (status, ratio) = classify_verification(0, 0, 0);
+        assert_eq!(status, ServiceStatus::Healthy);
+        assert_eq!(ratio, 0.0);
+    }
+
+    #[test]
+    fn classify_verification_healthy_below_thresholds() {
+        let (status, ratio) = classify_verification(95, 5, 3);
+        assert_eq!(status, ServiceStatus::Healthy);
+        assert!((ratio - 0.05).abs() < 1e-9);
+    }
+
+    #[test]
+    fn classify_verification_degraded_on_failure_ratio() {
+        // 15% failures — above the 10% warn threshold, below the 30% critical one.
+        let (status, _) = classify_verification(85, 15, 0);
+        assert_eq!(status, ServiceStatus::Degraded);
+    }
+
+    #[test]
+    fn classify_verification_degraded_on_queue_backlog() {
+        let (status, _) = classify_verification(100, 0, VERIFICATION_QUEUE_DEPTH_WARN);
+        assert_eq!(status, ServiceStatus::Degraded);
+    }
+
+    #[test]
+    fn classify_verification_unhealthy_on_high_failure_ratio() {
+        // 40% failures — a simulated verification outage.
+        let (status, ratio) = classify_verification(60, 40, 0);
+        assert_eq!(status, ServiceStatus::Unhealthy);
+        assert!((ratio - 0.4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn classify_verification_unhealthy_on_severe_queue_backlog() {
+        let (status, _) = classify_verification(100, 0, VERIFICATION_QUEUE_DEPTH_CRIT);
+        assert_eq!(status, ServiceStatus::Unhealthy);
+    }
+
+    #[test]
+    fn worst_status_picks_most_severe() {
+        assert_eq!(
+            ServiceStatus::Healthy.worst(ServiceStatus::Degraded),
+            ServiceStatus::Degraded
+        );
+        assert_eq!(
+            ServiceStatus::Degraded.worst(ServiceStatus::Unhealthy),
+            ServiceStatus::Unhealthy
+        );
+        assert_eq!(
+            ServiceStatus::Healthy.worst(ServiceStatus::Healthy),
+            ServiceStatus::Healthy
+        );
+        assert_eq!(
+            ServiceStatus::Unhealthy.worst(ServiceStatus::Healthy),
+            ServiceStatus::Unhealthy
+        );
+    }
+
+    use crate::cache::{CacheConfig, CacheLayer};
+    use crate::contract_events::ContractEventHub;
+    use crate::rate_limit::RateLimitState;
+    use crate::search_client::SearchClient;
+    use crate::search_postgres::PostgresSearchService;
+    use prometheus::Registry;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{Arc, RwLock};
+
+    /// Builds an `AppState` backed by a lazily-connected (never-touched) pool.
+    /// Mirrors the harness in `metrics_handler.rs`'s tests. Suitable only for
+    /// paths that short-circuit before hitting the database, such as the
+    /// shutting-down check below.
+    async fn test_state(shutting_down: bool) -> AppState {
+        let registry = Registry::new_custom(Some("t".into()), None).unwrap();
+        metrics::register_all(&registry).unwrap();
+        let db = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://postgres:postgres@localhost:5432/soroban_registry")
+            .unwrap();
+        let (job_engine, _rx) = soroban_batch::engine::JobEngine::new();
+        let (event_broadcaster, _) = tokio::sync::broadcast::channel(100);
+        AppState {
+            db: db.clone(),
+            started_at: Instant::now(),
+            cache: Arc::new(CacheLayer::new(CacheConfig::default()).await),
+            registry,
+            job_engine: Arc::new(job_engine),
+            is_shutting_down: Arc::new(AtomicBool::new(shutting_down)),
+            health_monitor_status: crate::health_monitor::HealthMonitorStatus::default(),
+            auth_mgr: Arc::new(RwLock::new(crate::auth::AuthManager::new(
+                "test-secret-test-secret-test-se".to_string(),
+            ))),
+            resource_mgr: Arc::new(RwLock::new(crate::resource_tracking::ResourceManager::new())),
+            contract_events: Arc::new(ContractEventHub::from_env()),
+            source_storage: Arc::new(shared::source_storage::SourceStorage::new().await.unwrap()),
+            event_broadcaster,
+            search: Arc::new(SearchClient::new("http://localhost:9200").unwrap()),
+            pg_search: Arc::new(PostgresSearchService::new(db)),
+            ai_service: None,
+            state_monitor: None,
+            rate_limit_state: Arc::new(RateLimitState::from_env()),
+            db_breaker: Arc::new(crate::db_resilience::CircuitBreaker::new(
+                3,
+                std::time::Duration::from_secs(10),
+            )),
+            db_queue: Arc::new(crate::db_resilience::DbQueue::new(
+                10,
+                10,
+                std::time::Duration::from_secs(1),
+            )),
+            feature_flags: Arc::new(crate::feature_flags::FeatureFlagManager::new()),
+            encryption: Arc::new(crate::crypto::EncryptionService::disabled()),
+        }
+    }
+
+    #[tokio::test]
+    async fn health_check_services_returns_unhealthy_when_shutting_down() {
+        // A service mid-shutdown must fail fast without touching the database —
+        // the lazily-connected pool here is never queried because the
+        // shutting-down branch short-circuits first.
+        let state = test_state(true).await;
+
+        let (status, body) = health_check_services(State(state)).await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body.0["status"], "unhealthy");
+        assert_eq!(body.0["reason"], "shutting_down");
+    }
+}

--- a/backend/api/tests/registry_monitoring_alerting_tests.rs
+++ b/backend/api/tests/registry_monitoring_alerting_tests.rs
@@ -1,0 +1,176 @@
+// Issue #1049: monitoring and alerting for registry uptime and error rates.
+//
+// These tests assert the observability wiring stays in place — that the
+// alerting rules, routing config, and documentation described in
+// docs/ALERTING.md actually exist and reference the metrics/routes the code
+// emits. They mirror the pattern in database_replication_ha_tests.rs.
+// Degraded-condition classification logic (healthy/degraded/unhealthy
+// thresholds) is unit-tested in-crate in src/service_health.rs.
+
+fn read(path: &str) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {}: {}", path, e))
+}
+
+#[test]
+fn test_alerting_documentation_exists() {
+    let doc_path = "../../docs/ALERTING.md";
+    assert!(
+        std::path::Path::new(doc_path).exists(),
+        "Alerting/escalation documentation should exist at {}",
+        doc_path
+    );
+    let doc = read(doc_path);
+    assert!(
+        doc.contains("Escalation") || doc.contains("escalation"),
+        "ALERTING.md should document escalation routing"
+    );
+    assert!(
+        doc.contains("/health/services"),
+        "ALERTING.md should document the per-service health endpoint"
+    );
+}
+
+#[test]
+fn test_health_services_endpoint_is_registered() {
+    let routes = read("../../backend/api/src/routes.rs");
+    assert!(
+        routes.contains("/health/services"),
+        "routes.rs should register GET /health/services"
+    );
+    assert!(
+        routes.contains("service_health::health_check_services"),
+        "routes.rs should wire /health/services to service_health::health_check_services"
+    );
+}
+
+#[test]
+fn test_alert_rules_cover_uptime_error_rate_and_latency() {
+    let alerts = read("../../observability/prometheus/alert_rules.yml");
+
+    // Uptime
+    assert!(
+        alerts.contains("RegistryAPIDown"),
+        "alert_rules.yml should alert when the API is unscrapeable (uptime)"
+    );
+    assert!(
+        alerts.contains(r#"up{job="soroban-registry-api"}"#),
+        "uptime alerts should key off the API's Prometheus scrape target"
+    );
+
+    // Error rate (overall + per core service)
+    for alert in [
+        "RegistryHighErrorRate",
+        "RegistryCriticalErrorRate",
+        "PublishServiceErrorRateHigh",
+        "SearchServiceErrorRateHigh",
+    ] {
+        assert!(
+            alerts.contains(alert),
+            "alert_rules.yml should define {}",
+            alert
+        );
+    }
+    assert!(
+        alerts.contains("http_requests_total"),
+        "error-rate alerts should be built on the http_requests_total metric"
+    );
+
+    // Latency
+    for alert in ["RegistryHighLatencyP95", "RegistryHighLatencyP99"] {
+        assert!(
+            alerts.contains(alert),
+            "alert_rules.yml should define {}",
+            alert
+        );
+    }
+    assert!(
+        alerts.contains("http_request_duration_seconds_bucket"),
+        "latency alerts should be built on the http_request_duration_seconds histogram"
+    );
+
+    // Core service degradation (verification, search)
+    for alert in [
+        "VerificationFailureRateHigh",
+        "VerificationQueueBacklog",
+        "SearchSlowQueriesHigh",
+    ] {
+        assert!(
+            alerts.contains(alert),
+            "alert_rules.yml should define {}",
+            alert
+        );
+    }
+
+    // Every alert must carry a severity label so Alertmanager can route it.
+    let severity_labels = alerts.matches("severity:").count();
+    let alert_defs = alerts.matches("- alert:").count();
+    assert!(alert_defs >= 10, "expected a substantial alert catalog");
+    assert_eq!(
+        severity_labels, alert_defs,
+        "every alert rule must declare a severity label for routing"
+    );
+}
+
+#[test]
+fn test_alertmanager_routes_by_severity_with_receivers() {
+    let am = read("../../observability/alertmanager/alertmanager.yml");
+
+    assert!(
+        am.contains(r#"severity = "critical""#),
+        "alertmanager.yml should route on severity=critical"
+    );
+    assert!(
+        am.contains(r#"severity = "warning""#),
+        "alertmanager.yml should route on severity=warning"
+    );
+    assert!(
+        am.contains("pagerduty_configs"),
+        "critical alerts should be configured to page via PagerDuty"
+    );
+    assert!(
+        am.contains("slack_configs"),
+        "alerts should be configured to notify Slack"
+    );
+    let receiver_count = am.matches("- name:").count();
+    assert!(
+        receiver_count >= 2,
+        "alertmanager.yml should define distinct receivers for critical vs warning severity, found {}",
+        receiver_count
+    );
+}
+
+#[test]
+fn test_alertmanager_secrets_are_provisioned_from_env_at_container_start() {
+    let compose = read("../../docker-compose.yml");
+    assert!(
+        compose.contains("SLACK_WEBHOOK_URL"),
+        "docker-compose.yml should pass SLACK_WEBHOOK_URL to alertmanager"
+    );
+    assert!(
+        compose.contains("PAGERDUTY_SERVICE_KEY"),
+        "docker-compose.yml should pass PAGERDUTY_SERVICE_KEY to alertmanager"
+    );
+    assert!(
+        compose.contains("/alertmanager/secrets/slack_webhook_url"),
+        "docker-compose.yml should materialize the Slack secret file alertmanager.yml expects"
+    );
+}
+
+#[test]
+fn test_verification_and_search_metrics_are_actually_recorded() {
+    // Guards against the alert rules referencing metrics that are declared
+    // but never incremented anywhere (which would mean the alert can never fire).
+    let handlers = read("../../backend/api/src/handlers.rs");
+    assert!(
+        handlers.contains("observe_verification_latency"),
+        "verify_contract should record verification outcomes so \
+         VerificationFailureRateHigh has real data to alert on"
+    );
+
+    let search = read("../../backend/api/src/search_postgres.rs");
+    assert!(
+        search.contains("SEARCH_QUERY_DURATION") && search.contains("SEARCH_SLOW_QUERIES"),
+        "the search handler should record query duration/slow-query metrics so \
+         SearchSlowQueriesHigh has real data to alert on"
+    );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -235,9 +235,18 @@ services:
   alertmanager:
     image: prom/alertmanager:v0.26.0
     container_name: soroban-alertmanager
+    # alertmanager.yml points slack_api_url_file/routing_key_file at
+    # /alertmanager/secrets/*; materialize those from env vars before the
+    # binary starts, since Alertmanager's config file has no native env
+    # expansion. Empty values are fine locally — Alertmanager only reads the
+    # file contents when it actually sends a notification.
+    entrypoint: ["/bin/sh", "-c"]
     command:
-      - --config.file=/etc/alertmanager/alertmanager.yml
-      - --storage.path=/alertmanager
+      - |
+        mkdir -p /alertmanager/secrets
+        printf '%s' "$$SLACK_WEBHOOK_URL" > /alertmanager/secrets/slack_webhook_url
+        printf '%s' "$$PAGERDUTY_SERVICE_KEY" > /alertmanager/secrets/pagerduty_routing_key
+        exec /bin/alertmanager --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager
     environment:
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-}
       PAGERDUTY_SERVICE_KEY: ${PAGERDUTY_SERVICE_KEY:-}

--- a/docs/ALERTING.md
+++ b/docs/ALERTING.md
@@ -1,0 +1,95 @@
+# Registry Monitoring & Alerting
+
+This documents the alerting configured for registry uptime, error rates, and
+latency (issue #1049), how alerts are routed, and how to respond to them.
+
+## Stack
+
+```
+API (/metrics) --> Prometheus (scrape + alert_rules.yml) --> Alertmanager --> Slack / PagerDuty
+```
+
+- `backend/api/src/metrics.rs` — Prometheus metric definitions, exported at `GET /metrics`.
+- `observability/prometheus/prometheus.yml` — scrape config; scrapes the API job `soroban-registry-api` every 15s.
+- `observability/prometheus/alert_rules.yml` — alerting rules (thresholds, `for` durations, severity labels).
+- `observability/alertmanager/alertmanager.yml` — routing tree and receivers.
+- `GET /health`, `/health/live`, `/health/ready`, `/health/detailed`, `/health/services` — liveness/readiness probes (`backend/api/src/handlers.rs`, `backend/api/src/service_health.rs`).
+
+## Health check endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /health` | Basic liveness; 503 while shutting down. |
+| `GET /health/live` | Kubernetes-style liveness probe (status code only). |
+| `GET /health/ready` | Readiness — 503 if the database is unreachable. |
+| `GET /health/detailed` | Liveness + database + cache dependency status. |
+| `GET /health/services` | Per-core-service status: **publish**, **search**, **verification** — each independently classified `healthy` / `degraded` / `unhealthy` so an operator can tell which request path is affected without reading raw metrics. |
+
+`/health/services` is the one to alert/page on for "is the registry actually
+usable" — the others answer narrower questions (process up? DB reachable?).
+
+## Alert catalog
+
+All rules live in `observability/prometheus/alert_rules.yml`.
+
+| Alert | Severity | Condition | Fires after |
+|---|---|---|---|
+| `RegistryAPIDown` | critical | Prometheus can't scrape the API | 1m |
+| `RegistryAvailabilitySLOBreach` | critical | 30-day scrape uptime < 99.5% | 5m |
+| `RegistryHighErrorRate` | warning | Overall 5xx rate > 2% | 5m |
+| `RegistryCriticalErrorRate` | critical | Overall 5xx rate > 5% | 5m |
+| `RegistryHighLatencyP95` | warning | Overall p95 latency > 1s | 5m |
+| `RegistryHighLatencyP99` | critical | Overall p99 latency > 2.5s | 5m |
+| `PublishServiceErrorRateHigh` | critical | `POST /api/contracts` 5xx rate > 5% | 10m |
+| `SearchServiceErrorRateHigh` | critical | `GET /api/search` 5xx rate > 5% | 10m |
+| `SearchServiceLatencyHigh` | warning | `GET /api/search` p95 latency > 1.5s | 10m |
+| `VerificationFailureRateHigh` | warning | Verification failure rate > 10% | 10m |
+| `VerificationQueueBacklog` | warning | Pending verification queue depth > 50 | 10m |
+| `SearchSlowQueriesHigh` | warning | Slow (>500ms) search queries > 1/s | 10m |
+| `DatabaseReplicationLagHigh` | warning | Replica lag > 100ms | 1m |
+| `DatabaseReplicationHealthDegraded` | critical | Replica reports unhealthy | 1m |
+
+Thresholds are deliberately conservative starting points — tune them against
+real traffic once there's a baseline, rather than treating them as final.
+
+## Escalation / routing
+
+Configured in `observability/alertmanager/alertmanager.yml`:
+
+- **critical** → `pagerduty-critical` receiver: pages on-call via PagerDuty **and** posts to the `#registry-alerts` Slack channel. Re-notifies every hour until acknowledged or resolved (`repeat_interval: 1h`, `group_wait: 10s` — pages fast).
+- **warning** → `slack-warnings` receiver: posts to `#registry-alerts` only, no page. Re-notifies every 4 hours (`repeat_interval: 4h`).
+
+Secrets (`SLACK_WEBHOOK_URL`, `PAGERDUTY_SERVICE_KEY`) are supplied as
+container env vars in `docker-compose.yml` and written to files the
+Alertmanager config reads via `slack_api_url_file` / `routing_key_file` —
+Alertmanager's config file has no native env-var expansion, so this avoids
+committing secrets into `alertmanager.yml`. Set them in `.env` (see
+`.env.example`) before running `docker compose up alertmanager`; without
+them, alerts still fire and are visible in Alertmanager/Prometheus, they just
+won't reach Slack/PagerDuty.
+
+### On-call response
+
+1. **Critical page fires** — check `/health/services` first to identify which
+   core service (publish/search/verification) is affected, then
+   `/health/detailed` for the underlying dependency (database/cache).
+2. **Acknowledge in PagerDuty** to stop re-paging while investigating.
+3. Check the Grafana dashboard (`observability/grafana/dashboards/soroban-registry.json`) for the affected metric's recent trend.
+4. If it's a database issue, see `docs/database-high-availability.md`.
+5. Resolve in PagerDuty once the alert clears in Alertmanager (or it will auto-resolve when Prometheus stops firing it).
+
+Warning-level Slack alerts don't require immediate action but should be
+triaged during business hours — they're often an early signal of something
+that becomes a critical page later (e.g. `RegistryHighErrorRate` trending
+toward `RegistryCriticalErrorRate`).
+
+## Simulating degraded conditions (for testing)
+
+- `backend/api/src/service_health.rs` unit tests exercise the classification
+  logic (healthy/degraded/unhealthy thresholds) for each core service without
+  needing a live database.
+- To see a real alert fire locally: run the stack via `docker-compose.yml`,
+  then either stop the `api` container (triggers `RegistryAPIDown`) or use a
+  load-testing tool against `POST /api/contracts` with invalid payloads to
+  drive up the error rate (triggers `PublishServiceErrorRateHigh` /
+  `RegistryHighErrorRate` once sustained past the `for:` duration).

--- a/observability/alertmanager/alertmanager.yml
+++ b/observability/alertmanager/alertmanager.yml
@@ -1,13 +1,48 @@
-global: {}
+global:
+  resolve_timeout: 5m
+  # Populated at container start from the SLACK_WEBHOOK_URL env var — see
+  # docker-compose.yml's alertmanager service and docs/ALERTING.md.
+  slack_api_url_file: /alertmanager/secrets/slack_webhook_url
 
+# Escalation policy (see docs/ALERTING.md for the full runbook):
+#   critical -> PagerDuty page + Slack, paged again hourly until acknowledged/resolved
+#   warning  -> Slack only, no paging
 route:
-  receiver: default
-  group_by: ["alertname", "cluster", "service"]
+  receiver: slack-warnings
+  group_by: ["alertname", "severity", "service"]
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity = "critical"
+      receiver: pagerduty-critical
+      group_wait: 10s
+      repeat_interval: 1h
+    - matchers:
+        - severity = "warning"
+      receiver: slack-warnings
+      repeat_interval: 4h
 
 receivers:
-  - name: default
+  - name: slack-warnings
+    slack_configs:
+      - channel: "#registry-alerts"
+        send_resolved: true
+        title: '{{ .CommonAnnotations.summary }}'
+        text: '{{ .CommonAnnotations.description }}'
+
+  - name: pagerduty-critical
+    slack_configs:
+      - channel: "#registry-alerts"
+        send_resolved: true
+        title: '🚨 {{ .CommonAnnotations.summary }}'
+        text: '{{ .CommonAnnotations.description }}'
+    pagerduty_configs:
+      # Populated at container start from the PAGERDUTY_SERVICE_KEY env var.
+      - routing_key_file: /alertmanager/secrets/pagerduty_routing_key
+        send_resolved: true
+        severity: critical
+        description: '{{ .CommonAnnotations.summary }}'
 
 templates: []

--- a/observability/prometheus/alert_rules.yml
+++ b/observability/prometheus/alert_rules.yml
@@ -19,3 +19,146 @@ groups:
           summary: Database replication health is degraded
           description: The replica monitor reports an unhealthy replication state.
 
+  - name: registry-uptime
+    rules:
+      - alert: RegistryAPIDown
+        expr: up{job="soroban-registry-api"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: Registry API is unreachable
+          description: Prometheus has failed to scrape {{ $labels.instance }} for at least 1 minute. The registry API is likely down.
+
+      - alert: RegistryAvailabilitySLOBreach
+        expr: avg_over_time(up{job="soroban-registry-api"}[30d]) < 0.995
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Registry 30-day availability SLO breached
+          description: 30-day scrape availability is {{ $value | humanizePercentage }}, below the 99.5% SLO target.
+
+  - name: registry-error-rate
+    rules:
+      - alert: RegistryHighErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+            /
+          sum(rate(http_requests_total[5m]))
+          > 0.02
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Registry API 5xx error rate is elevated
+          description: "{{ $value | humanizePercentage }} of requests over the last 5m returned a 5xx status, above the 2% warning threshold."
+
+      - alert: RegistryCriticalErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+            /
+          sum(rate(http_requests_total[5m]))
+          > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Registry API 5xx error rate is critical
+          description: "{{ $value | humanizePercentage }} of requests over the last 5m returned a 5xx status, above the 5% critical threshold."
+
+  - name: registry-latency
+    rules:
+      - alert: RegistryHighLatencyP95
+        expr: |
+          histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Registry API p95 latency is elevated
+          description: p95 request latency over the last 5m is {{ $value }}s, above the 1s warning threshold.
+
+      - alert: RegistryHighLatencyP99
+        expr: |
+          histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) > 2.5
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Registry API p99 latency is critical
+          description: p99 request latency over the last 5m is {{ $value }}s, above the 2.5s critical threshold.
+
+  - name: registry-core-services
+    rules:
+      # Per-route error rate for the three core service endpoints, using the
+      # matched-route "path" label emitted by http_metrics_middleware (main.rs)
+      # so these fire on the same live data as the generic error-rate alerts,
+      # scoped to just the endpoint that matters for each service.
+      - alert: PublishServiceErrorRateHigh
+        expr: |
+          sum(rate(http_requests_total{path="/api/contracts", method="POST", status=~"5.."}[10m]))
+            /
+          sum(rate(http_requests_total{path="/api/contracts", method="POST"}[10m]))
+          > 0.05
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: Contract publish error rate is critical
+          description: "{{ $value | humanizePercentage }} of POST /api/contracts requests over the last 10m have failed with a 5xx status."
+
+      - alert: SearchServiceErrorRateHigh
+        expr: |
+          sum(rate(http_requests_total{path="/api/search", status=~"5.."}[10m]))
+            /
+          sum(rate(http_requests_total{path="/api/search"}[10m]))
+          > 0.05
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: Search service error rate is critical
+          description: "{{ $value | humanizePercentage }} of GET /api/search requests over the last 10m have failed with a 5xx status."
+
+      - alert: SearchServiceLatencyHigh
+        expr: |
+          histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{path="/api/search"}[10m])) by (le)) > 1.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Search service p95 latency is elevated
+          description: p95 latency for GET /api/search over the last 10m is {{ $value }}s, above the 1.5s warning threshold.
+
+      - alert: VerificationFailureRateHigh
+        expr: |
+          rate(verification_failure_total[10m])
+            /
+          (rate(verification_success_total[10m]) + rate(verification_failure_total[10m]))
+          > 0.1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Contract verification failure rate is elevated
+          description: "{{ $value | humanizePercentage }} of verifications over the last 10m have failed, above the 10% warning threshold."
+
+      - alert: VerificationQueueBacklog
+        expr: verification_queue_depth > 50
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Verification queue is backing up
+          description: Verification queue depth is {{ $value }}, above the 50-job warning threshold for 10 minutes.
+
+      - alert: SearchSlowQueriesHigh
+        expr: sum(rate(search_slow_queries_total[5m])) > 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Search queries are slowing down
+          description: Slow search queries are occurring at {{ $value }}/s over the last 5m, above the 1/s warning threshold.
+


### PR DESCRIPTION

## Problem

There was no automated alerting tied to registry health (uptime, error
rates, latency spikes), despite an existing "monitoring" label in use across
the project. Outages or degraded performance could go unnoticed until users
reported failures. On closer look, the repo already had a lot of
observability scaffolding (Prometheus metrics, health endpoints, an
alerting module, Grafana dashboards) but several pieces were either missing
or stubbed and never wired up:

- No alert rules existed for HTTP error rate, latency, or uptime — only
  database replication had alerts.
- Alertmanager shipped a single `default` receiver with no Slack/PagerDuty
  config, so alerts had nowhere to go even if rules existed.
- Verification and search metrics (`verification_success_total`,
  `search_slow_queries_total`, etc.) were declared but never incremented
  anywhere in the code, so any alert built on them could never fire.
- No endpoint reported health per core service — only generic DB/cache
  checks existed.

## What changed

**Per-service health endpoint** — `GET /health/services`
(`backend/api/src/service_health.rs`) classifies **publish**, **search**,
and **verification** independently as healthy/degraded/unhealthy, using
timed dependency checks (publish/search) and live failure-rate/queue-depth
counters (verification). This satisfies the "health check endpoints for
core services" acceptance criterion directly.

**Wired the previously-dead metrics** — `verify_contract` now records
success/failure outcomes and latency via `observe_verification_latency`;
the full-text search handler now records query duration and increments a
slow-query counter. Without this, the new verification/search alerts below
would reference metrics that never move.

**Prometheus alert rules** (`observability/prometheus/alert_rules.yml`) —
added rules for:
- Uptime: `RegistryAPIDown` (scrape failure), `RegistryAvailabilitySLOBreach` (30-day availability < 99.5%)
- Error rate: overall warning/critical thresholds, plus per-endpoint rules for `POST /api/contracts` and `GET /api/search`
- Latency: overall p95/p99, plus `GET /api/search` p95
- Core service degradation: verification failure rate, verification queue backlog, slow search queries

**Alertmanager routing/escalation** (`observability/alertmanager/alertmanager.yml`) —
critical alerts page via PagerDuty **and** post to Slack, re-notifying
hourly until acknowledged; warnings post to Slack only, re-notifying every
4 hours. Since Alertmanager's config has no native env-var expansion,
`docker-compose.yml`'s alertmanager service now materializes the Slack/
PagerDuty secrets to files from env vars at container start, which the
config reads via `slack_api_url_file`/`routing_key_file`.

**Documentation** — `docs/ALERTING.md` documents the full alert catalog,
the escalation policy, and an on-call runbook (what to check first, how to
acknowledge/resolve).

**Tests simulating degraded conditions** — unit tests in
`service_health.rs` cover healthy/degraded/unhealthy classification for
each core service (slow dependency, DB error, timeout, high verification
failure ratio, queue backlog). Integration tests in
`backend/api/tests/registry_monitoring_alerting_tests.rs` assert the
alert rules, routing config, and metric wiring stay in place (following the
existing `database_replication_ha_tests.rs` convention).

## Note for reviewers

The `api` crate currently fails `cargo check` on `main` for unrelated,
pre-existing reasons (`axum::async_trait` no longer exists in the pinned
axum 0.8, a few missing types) — confirmed via `git stash` that this
predates this change. None of the files touched here appear in that error
list and `rustfmt --check` passes on all new/edited Rust files, but a full
green `cargo check` isn't possible until that separate issue is fixed.

Closes #1049
