### PR TITLE
Database: Add migration checksum validation in CI

### DIFF
--- a/.github/scripts/check-migration-immutability.sh
+++ b/.github/scripts/check-migration-immutability.sh
@@ -10,13 +10,12 @@ if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
   exit 1
 fi
 
-merge_base=$(git merge-base "$base_ref" HEAD)
 status=0
 
 while IFS= read -r -d '' change && IFS= read -r -d '' file_path; do
   case "$change" in
-    M)
-      base_checksum=$(git show "$merge_base:$file_path" | sha256sum | cut -d ' ' -f 1)
+    M|T)
+      base_checksum=$(git show "$base_ref:$file_path" | sha256sum | cut -d ' ' -f 1)
       head_checksum=$(git show "HEAD:$file_path" | sha256sum | cut -d ' ' -f 1)
       echo "ERROR: modified merged migration: $file_path" >&2
       echo "  base SHA-256: $base_checksum" >&2
@@ -28,7 +27,7 @@ while IFS= read -r -d '' change && IFS= read -r -d '' file_path; do
       status=1
       ;;
   esac
-done < <(git diff --no-renames --name-status -z --diff-filter=MD "$base_ref"...HEAD -- "$migrations_dir")
+done < <(git diff --no-renames --name-status -z --diff-filter=MDT "$base_ref" HEAD -- "$migrations_dir")
 
 if [[ $status -ne 0 ]]; then
   echo "Merged migrations are immutable. Add a new migration to fix the schema forward." >&2

--- a/.github/scripts/check-migration-immutability.sh
+++ b/.github/scripts/check-migration-immutability.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+base_ref=${1:-origin/main}
+migrations_dir="database/migrations"
+
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "ERROR: base ref not found: $base_ref" >&2
+  exit 1
+fi
+
+merge_base=$(git merge-base "$base_ref" HEAD)
+status=0
+
+while IFS= read -r -d '' change && IFS= read -r -d '' file_path; do
+  case "$change" in
+    M)
+      base_checksum=$(git show "$merge_base:$file_path" | sha256sum | cut -d ' ' -f 1)
+      head_checksum=$(git show "HEAD:$file_path" | sha256sum | cut -d ' ' -f 1)
+      echo "ERROR: modified merged migration: $file_path" >&2
+      echo "  base SHA-256: $base_checksum" >&2
+      echo "  head SHA-256: $head_checksum" >&2
+      status=1
+      ;;
+    D)
+      echo "ERROR: deleted merged migration: $file_path" >&2
+      status=1
+      ;;
+  esac
+done < <(git diff --no-renames --name-status -z --diff-filter=MD "$base_ref"...HEAD -- "$migrations_dir")
+
+if [[ $status -ne 0 ]]; then
+  echo "Merged migrations are immutable. Add a new migration to fix the schema forward." >&2
+  exit $status
+fi
+
+echo "Migration checksums match the base branch"

--- a/.github/scripts/test-migration-immutability.sh
+++ b/.github/scripts/test-migration-immutability.sh
@@ -61,4 +61,11 @@ git -C "$fixture" rm --quiet database/migrations/002_user_names.sql
 git -C "$fixture" commit --quiet -m "Delete migration"
 assert_check 1 "ERROR: deleted merged migration: database/migrations/002_user_names.sql"
 
+git -C "$fixture" switch --quiet -C typechange "$base_commit"
+git -C "$fixture" rm --quiet database/migrations/001_users.sql
+ln -s 002_user_names.sql "$fixture/database/migrations/001_users.sql"
+git -C "$fixture" add database/migrations/001_users.sql
+git -C "$fixture" commit --quiet -m "Convert migration to symlink"
+assert_check 1 "ERROR: modified merged migration: database/migrations/001_users.sql"
+
 echo "Migration immutability tests passed"

--- a/.github/scripts/test-migration-immutability.sh
+++ b/.github/scripts/test-migration-immutability.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+checker="$script_dir/check-migration-immutability.sh"
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+
+git -C "$fixture" init --quiet --initial-branch=main
+git -C "$fixture" config user.email "migration-test@example.com"
+git -C "$fixture" config user.name "Migration Test"
+mkdir -p "$fixture/database/migrations"
+printf 'CREATE TABLE users (id BIGINT PRIMARY KEY);\n' > "$fixture/database/migrations/001_users.sql"
+printf 'ALTER TABLE users ADD COLUMN name TEXT;\n' > "$fixture/database/migrations/002_user_names.sql"
+git -C "$fixture" add database/migrations
+git -C "$fixture" commit --quiet -m "Add sample migrations"
+base_commit=$(git -C "$fixture" rev-parse HEAD)
+
+assert_check() {
+  local expected_status=$1
+  local expected_output=$2
+  local output
+  local actual_status
+
+  if output=$(cd "$fixture" && bash "$checker" "$base_commit" 2>&1); then
+    actual_status=0
+  else
+    actual_status=$?
+  fi
+
+  if [[ $actual_status -ne $expected_status || "$output" != *"$expected_output"* ]]; then
+    echo "ERROR: expected status $expected_status and output containing: $expected_output" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+
+  if [[ $actual_status -ne 0 ]]; then
+    echo "$output"
+  fi
+}
+
+git -C "$fixture" switch --quiet -c unchanged
+git -C "$fixture" commit --quiet --allow-empty -m "No migration changes"
+assert_check 0 "Migration checksums match the base branch"
+
+git -C "$fixture" switch --quiet -C added "$base_commit"
+printf 'CREATE INDEX users_name_idx ON users (name);\n' > "$fixture/database/migrations/003_user_name_index.sql"
+git -C "$fixture" add database/migrations/003_user_name_index.sql
+git -C "$fixture" commit --quiet -m "Add migration"
+assert_check 0 "Migration checksums match the base branch"
+
+git -C "$fixture" switch --quiet -C modified "$base_commit"
+printf 'CREATE TABLE users (id UUID PRIMARY KEY);\n' > "$fixture/database/migrations/001_users.sql"
+git -C "$fixture" add database/migrations/001_users.sql
+git -C "$fixture" commit --quiet -m "Modify migration"
+assert_check 1 "ERROR: modified merged migration: database/migrations/001_users.sql"
+
+git -C "$fixture" switch --quiet -C deleted "$base_commit"
+git -C "$fixture" rm --quiet database/migrations/002_user_names.sql
+git -C "$fixture" commit --quiet -m "Delete migration"
+assert_check 1 "ERROR: deleted merged migration: database/migrations/002_user_names.sql"
+
+echo "Migration immutability tests passed"

--- a/.github/workflows/validate-migrations.yml
+++ b/.github/workflows/validate-migrations.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "database/migrations/**"
       - ".github/scripts/validate-migrations.sh"
+      - ".github/scripts/check-migration-immutability.sh"
+      - ".github/scripts/test-migration-immutability.sh"
       - ".github/workflows/validate-migrations.yml"
   push:
     branches:
@@ -14,15 +16,24 @@ on:
 
 jobs:
   validate:
-    name: Check Migration File Naming
+    name: Check Migration Files
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Validate migration files
+      - name: Validate migration filenames
         run: bash .github/scripts/validate-migrations.sh
+
+      - name: Test migration checksum validation
+        run: bash .github/scripts/test-migration-immutability.sh
+
+      - name: Check merged migration checksums
+        if: github.event_name == 'pull_request'
+        run: bash .github/scripts/check-migration-immutability.sh "${{ github.event.pull_request.base.sha }}"
 
       - name: Comment on PR (on failure)
         if: failure() && github.event_name == 'pull_request'
@@ -33,5 +44,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '❌ **Migration Validation Failed**\n\nPlease check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.\n\nCommon issues:\n- Duplicate migration prefixes\n- Invalid filename format\n- Missing zero-padding in prefix\n\nSee [docs/MIGRATIONS.md](../blob/main/docs/MIGRATIONS.md) for naming conventions.'
+              body: '❌ **Migration Validation Failed**\n\nPlease check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details. Existing migrations cannot be modified, deleted, or renamed. Add a new migration to fix the schema forward.'
             })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for your interest in contributing! This document provides guidelines a
 - [Testing](#testing)
 - [Submitting a Pull Request](#submitting-a-pull-request)
 - [Code Standards](#code-standards)
+- [Database Migrations](#database-migrations)
 - [Issue Selection](#issue-selection)
 
 ## Getting Started
@@ -214,6 +215,10 @@ CREATE TABLE contract_dependencies (
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 ```
+
+### Database Migrations
+
+Migration files already merged into `main` are immutable. Never edit, delete, or rename an existing file in `database/migrations`, because deployed databases record its checksum. Make schema corrections by adding a new migration that moves the schema forward.
 
 ## Testing
 


### PR DESCRIPTION
## Description

I added a migration guard that compares merged migration files with the PR base using SHA-256 checksums. New migration files remain allowed; edits, deletions, and renames of existing files fail the migration workflow.

The workflow also runs a fixture test with a sample migration set, and `CONTRIBUTING.md` now tells contributors to fix schemas forward with a new migration.

## Testing

Passed:

- `bash .github/scripts/validate-migrations.sh`
- `bash .github/scripts/check-migration-immutability.sh upstream/main`
- `bash .github/scripts/test-migration-immutability.sh`
- `bash -n .github/scripts/*.sh`
- `git diff --check upstream/main...HEAD`
- `npm test` in `tagging-service`: 1 passed, 0 failed
- `./node_modules/.bin/eslint .` in `frontend`: 0 errors, 212 existing warnings
- `./node_modules/.bin/next build` in `frontend`
- `cargo fmt --all -- --check` in `soroban-registry`

The fixture test allows unchanged and newly added migrations. Its negative cases produced:

```text
ERROR: modified merged migration: database/migrations/001_users.sql
  base SHA-256: ac532b1d469583e55c613482d9912f578eaf01a257eaa69d2c7c76e977b925ad
  head SHA-256: f39e253974858b40aa337266866554e10d0960b24ed17d301d51978cbc30f7dc
Merged migrations are immutable. Add a new migration to fix the schema forward.
ERROR: deleted merged migration: database/migrations/002_user_names.sql
Merged migrations are immutable. Add a new migration to fix the schema forward.
Migration immutability tests passed
```

I ran the full test commands on clean `main` and again on this branch. The results are identical apart from the new passing shell test:

- Frontend: 9 suites passed, 5 failed; 45 tests passed, 4 failed on both revisions. The same suites fail: `FilterPanel.test.tsx`, `contractsContentFilters.test.ts`, `api.test.ts`, `ipfsMirror.test.ts`, and `resilience.test.ts`.
- Backend, CLI, and `soroban-registry` Rust tests: 0 tests ran on either revision because `openssl-sys` cannot find the host OpenSSL development files or `pkg-config`.
- Tagging service: 1 passed, 0 failed on both revisions.

Pre-existing checks that remain unsuccessful:

- `cargo fmt --all -- --check` reports existing formatting differences in the backend and CLI.
- Rust Clippy and test builds stop in `openssl-sys` because this host has no `pkg-config` or OpenSSL development files.
- `npm run build` in `tagging-service` reports the same two existing TypeScript errors in `src/dal/contractsDataAccess.ts` and `src/db.ts`.
- The frontend test command reports the five suites listed above on both revisions.

## Related Issues

Closes #1056