### PR TITLE
fix(api): add idempotency keys for contract publish endpoint (#1055)

### DIFF
--- a/backend/api/src/cache.rs
+++ b/backend/api/src/cache.rs
@@ -2,8 +2,32 @@ use moka::future::Cache as MokaCache;
 use redis::aio::ConnectionManager;
 use redis::AsyncCommands;
 use sqlx::PgPool;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex as AsyncMutex;
+
+/// Sentinel value stored while an idempotency key's request is still being
+/// processed, distinguishing "in flight" from a cached completed response.
+const IDEMPOTENCY_IN_PROGRESS: &str = "__in_progress__";
+/// How long an idempotency lock holds before it's considered abandoned
+/// (e.g. the process crashed mid-request) and a retry is allowed to proceed.
+const IDEMPOTENCY_LOCK_TTL_SECS: u64 = 60;
+/// How long a completed response stays replayable for the same key.
+const IDEMPOTENCY_RESPONSE_TTL_SECS: u64 = 86_400;
+
+/// Outcome of attempting to claim an idempotency key.
+pub enum IdempotencyClaim {
+    /// First time this key is seen (or its prior lock/response expired) —
+    /// caller should proceed and report the outcome back via
+    /// `complete_idempotency_key` / `release_idempotency_key`.
+    Fresh,
+    /// Another request with the same key is currently being processed.
+    InProgress,
+    /// A prior request with this key already completed; here's its cached
+    /// response body, to be replayed as-is.
+    Completed(String),
+}
 
 /// Cache configuration options
 #[derive(Clone, Debug)]
@@ -123,6 +147,10 @@ pub struct CacheLayer {
     pub contract_access_cache: MokaCache<String, bool>,
     config: CacheConfig,
     pub redis_cm: Option<ConnectionManager>,
+    /// Fallback store for idempotency keys when Redis is disabled (local/dev/test).
+    /// Only guards against concurrent requests within this single process — unlike
+    /// the Redis path, it does not coordinate across multiple backend instances.
+    idempotency_local: AsyncMutex<HashMap<String, String>>,
 }
 
 impl CacheLayer {
@@ -198,6 +226,7 @@ impl CacheLayer {
             contract_access_cache,
             redis_cm,
             config,
+            idempotency_local: AsyncMutex::new(HashMap::new()),
         }
     }
 
@@ -536,6 +565,95 @@ impl CacheLayer {
                 tracing::warn!("Redis invalidate_contract_meta error: {}", e);
             }
         }
+    }
+
+    /// Atomically claims an idempotency key: the first caller for a given key
+    /// gets `Fresh` and should proceed with the request; concurrent callers
+    /// with the same key see `InProgress` while it's in flight, and callers
+    /// after it finished get the cached `Completed` response to replay.
+    ///
+    /// The Redis path uses `SET NX EX` so the claim-and-lock is a single
+    /// atomic operation — no window where two concurrent requests could both
+    /// observe "key not present" and both proceed.
+    pub async fn claim_idempotency_key(&self, key: &str) -> IdempotencyClaim {
+        let ns_key = format!("idempotency:{}", key);
+
+        if let Some(cm) = &self.redis_cm {
+            let mut conn = cm.clone();
+            let claimed: Option<String> = redis::cmd("SET")
+                .arg(&ns_key)
+                .arg(IDEMPOTENCY_IN_PROGRESS)
+                .arg("NX")
+                .arg("EX")
+                .arg(IDEMPOTENCY_LOCK_TTL_SECS)
+                .query_async(&mut conn)
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::warn!("Redis claim_idempotency_key error: {}", e);
+                    None
+                });
+
+            if claimed.is_some() {
+                return IdempotencyClaim::Fresh;
+            }
+
+            return match conn.get::<_, Option<String>>(&ns_key).await {
+                Ok(Some(val)) if val == IDEMPOTENCY_IN_PROGRESS => IdempotencyClaim::InProgress,
+                Ok(Some(val)) => IdempotencyClaim::Completed(val),
+                // Lock expired between the failed NX and this GET (rare) — treat
+                // as a fresh attempt rather than blocking the caller forever.
+                _ => IdempotencyClaim::Fresh,
+            };
+        }
+
+        let mut guard = self.idempotency_local.lock().await;
+        match guard.get(key) {
+            None => {
+                guard.insert(key.to_string(), IDEMPOTENCY_IN_PROGRESS.to_string());
+                IdempotencyClaim::Fresh
+            }
+            Some(val) if val == IDEMPOTENCY_IN_PROGRESS => IdempotencyClaim::InProgress,
+            Some(val) => IdempotencyClaim::Completed(val.clone()),
+        }
+    }
+
+    /// Records the successful outcome for an idempotency key so subsequent
+    /// requests with the same key replay it instead of re-running the work.
+    pub async fn complete_idempotency_key(&self, key: &str, response_body: String) {
+        let ns_key = format!("idempotency:{}", key);
+
+        if let Some(cm) = &self.redis_cm {
+            let mut conn = cm.clone();
+            if let Err(e) = conn
+                .set_ex::<_, _, ()>(&ns_key, &response_body, IDEMPOTENCY_RESPONSE_TTL_SECS)
+                .await
+            {
+                tracing::warn!("Redis complete_idempotency_key error: {}", e);
+            }
+            return;
+        }
+
+        let mut guard = self.idempotency_local.lock().await;
+        guard.insert(key.to_string(), response_body);
+    }
+
+    /// Releases an idempotency key's lock without caching a response —
+    /// used when the underlying request failed, so a corrected or transient
+    /// retry with the same key isn't stuck behind an "in progress" lock for
+    /// the rest of its window.
+    pub async fn release_idempotency_key(&self, key: &str) {
+        let ns_key = format!("idempotency:{}", key);
+
+        if let Some(cm) = &self.redis_cm {
+            let mut conn = cm.clone();
+            if let Err(e) = conn.del::<_, ()>(&ns_key).await {
+                tracing::warn!("Redis release_idempotency_key error: {}", e);
+            }
+            return;
+        }
+
+        let mut guard = self.idempotency_local.lock().await;
+        guard.remove(key);
     }
 
     /// Get a cached vulnerability assessment. These use the 24h ABI cache

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -78,6 +78,7 @@ pub struct ContractStatsResponse {
 use crate::{
     analytics,
     breaking_changes::{diff_abi, has_breaking_changes, resolve_abi},
+    cache::IdempotencyClaim,
     contract_events::ContractEventEnvelope,
     dependency,
     error::{ApiError, ApiResult},
@@ -4411,6 +4412,41 @@ async fn generate_unique_slug(
     }
 }
 
+/// Maximum accepted length for the `Idempotency-Key` header. Same order of
+/// magnitude as Stripe's limit — long enough for a UUID or a client-side
+/// hash, short enough to keep a header value from becoming a memory/Redis
+/// abuse vector.
+const IDEMPOTENCY_KEY_MAX_LEN: usize = 255;
+
+/// Extracts and validates the optional `Idempotency-Key` header. Returns
+/// `Err` only when the header is present but malformed (not valid UTF-8,
+/// empty, or too long) — a missing header is not an error, it just means
+/// idempotency is opted out of for this request.
+fn extract_idempotency_key(headers: &HeaderMap) -> ApiResult<Option<String>> {
+    let Some(raw) = headers.get("Idempotency-Key") else {
+        return Ok(None);
+    };
+
+    let key = raw.to_str().map_err(|_| {
+        ApiError::bad_request(
+            "InvalidIdempotencyKey",
+            "Idempotency-Key header must be valid UTF-8",
+        )
+    })?;
+
+    if key.is_empty() || key.len() > IDEMPOTENCY_KEY_MAX_LEN {
+        return Err(ApiError::bad_request(
+            "InvalidIdempotencyKey",
+            format!(
+                "Idempotency-Key must be between 1 and {} characters",
+                IDEMPOTENCY_KEY_MAX_LEN
+            ),
+        ));
+    }
+
+    Ok(Some(key.to_string()))
+}
+
 #[utoipa::path(
     post,
     path = "/api/contracts",
@@ -4426,6 +4462,61 @@ pub async fn publish_contract(
     State(state): State<AppState>,
     headers: HeaderMap,
     ValidatedJson(req): ValidatedJson<PublishRequest>,
+) -> ApiResult<Json<Contract>> {
+    let idempotency_key = extract_idempotency_key(&headers)?;
+
+    if let Some(key) = &idempotency_key {
+        match state.cache.claim_idempotency_key(key).await {
+            IdempotencyClaim::Completed(cached_body) => {
+                let contract: Contract = serde_json::from_str(&cached_body).map_err(|err| {
+                    ApiError::internal(format!(
+                        "Failed to decode cached idempotent publish response: {}",
+                        err
+                    ))
+                })?;
+                return Ok(Json(contract));
+            }
+            IdempotencyClaim::InProgress => {
+                return Err(ApiError::conflict(
+                    "IdempotencyKeyInProgress",
+                    "A request with this Idempotency-Key is already being processed. Retry shortly.",
+                ));
+            }
+            IdempotencyClaim::Fresh => {}
+        }
+    }
+
+    let result = publish_contract_inner(&state, &headers, req).await;
+
+    if let Some(key) = &idempotency_key {
+        match &result {
+            Ok(Json(contract)) => match serde_json::to_string(contract) {
+                Ok(body) => state.cache.complete_idempotency_key(key, body).await,
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to serialize contract for idempotency cache: {}",
+                        err
+                    );
+                    state.cache.release_idempotency_key(key).await;
+                }
+            },
+            Err(_) => {
+                // Don't cache error responses under the key: validation/conflict
+                // errors are cheap to recompute, and releasing the lock lets a
+                // corrected request (or a retry after a transient failure) go
+                // through immediately instead of waiting out the full lock TTL.
+                state.cache.release_idempotency_key(key).await;
+            }
+        }
+    }
+
+    result
+}
+
+async fn publish_contract_inner(
+    state: &AppState,
+    headers: &HeaderMap,
+    req: PublishRequest,
 ) -> ApiResult<Json<Contract>> {
     let mut tx = state
         .db
@@ -4486,6 +4577,18 @@ pub async fn publish_contract(
             }
         })));
     }
+
+    // Pre-existing bug found while verifying #1055 end-to-end, unrelated to
+    // idempotency: `tx` was never committed. Everything below this point
+    // already runs against `&state.db` (a fresh pool connection), not `tx`,
+    // so the upserted publisher row was invisible to it under any pool size
+    // above 1 — the INSERT into `contracts` a few lines down would fail with
+    // a `contracts_publisher_id_fkey` violation for any publisher not
+    // already committed by a prior request. Reproduced directly against a
+    // real Postgres + this exact `main` code before this fix.
+    tx.commit()
+        .await
+        .map_err(|err| db_internal_error("commit publish tx", err))?;
 
     let network_key = req.network.to_string();
     let mut config_map = serde_json::Map::new();
@@ -4605,7 +4708,7 @@ pub async fn publish_contract(
         contract.id,
         publisher.id,
         creation_changes,
-        &extract_ip_address(&headers),
+        &extract_ip_address(headers),
     )
     .await
     .map_err(|err| db_internal_error("write contract_created audit log", err))?;

--- a/backend/api/tests/idempotency_publish_tests.rs
+++ b/backend/api/tests/idempotency_publish_tests.rs
@@ -1,0 +1,219 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// IDEMPOTENCY-KEY TESTS FOR CONTRACT PUBLISH (Issue #1055)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Tests for the optional `Idempotency-Key` header on POST /api/contracts:
+// - A repeated request with the same key replays the first response instead
+//   of re-running publish logic (proven by sending a *different* payload on
+//   the retry and asserting the original, cached contract comes back).
+// - Concurrent requests with the same key never create more than one
+//   contract: exactly one succeeds with 200, the rest either see the same
+//   cached contract back or a 409 "in progress" while the first is still
+//   running.
+// - The header is validated at the boundary: empty or oversized keys are
+//   rejected with 400 before any publish logic runs.
+// - Omitting the header entirely leaves existing behavior untouched.
+//
+// To run: cargo test --test idempotency_publish_tests -- --ignored
+// ═══════════════════════════════════════════════════════════════════════════
+
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+
+fn api_base_url() -> String {
+    std::env::var("TEST_API_BASE_URL").unwrap_or_else(|_| "http://localhost:3001".to_string())
+}
+
+/// Generates a random 56-character Stellar-format StrKey (prefix + 55
+/// uppercase alphanumeric characters), matching CONTRACT_ID_REGEX /
+/// STELLAR_ADDRESS_REGEX in validation/validators.rs.
+fn random_strkey(prefix: char) -> String {
+    let raw = format!(
+        "{:032X}{:032X}",
+        uuid::Uuid::new_v4().as_u128(),
+        uuid::Uuid::new_v4().as_u128()
+    );
+    format!("{}{}", prefix, &raw[..55])
+}
+
+fn publish_payload(contract_id: &str, wasm_hash: &str, network: &str) -> Value {
+    json!({
+        "contract_id": contract_id,
+        "wasm_hash": wasm_hash,
+        "name": format!("Test Contract {}", uuid::Uuid::new_v4()),
+        "network": network,
+        "publisher_address": random_strkey('G'),
+        "tags": []
+    })
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_repeated_publish_with_same_key_replays_cached_response() {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+    let idempotency_key = uuid::Uuid::new_v4().to_string();
+
+    let contract_id = random_strkey('C');
+    let wasm_hash = format!("{:064x}", uuid::Uuid::new_v4().as_u128());
+    let payload = publish_payload(&contract_id, &wasm_hash, "testnet");
+
+    let res1 = client
+        .post(format!("{}/api/contracts", base))
+        .header("Idempotency-Key", &idempotency_key)
+        .json(&payload)
+        .send()
+        .await
+        .expect("first publish request failed");
+    assert_eq!(res1.status(), StatusCode::OK);
+    let first: Value = res1.json().await.unwrap();
+
+    // Retry with the SAME key but a materially different payload (a new
+    // contract_id and wasm_hash). If the idempotency cache is actually being
+    // consulted before publish logic runs, this must still return the first
+    // response untouched — not a second contract, and not a validation
+    // error about the second payload.
+    let different_contract_id = random_strkey('C');
+    let different_wasm_hash = format!("{:064x}", uuid::Uuid::new_v4().as_u128());
+    let different_payload =
+        publish_payload(&different_contract_id, &different_wasm_hash, "testnet");
+
+    let res2 = client
+        .post(format!("{}/api/contracts", base))
+        .header("Idempotency-Key", &idempotency_key)
+        .json(&different_payload)
+        .send()
+        .await
+        .expect("replayed publish request failed");
+    assert_eq!(res2.status(), StatusCode::OK);
+    let second: Value = res2.json().await.unwrap();
+
+    assert_eq!(first["id"], second["id"]);
+    assert_eq!(second["contract_id"], contract_id);
+    assert_eq!(second["wasm_hash"], wasm_hash);
+    assert_ne!(second["contract_id"], different_contract_id);
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_concurrent_requests_with_same_key_create_at_most_one_contract() {
+    let base = api_base_url();
+    let idempotency_key = uuid::Uuid::new_v4().to_string();
+
+    let contract_id = random_strkey('C');
+    let wasm_hash = format!("{:064x}", uuid::Uuid::new_v4().as_u128());
+    let payload = publish_payload(&contract_id, &wasm_hash, "testnet");
+
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let base = base.clone();
+        let key = idempotency_key.clone();
+        let payload = payload.clone();
+        handles.push(tokio::spawn(async move {
+            reqwest::Client::new()
+                .post(format!("{}/api/contracts", base))
+                .header("Idempotency-Key", &key)
+                .json(&payload)
+                .send()
+                .await
+        }));
+    }
+
+    let mut ok_ids = Vec::new();
+    let mut conflict_count = 0;
+    for handle in handles {
+        let response = handle
+            .await
+            .expect("task panicked")
+            .expect("request failed");
+        match response.status() {
+            StatusCode::OK => {
+                let body: Value = response.json().await.unwrap();
+                ok_ids.push(body["id"].clone());
+            }
+            StatusCode::CONFLICT => {
+                conflict_count += 1;
+            }
+            other => panic!("unexpected status from concurrent publish: {}", other),
+        }
+    }
+
+    // Every 200 response must reference the exact same contract row — never
+    // two different ids, which would mean the same key raced past the lock
+    // and published twice.
+    assert!(!ok_ids.is_empty(), "at least one request should succeed");
+    for id in &ok_ids {
+        assert_eq!(
+            id, &ok_ids[0],
+            "concurrent requests created different contracts"
+        );
+    }
+    assert_eq!(
+        ok_ids.len() + conflict_count,
+        10,
+        "every request must resolve to either 200 (cached/created) or 409 (in progress)"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_empty_idempotency_key_is_rejected() {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+
+    let contract_id = random_strkey('C');
+    let wasm_hash = format!("{:064x}", uuid::Uuid::new_v4().as_u128());
+    let payload = publish_payload(&contract_id, &wasm_hash, "testnet");
+
+    let res = client
+        .post(format!("{}/api/contracts", base))
+        .header("Idempotency-Key", "")
+        .json(&payload)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_oversized_idempotency_key_is_rejected() {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+
+    let contract_id = random_strkey('C');
+    let wasm_hash = format!("{:064x}", uuid::Uuid::new_v4().as_u128());
+    let payload = publish_payload(&contract_id, &wasm_hash, "testnet");
+    let oversized_key = "a".repeat(256);
+
+    let res = client
+        .post(format!("{}/api/contracts", base))
+        .header("Idempotency-Key", oversized_key)
+        .json(&payload)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_missing_idempotency_key_publishes_normally() {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+
+    let contract_id = random_strkey('C');
+    let wasm_hash = format!("{:064x}", uuid::Uuid::new_v4().as_u128());
+    let payload = publish_payload(&contract_id, &wasm_hash, "testnet");
+
+    // No Idempotency-Key header at all — existing behavior must be unaffected.
+    let res = client
+        .post(format!("{}/api/contracts", base))
+        .json(&payload)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["contract_id"], contract_id);
+}


### PR DESCRIPTION
## Summary

Adds an optional `Idempotency-Key` header on `POST /api/contracts`, per #1055's acceptance criteria:

- Accepts an optional `Idempotency-Key` header on publish.
- Returns the cached response for a repeated key within a TTL window (24h) instead of re-running publish logic.
- Concurrent requests with the same key are serialized via an atomic Redis lock (`SET NX EX`) — one proceeds, the rest see `409` while it's in flight or the cached response once it finishes.

**Why this matters beyond duplicate contract rows:** #953 already prevents two publishes from creating duplicate `contracts` rows for the same `(contract_id, network)`. But a retry still re-ran the audit log write, the analytics event, the contract-event broadcast, and the usage counter increment for the same logical publish — i.e. duplicated side effects even with no duplicate row. This closes that gap.

## Implementation

- `CacheLayer::claim_idempotency_key` / `complete_idempotency_key` / `release_idempotency_key` in `backend/api/src/cache.rs`. Claiming is a single atomic `SET NX EX` against Redis — no window where two concurrent requests could both see "key not seen" and both proceed. A 60s lock TTL protects against a crashed process leaving a key stuck; completed responses are cached for 24h. Falls back to an in-process `Mutex<HashMap>` when Redis is disabled (matches this file's existing L1/L2 pattern elsewhere) — that path only guards a single process, not multiple instances, which is an accepted tradeoff for the dev/test path.
- `publish_contract` is now a thin wrapper around the renamed `publish_contract_inner` (the original body, unchanged): validate the header → claim the key → run the original logic only if `Fresh` → cache the response. I chose wrapping over threading cache calls through the original function's several early-return branches (idempotent replay of an existing contract, real conflict, happy path) — wrapping is the only way to cover all of them without duplicating the caching logic at each exit point.
- Error responses are **not** cached under the key, only `200`s. Validation/conflict errors are cheap to recompute, and *not* caching them means a corrected retry or a retry after a transient failure isn't stuck behind a stale lock for the rest of the window — the lock is released immediately on error instead.
- Header is validated at the boundary: empty or >255 chars → `400` before any publish logic runs (255 chars matches Stripe's convention for this header).

## A bug found (and fixed) while verifying this end-to-end

Unrelated to idempotency, but it blocked verifying this feature at all: `publish_contract`'s transaction (`tx`, used for the publisher upsert and the #953 duplicate check) was **never committed**. Everything after the duplicate check — including the `INSERT INTO contracts` that references the just-upserted `publisher.id` — runs against `&state.db` (a fresh pool connection), not `tx`. Since the pool defaults to 10–50 connections (#876) and a transaction holds its connection until commit/rollback/drop, that `INSERT` essentially never lands on the same physical connection as `tx`, so the not-yet-committed publisher row is invisible to it: **any publish from a `publisher_address` not already committed by a prior request fails with a `contracts_publisher_id_fkey` violation.**

I reproduced this directly against a real Postgres + the current `main` handler with a plain `curl` POST for a brand-new publisher address (before my fix). It also explains why the existing `duplicate_publish_tests.rs` integration tests fail against a live server as of this PR's base commit — they're `#[ignore]`d, so they evidently aren't run against a real DB in CI, and nobody had caught it. Fixed with one `tx.commit()` right after the duplicate check confirms there's no conflict. Verified both the existing `duplicate_publish_tests.rs` (3/3) and my new idempotency tests pass with this fix in place, and fail without it. Happy to split this into its own PR if you'd rather review it separately — flagging it here since it blocks the acceptance criteria for #1055 as well (an idempotent retry of a brand-new publisher's first publish would hit the same bug).

## Test plan

`backend/api/tests/idempotency_publish_tests.rs`, following this repo's existing `#[ignore]`d-integration-test convention (see `duplicate_publish_tests.rs`):
- `test_repeated_publish_with_same_key_replays_cached_response` — retries with the same key but a **different** payload (new `contract_id`/`wasm_hash`), asserting the original cached contract comes back unchanged. Proves the cache is actually consulted before publish logic runs, not just that retries happen to be identical.
- `test_concurrent_requests_with_same_key_create_at_most_one_contract` — fires 10 concurrent requests sharing one key; every `200` must reference the exact same contract id, the rest `409`. This is the core race-condition guarantee the issue asks for.
- `test_empty_idempotency_key_is_rejected` / `test_oversized_idempotency_key_is_rejected` — header validation.
- `test_missing_idempotency_key_publishes_normally` — confirms the feature is opt-in.

- [x] `cargo fmt` / `cargo check -p api` / `cargo clippy -p api --lib` clean for every file touched (no new warnings — verified none of the pre-existing ~65/125 warnings from check/clippy are in `cache.rs` or the touched `handlers.rs` lines).
- [x] All 5 new tests pass against a real Postgres 16 + Redis 7 + this build (`cargo test --test idempotency_publish_tests -- --ignored --test-threads=1`).
- [x] Existing `duplicate_publish_tests.rs` (3/3) still pass — no regression, and they now actually pass against a live server thanks to the `tx.commit()` fix.

Closes #1055