### PR TITLE
docs: add structured audit log specification for write operations (#1063)

### DIFF
--- a/docs/audit_log_specification.md
+++ b/docs/audit_log_specification.md
@@ -1,0 +1,35 @@
+# Structured Audit Log Specification for Registry Write Operations
+
+Technical design specification for structured, immutable audit log events across all contract publish, deprecation, transfer, and deletion operations in Soroban Registry.
+
+---
+
+## 1. Audit Log Schema
+
+```json
+{
+  "event_id": "audit_84920481029",
+  "timestamp": "2026-07-25T04:15:00Z",
+  "actor_id": "usr_01HJ8Z",
+  "action": "CONTRACT_PUBLISH",
+  "target_contract_id": "CABC123...XYZ",
+  "ip_address_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "changes": {
+    "version": "1.0.0",
+    "wasm_hash": "a8f902..."
+  }
+}
+```
+
+---
+
+## 2. Event Dispatch Engine
+
+- Audit events are emitted asynchronously to PostgreSQL `audit_logs` table.
+- Indexing triggers alertwebhooks on high-risk actions (e.g. ownership transfer).
+
+---
+
+## References
+
+- Issue reference: Fixes #1063


### PR DESCRIPTION
Add Structured Audit Log Specification for Write Operations (#1063)

Added docs/audit_log_specification.md with:
- JSON event schema and async dispatch engine

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #1063