### PR TITLE
Detect duplicate contract publishes by contract_id and network

### DIFF
--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -4429,6 +4429,49 @@ pub async fn publish_contract(
     .map_err(|err| db_internal_error("upsert publisher", err))?;
 
     let wasm_hash = req.wasm_hash.clone();
+
+    // Duplicate detection (Issue #953): a contract is uniquely identified by
+    // (contract_id, network). If one is already registered, this is either a
+    // retry of a prior successful publish (same wasm_hash - return the
+    // existing record so publish stays idempotent) or an attempt to
+    // re-register the same contract_id with different source code (a real
+    // conflict, reported with a reference to the existing record).
+    if let Some(existing) = sqlx::query_as::<_, Contract>(
+        "SELECT * FROM contracts WHERE contract_id = $1 AND network = $2",
+    )
+    .bind(&req.contract_id)
+    .bind(&req.network)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|err| db_internal_error("check existing contract", err))?
+    {
+        tx.rollback()
+            .await
+            .map_err(|err| db_internal_error("rollback publish tx", err))?;
+
+        if existing.wasm_hash == wasm_hash {
+            return Ok(Json(existing));
+        }
+
+        return Err(ApiError::conflict(
+            "ContractAlreadyRegistered",
+            format!(
+                "Contract {} is already registered for network {}",
+                req.contract_id, req.network
+            ),
+        )
+        .with_details(json!({
+            "existing_contract": {
+                "id": existing.id,
+                "contract_id": existing.contract_id,
+                "slug": existing.slug,
+                "network": existing.network.to_string(),
+                "wasm_hash": existing.wasm_hash,
+                "published_at": existing.created_at,
+            }
+        })));
+    }
+
     let network_key = req.network.to_string();
     let mut config_map = serde_json::Map::new();
     config_map.insert(

--- a/backend/api/tests/duplicate_publish_tests.rs
+++ b/backend/api/tests/duplicate_publish_tests.rs
@@ -1,0 +1,154 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// DUPLICATE CONTRACT DETECTION ON PUBLISH TESTS (Issue #953)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Tests for duplicate-contract detection on POST /api/contracts covering:
+// - Idempotent replay of a prior successful publish (same contract_id,
+//   network, and wasm_hash) returns the existing record instead of erroring.
+// - Republishing an already-registered contract_id/network with different
+//   source code returns a 409 conflict referencing the existing record.
+// - Reusing the same wasm_hash under a different contract_id is allowed
+//   (identical bytecode is legitimately deployed as separate instances).
+//
+// To run: cargo test --test duplicate_publish_tests -- --ignored
+// ═══════════════════════════════════════════════════════════════════════════
+
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+
+fn api_base_url() -> String {
+    std::env::var("TEST_API_BASE_URL").unwrap_or_else(|_| "http://localhost:3001".to_string())
+}
+
+/// Generates a random 56-character Stellar-format StrKey (prefix + 55
+/// uppercase alphanumeric characters), matching CONTRACT_ID_REGEX /
+/// STELLAR_ADDRESS_REGEX in validation/validators.rs.
+fn random_strkey(prefix: char) -> String {
+    let raw = format!(
+        "{:032X}{:032X}",
+        uuid::Uuid::new_v4().as_u128(),
+        uuid::Uuid::new_v4().as_u128()
+    );
+    format!("{}{}", prefix, &raw[..55])
+}
+
+fn publish_payload(contract_id: &str, wasm_hash: &str, network: &str) -> Value {
+    json!({
+        "contract_id": contract_id,
+        "wasm_hash": wasm_hash,
+        "name": format!("Test Contract {}", uuid::Uuid::new_v4()),
+        "network": network,
+        "publisher_address": random_strkey('G'),
+        "tags": []
+    })
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_repeated_publish_with_same_source_is_idempotent() {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+
+    let contract_id = random_strkey('C');
+    let wasm_hash = format!("{:064x}", uuid::Uuid::new_v4().as_u128());
+    let payload = publish_payload(&contract_id, &wasm_hash, "testnet");
+
+    let res1 = client
+        .post(format!("{}/api/contracts", base))
+        .json(&payload)
+        .send()
+        .await
+        .expect("first publish request failed");
+    assert_eq!(res1.status(), StatusCode::OK);
+    let first: Value = res1.json().await.unwrap();
+
+    // Retry the exact same publish (e.g. a client retrying after a dropped
+    // response). This must not create a second row or return an error.
+    let res2 = client
+        .post(format!("{}/api/contracts", base))
+        .json(&payload)
+        .send()
+        .await
+        .expect("second publish request failed");
+    assert_eq!(res2.status(), StatusCode::OK);
+    let second: Value = res2.json().await.unwrap();
+
+    assert_eq!(first["id"], second["id"]);
+    assert_eq!(second["contract_id"], contract_id);
+    assert_eq!(second["wasm_hash"], wasm_hash);
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_republish_with_different_source_returns_conflict() {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+
+    let contract_id = random_strkey('C');
+    let wasm_hash = format!("{:064x}", uuid::Uuid::new_v4().as_u128());
+    let payload = publish_payload(&contract_id, &wasm_hash, "testnet");
+
+    let res1 = client
+        .post(format!("{}/api/contracts", base))
+        .json(&payload)
+        .send()
+        .await
+        .expect("initial publish request failed");
+    assert_eq!(res1.status(), StatusCode::OK);
+    let existing: Value = res1.json().await.unwrap();
+
+    // Same contract_id + network, but different wasm_hash: a genuine attempt
+    // to overwrite an already-registered contract's source.
+    let other_wasm_hash = format!("{:064x}", uuid::Uuid::new_v4().as_u128());
+    let conflicting_payload = publish_payload(&contract_id, &other_wasm_hash, "testnet");
+
+    let res2 = client
+        .post(format!("{}/api/contracts", base))
+        .json(&conflicting_payload)
+        .send()
+        .await
+        .expect("conflicting publish request failed");
+    assert_eq!(res2.status(), StatusCode::CONFLICT);
+
+    let body: Value = res2.json().await.unwrap();
+    let reference = &body["details"]["existing_contract"];
+    assert_eq!(reference["id"], existing["id"]);
+    assert_eq!(reference["contract_id"], contract_id);
+    assert_eq!(reference["wasm_hash"], wasm_hash);
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_same_source_hash_under_different_contract_id_is_allowed() {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+
+    let wasm_hash = format!("{:064x}", uuid::Uuid::new_v4().as_u128());
+
+    let contract_id_a = random_strkey('C');
+    let payload_a = publish_payload(&contract_id_a, &wasm_hash, "testnet");
+    let res_a = client
+        .post(format!("{}/api/contracts", base))
+        .json(&payload_a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res_a.status(), StatusCode::OK);
+
+    // Identical bytecode published under a different contract_id is a
+    // legitimate separate deployment, not a duplicate.
+    let contract_id_b = random_strkey('C');
+    let payload_b = publish_payload(&contract_id_b, &wasm_hash, "testnet");
+    let res_b = client
+        .post(format!("{}/api/contracts", base))
+        .json(&payload_b)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res_b.status(), StatusCode::OK);
+
+    let a: Value = res_a.json().await.unwrap();
+    let b: Value = res_b.json().await.unwrap();
+    assert_ne!(a["id"], b["id"]);
+    assert_eq!(a["wasm_hash"], b["wasm_hash"]);
+}


### PR DESCRIPTION
## What changed

`publish_contract` (`POST /api/contracts`) now checks for an existing contract with the same `contract_id` and `network` before inserting a new row.

- If a matching record exists with the same `wasm_hash`, the request is treated as a retry of a prior successful publish and returns the existing record instead of erroring, keeping publish idempotent.
- If a matching record exists with a different `wasm_hash`, the request returns a 409 conflict (`ContractAlreadyRegistered`) with a `details.existing_contract` reference (id, contract_id, slug, network, wasm_hash, published_at) so callers can look up what's already registered.
- The existing DB-constraint fallback (`contracts_contract_id_network_key`) is left in place as a safety net for races between the check and the insert.

Publishing the same `wasm_hash` under a different `contract_id` is intentionally still allowed - identical bytecode is legitimately redeployed as separate contract instances (e.g. multiple deployments of the same audited contract template), so treating that as a conflict would block a normal workflow.

## Why

Closes #953. Republishing an already-registered contract_id/network previously only failed via a raw DB unique-constraint violation, with no distinction between a harmless retry and a genuine attempt to overwrite an existing contract's source, and no reference to the record already on file.

## Tests

Added `backend/api/tests/duplicate_publish_tests.rs`:
- `test_repeated_publish_with_same_source_is_idempotent` - identical repeated publish returns the same record, no duplicate row.
- `test_republish_with_different_source_returns_conflict` - same contract_id/network with a different wasm_hash returns 409 with the existing record reference.
- `test_same_source_hash_under_different_contract_id_is_allowed` - same wasm_hash under a different contract_id succeeds for both.

These follow the existing `#[ignore = "requires running API + database"]` convention used by `slug_tests.rs` / `review_tests.rs` (run with `cargo test --test duplicate_publish_tests -- --ignored`). I ran them live against a local Postgres instance and a running API server and verified all three pass, and confirmed via direct DB inspection that exactly the expected number of rows were created in each case.

Note: while setting up that live run I found `publish_contract` currently fails for any first-time publisher address on a fresh database (the publisher upsert happens inside a transaction that is opened but never committed, while the contract insert runs on a separate pooled connection that can't see it, causing a foreign-key violation). That bug predates this branch and is unrelated to duplicate detection, so it's not touched here - I worked around it locally only to validate this change, and I'll follow up with a separate issue/PR for it.