### PR TITLE
docs: add CLI contract audit command specification (#1060)

### DIFF
--- a/docs/cli_contract_audit.md
+++ b/docs/cli_contract_audit.md
@@ -1,0 +1,27 @@
+# `soroban-registry contract audit` CLI Specification
+
+Command specification for the local CLI tool to detect bytecode, ABI, and storage schema drift between a local compiled WASM and published registry contracts.
+
+---
+
+## 1. CLI Usage
+
+```bash
+soroban-registry contract audit --local target/wasm32-unknown-unknown/release/contract.wasm --remote CABC123...XYZ
+```
+
+---
+
+## 2. Drift Checks Implemented
+
+| Check | Pass Condition | Failure Output |
+| :--- | :--- | :--- |
+| **Bytecode Hash** | Local SHA256 == Remote SHA256 | `[FAIL] WASM byte mismatch` |
+| **Interface ABI** | All exported functions & types match | `[FAIL] Missing function: 'withdraw'` |
+| **WASM Optimizations** | Optimizations applied via `wasm-opt` | `[WARN] Unoptimized WASM detected` |
+
+---
+
+## References
+
+- Issue reference: Fixes #1060


### PR DESCRIPTION
Add CLI Contract Audit Command Specification (#1060)

Added docs/cli_contract_audit.md with:
- Command parameters and WASM drift checks

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #1060