### PR TITLE
docs: add two-step ownership transfer specification (#1058)

### DIFF
--- a/docs/two_step_ownership_transfer.md
+++ b/docs/two_step_ownership_transfer.md
@@ -1,0 +1,20 @@
+# Two-Step Contract Ownership Transfer Specification
+
+Security specification for a two-step transfer workflow (`propose_transfer` -> `accept_transfer`) to prevent accidental loss of registered contract administrative rights.
+
+---
+
+## 1. Two-Step Transfer Protocol
+
+```
+[ Current Owner ] ───> `propose_transfer(new_owner)` ───> [ Pending Owner Field Set ]
+                                                                     │
+                                                                     ▼
+[ Transfer Complete ] <─── `accept_transfer()` <─── [ New Owner Accepts ]
+```
+
+---
+
+## References
+
+- Issue reference: Fixes #1058


### PR DESCRIPTION
Add Two-Step Ownership Transfer Specification (#1058)

Added docs/two_step_ownership_transfer.md with:
- Two-step confirmation protocol to protect registry admin rights

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #1058