### PR TITLE
Feat:Add dependency vulnerability scanning for published contract metadata

### DIFF
--- a/backend/api/src/dependency_vulnerability.rs
+++ b/backend/api/src/dependency_vulnerability.rs
@@ -1,0 +1,239 @@
+//! Dependency vulnerability scanning for published contract metadata.
+//!
+//! Compares a contract's declared package/crate dependencies against a
+//! curated, offline snapshot of well-documented Rust ecosystem advisories —
+//! the same kind of data `cargo-audit` pulls from the RustSec Advisory
+//! Database — the way `npm audit` / crates.io flag insecure packages.
+//!
+//! The matching logic (`scan_dependencies`, `is_patched`) is pure and has no
+//! database dependency, so it can be unit tested directly; `sync_known_advisories`
+//! is the only piece that touches Postgres, upserting the curated dataset into
+//! `cve_vulnerabilities` so it stays queryable/browsable on its own.
+
+use shared::{DependencyVulnerabilityFinding, IssueSeverity, PackageDependencyInput, SemVer};
+
+/// A single curated advisory entry.
+#[derive(Debug, Clone)]
+pub struct Advisory {
+    pub cve_id: &'static str,
+    pub package_name: &'static str,
+    pub severity: IssueSeverity,
+    pub description: &'static str,
+    /// Versions known to contain the fix, one per affected major line.
+    /// A declared dependency is vulnerable unless its version is at or
+    /// above the patched version for its own major line.
+    pub patched_versions: &'static [&'static str],
+}
+
+/// Curated snapshot of well-documented RustSec advisories for crates
+/// commonly pulled in by Rust/Soroban contracts. This is a local, offline
+/// dataset rather than a live feed; refresh it periodically from
+/// https://rustsec.org as new advisories are published.
+pub fn known_advisories() -> Vec<Advisory> {
+    vec![
+        Advisory {
+            cve_id: "RUSTSEC-2020-0071",
+            package_name: "time",
+            severity: IssueSeverity::High,
+            description: "Unsound use of localtime_r when formatting/parsing local times on \
+                Unix could read uninitialized memory, risking a segfault or disclosure of \
+                unrelated process memory.",
+            patched_versions: &["0.2.23"],
+        },
+        Advisory {
+            cve_id: "RUSTSEC-2020-0159",
+            package_name: "chrono",
+            severity: IssueSeverity::Medium,
+            description: "Local::now() called the C localtime_r function unsoundly on Unix; \
+                concurrent use from multiple threads while mutating environment variables \
+                could cause memory corruption.",
+            patched_versions: &["0.4.20"],
+        },
+        Advisory {
+            cve_id: "RUSTSEC-2021-0003",
+            package_name: "smallvec",
+            severity: IssueSeverity::Critical,
+            description: "SmallVec::insert_many could mis-calculate capacity when the inserted \
+                iterator's size_hint was inaccurate, leading to a buffer overflow / \
+                out-of-bounds write.",
+            patched_versions: &["0.6.14", "1.6.1"],
+        },
+    ]
+}
+
+/// Returns true if `current` is at or above the patched version for its own
+/// major line. If no patched version shares `current`'s major line, the
+/// dependency is treated as patched only when its major version is newer
+/// than every known-vulnerable line (i.e. it postdates the whole advisory).
+/// Versions that fail to parse as semver are treated conservatively as
+/// unpatched, since we cannot prove they contain the fix.
+pub fn is_patched(current: &str, patched_versions: &[&str]) -> bool {
+    let Some(current) = SemVer::parse(current.trim().trim_start_matches('v')) else {
+        return false;
+    };
+
+    let patched: Vec<SemVer> = patched_versions
+        .iter()
+        .filter_map(|v| SemVer::parse(v))
+        .collect();
+
+    if patched.is_empty() {
+        return false;
+    }
+
+    if let Some(same_major) = patched.iter().find(|p| p.major == current.major) {
+        return &current >= same_major;
+    }
+
+    patched.iter().all(|p| current.major > p.major)
+}
+
+/// Compares a contract's declared dependencies against the known advisory
+/// set and returns every match where the declared version is not patched.
+pub fn scan_dependencies(
+    dependencies: &[PackageDependencyInput],
+) -> Vec<DependencyVulnerabilityFinding> {
+    let advisories = known_advisories();
+    let mut findings = Vec::new();
+
+    for dep in dependencies {
+        let package_name = dep.package_name.trim();
+        for advisory in &advisories {
+            if !advisory.package_name.eq_ignore_ascii_case(package_name) {
+                continue;
+            }
+            if is_patched(&dep.version, advisory.patched_versions) {
+                continue;
+            }
+            findings.push(DependencyVulnerabilityFinding {
+                package_name: dep.package_name.clone(),
+                version: dep.version.clone(),
+                cve_id: advisory.cve_id.to_string(),
+                severity: advisory.severity.to_string(),
+                description: Some(advisory.description.to_string()),
+                recommended_version: advisory.patched_versions.last().map(|v| v.to_string()),
+            });
+        }
+    }
+
+    findings
+}
+
+/// Upserts the curated advisory dataset into `cve_vulnerabilities` so it
+/// remains queryable directly (e.g. by the existing vulnerability-assessment
+/// endpoint) without depending on `scan_dependencies` having run first.
+pub async fn sync_known_advisories(db: &sqlx::PgPool) -> Result<(), sqlx::Error> {
+    for advisory in known_advisories() {
+        let patched: Vec<String> = advisory
+            .patched_versions
+            .iter()
+            .map(|v| v.to_string())
+            .collect();
+
+        sqlx::query(
+            r#"
+            INSERT INTO cve_vulnerabilities
+                (cve_id, description, severity, package_name, patched_versions)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (cve_id) DO UPDATE SET
+                description = EXCLUDED.description,
+                severity = EXCLUDED.severity,
+                package_name = EXCLUDED.package_name,
+                patched_versions = EXCLUDED.patched_versions,
+                updated_at = NOW()
+            "#,
+        )
+        .bind(advisory.cve_id)
+        .bind(advisory.description)
+        .bind(advisory.severity.to_string())
+        .bind(advisory.package_name)
+        .bind(&patched)
+        .execute(db)
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dep(name: &str, version: &str) -> PackageDependencyInput {
+        PackageDependencyInput {
+            package_name: name.to_string(),
+            version: version.to_string(),
+        }
+    }
+
+    #[test]
+    fn clean_dependency_set_has_no_findings() {
+        let deps = vec![
+            dep("time", "0.3.36"),
+            dep("chrono", "0.4.38"),
+            dep("smallvec", "1.13.2"),
+            dep("soroban-sdk", "21.0.0"),
+        ];
+        assert!(scan_dependencies(&deps).is_empty());
+    }
+
+    #[test]
+    fn vulnerable_dependency_set_flags_known_cves() {
+        let deps = vec![
+            dep("time", "0.2.10"),
+            dep("smallvec", "0.6.10"),
+            dep("soroban-sdk", "21.0.0"),
+        ];
+        let findings = scan_dependencies(&deps);
+        assert_eq!(findings.len(), 2);
+        assert!(findings.iter().any(|f| f.cve_id == "RUSTSEC-2020-0071"));
+        assert!(findings.iter().any(|f| f.cve_id == "RUSTSEC-2021-0003"));
+    }
+
+    #[test]
+    fn version_at_patch_boundary_is_not_flagged() {
+        assert!(is_patched("0.2.23", &["0.2.23"]));
+        assert!(!is_patched("0.2.22", &["0.2.23"]));
+    }
+
+    #[test]
+    fn later_minor_release_on_same_major_line_is_patched() {
+        // 0.3.x postdates the 0.2.23 fix within the same 0.x major line.
+        assert!(is_patched("0.3.36", &["0.2.23"]));
+    }
+
+    #[test]
+    fn multi_branch_patch_versions_cover_both_lines_independently() {
+        assert!(is_patched("0.6.14", &["0.6.14", "1.6.1"]));
+        assert!(is_patched("1.7.0", &["0.6.14", "1.6.1"]));
+        assert!(!is_patched("0.6.13", &["0.6.14", "1.6.1"]));
+        // 1.6.0 is still within the vulnerable 1.x range even though a
+        // fix exists on the older 0.x line.
+        assert!(!is_patched("1.6.0", &["0.6.14", "1.6.1"]));
+    }
+
+    #[test]
+    fn newer_major_with_no_matching_advisory_line_is_assumed_patched() {
+        assert!(is_patched("2.0.0", &["0.6.14", "1.6.1"]));
+    }
+
+    #[test]
+    fn unparseable_version_is_treated_as_vulnerable() {
+        assert!(!is_patched("not-a-version", &["0.2.23"]));
+    }
+
+    #[test]
+    fn package_name_matching_is_case_insensitive_and_trims_whitespace() {
+        let deps = vec![dep("  Time ", "0.2.10")];
+        let findings = scan_dependencies(&deps);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].cve_id, "RUSTSEC-2020-0071");
+    }
+
+    #[test]
+    fn recommended_version_is_the_latest_known_patch() {
+        let findings = scan_dependencies(&[dep("smallvec", "0.5.0")]);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].recommended_version.as_deref(), Some("1.6.1"));
+    }
+}

--- a/backend/api/src/dependency_vulnerability_handlers.rs
+++ b/backend/api/src/dependency_vulnerability_handlers.rs
@@ -1,0 +1,337 @@
+//! HTTP handlers for dependency vulnerability scanning.
+//!
+//! Publishers declare package/crate dependencies for a contract, which are
+//! immediately scanned against `dependency_vulnerability::known_advisories`.
+//! Warnings are then readable by anyone via `GET .../dependency-scan` (for
+//! display on contract pages), and publishers can opt in to a manual re-scan
+//! at any time via `POST .../dependency-scan` without re-declaring their
+//! dependency list.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use uuid::Uuid;
+
+use shared::{
+    DeclarePackageDependenciesRequest, DependencyScanReport, DependencyVulnerabilityFinding,
+    PackageDependency, PackageDependencyInput,
+};
+
+use crate::{
+    auth::AuthClaims,
+    dependency_vulnerability::{scan_dependencies, sync_known_advisories},
+    error::{ApiError, ApiResult},
+    handlers::db_internal_error,
+    state::AppState,
+    validation::extractors::ValidatedJson,
+};
+
+const MAX_DECLARED_DEPENDENCIES: usize = 200;
+
+#[derive(Debug, sqlx::FromRow)]
+struct DeclaredDependencyRow {
+    package_name: String,
+    version: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct ScanFindingRow {
+    package_name: String,
+    current_version: String,
+    cve_id: String,
+    severity: String,
+    description: Option<String>,
+    recommended_version: Option<String>,
+}
+
+async fn require_contract_owner(
+    state: &AppState,
+    contract_id: Uuid,
+    claims: &AuthClaims,
+) -> ApiResult<()> {
+    let publisher_id: Option<Uuid> =
+        sqlx::query_scalar("SELECT publisher_id FROM contracts WHERE id = $1")
+            .bind(contract_id)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|e| db_internal_error("lookup contract publisher", e))?;
+
+    let publisher_id = publisher_id
+        .ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
+
+    if publisher_id != claims.publisher_id {
+        return Err(ApiError::forbidden(
+            "Only the contract's publisher can manage dependency scanning",
+        ));
+    }
+
+    Ok(())
+}
+
+/// POST /api/contracts/:id/package-dependencies
+///
+/// Declares (replacing) the package/crate dependencies for a contract and
+/// immediately scans them against known vulnerability sources.
+pub async fn declare_package_dependencies(
+    State(state): State<AppState>,
+    claims: AuthClaims,
+    Path(id): Path<Uuid>,
+    ValidatedJson(body): ValidatedJson<DeclarePackageDependenciesRequest>,
+) -> ApiResult<(StatusCode, Json<DependencyScanReport>)> {
+    require_contract_owner(&state, id, &claims).await?;
+
+    if body.dependencies.len() > MAX_DECLARED_DEPENDENCIES {
+        return Err(ApiError::bad_request(
+            "TooManyDependencies",
+            format!(
+                "At most {} dependencies may be declared at once",
+                MAX_DECLARED_DEPENDENCIES
+            ),
+        ));
+    }
+
+    for dep in &body.dependencies {
+        if dep.package_name.trim().is_empty() || dep.version.trim().is_empty() {
+            return Err(ApiError::bad_request(
+                "InvalidDependency",
+                "Each dependency requires a non-empty package_name and version",
+            ));
+        }
+    }
+
+    let mut tx = state
+        .db
+        .begin()
+        .await
+        .map_err(|e| db_internal_error("begin package dependency tx", e))?;
+
+    sqlx::query("DELETE FROM contract_package_dependencies WHERE contract_id = $1")
+        .bind(id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| db_internal_error("clear package dependencies", e))?;
+
+    for dep in &body.dependencies {
+        sqlx::query(
+            r#"
+            INSERT INTO contract_package_dependencies (contract_id, package_name, version)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (contract_id, package_name) DO UPDATE SET version = EXCLUDED.version
+            "#,
+        )
+        .bind(id)
+        .bind(&dep.package_name)
+        .bind(&dep.version)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| db_internal_error("insert package dependency", e))?;
+    }
+
+    tx.commit()
+        .await
+        .map_err(|e| db_internal_error("commit package dependency tx", e))?;
+
+    let report = run_scan(&state, id, "publish").await?;
+    Ok((StatusCode::CREATED, Json(report)))
+}
+
+/// GET /api/contracts/:id/package-dependencies
+pub async fn get_package_dependencies(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<Vec<PackageDependency>>> {
+    let deps = sqlx::query_as::<_, PackageDependency>(
+        r#"
+        SELECT id, contract_id, package_name, version, created_at
+        FROM contract_package_dependencies
+        WHERE contract_id = $1
+        ORDER BY package_name
+        "#,
+    )
+    .bind(id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| db_internal_error("fetch package dependencies", e))?;
+
+    Ok(Json(deps))
+}
+
+/// GET /api/contracts/:id/dependency-scan
+///
+/// Returns the current vulnerability warnings for a contract's declared
+/// dependencies, for display on the contract page.
+pub async fn get_dependency_scan_report(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<DependencyScanReport>> {
+    let exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM contracts WHERE id = $1)")
+        .bind(id)
+        .fetch_one(&state.db)
+        .await
+        .map_err(|e| db_internal_error("check contract exists", e))?;
+
+    if !exists {
+        return Err(ApiError::not_found("ContractNotFound", "Contract not found"));
+    }
+
+    let report = build_report(&state, id).await?;
+    Ok(Json(report))
+}
+
+/// POST /api/contracts/:id/dependency-scan
+///
+/// Opt-in manual re-scan trigger for publishers: re-checks previously
+/// declared dependencies against the latest known vulnerability sources
+/// without requiring the dependency list to be re-declared.
+pub async fn trigger_dependency_scan(
+    State(state): State<AppState>,
+    claims: AuthClaims,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<DependencyScanReport>> {
+    require_contract_owner(&state, id, &claims).await?;
+    let report = run_scan(&state, id, "manual").await?;
+    Ok(Json(report))
+}
+
+async fn run_scan(
+    state: &AppState,
+    contract_id: Uuid,
+    triggered_by: &str,
+) -> ApiResult<DependencyScanReport> {
+    sync_known_advisories(&state.db)
+        .await
+        .map_err(|e| db_internal_error("sync known advisories", e))?;
+
+    let declared: Vec<PackageDependencyInput> = sqlx::query_as::<_, DeclaredDependencyRow>(
+        "SELECT package_name, version FROM contract_package_dependencies WHERE contract_id = $1",
+    )
+    .bind(contract_id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| db_internal_error("fetch declared dependencies for scan", e))?
+    .into_iter()
+    .map(|row| PackageDependencyInput {
+        package_name: row.package_name,
+        version: row.version,
+    })
+    .collect();
+
+    let findings = scan_dependencies(&declared);
+
+    let mut tx = state
+        .db
+        .begin()
+        .await
+        .map_err(|e| db_internal_error("begin scan tx", e))?;
+
+    sqlx::query("DELETE FROM contract_scan_results WHERE contract_id = $1")
+        .bind(contract_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| db_internal_error("clear stale scan results", e))?;
+
+    for finding in &findings {
+        sqlx::query(
+            r#"
+            INSERT INTO contract_scan_results
+                (contract_id, cve_id, package_name, current_version, recommended_version)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (contract_id, cve_id) DO UPDATE SET
+                package_name = EXCLUDED.package_name,
+                current_version = EXCLUDED.current_version,
+                recommended_version = EXCLUDED.recommended_version
+            "#,
+        )
+        .bind(contract_id)
+        .bind(&finding.cve_id)
+        .bind(&finding.package_name)
+        .bind(&finding.version)
+        .bind(&finding.recommended_version)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| db_internal_error("persist scan finding", e))?;
+    }
+
+    sqlx::query(
+        r#"
+        INSERT INTO contract_dependency_scan_runs
+            (contract_id, triggered_by, dependencies_scanned, vulnerabilities_found)
+        VALUES ($1, $2, $3, $4)
+        "#,
+    )
+    .bind(contract_id)
+    .bind(triggered_by)
+    .bind(declared.len() as i32)
+    .bind(findings.len() as i32)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| db_internal_error("record scan run", e))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| db_internal_error("commit scan tx", e))?;
+
+    build_report(state, contract_id).await
+}
+
+async fn build_report(state: &AppState, contract_id: Uuid) -> ApiResult<DependencyScanReport> {
+    let dependencies_scanned: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM contract_package_dependencies WHERE contract_id = $1",
+    )
+    .bind(contract_id)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| db_internal_error("count declared dependencies", e))?;
+
+    let findings: Vec<DependencyVulnerabilityFinding> = sqlx::query_as::<_, ScanFindingRow>(
+        r#"
+        SELECT csr.package_name, csr.current_version, csr.cve_id, cv.severity,
+               cv.description, csr.recommended_version
+        FROM contract_scan_results csr
+        JOIN cve_vulnerabilities cv ON cv.cve_id = csr.cve_id
+        WHERE csr.contract_id = $1 AND csr.is_false_positive = false
+        ORDER BY csr.package_name
+        "#,
+    )
+    .bind(contract_id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| db_internal_error("fetch scan findings", e))?
+    .into_iter()
+    .map(|row| DependencyVulnerabilityFinding {
+        package_name: row.package_name,
+        version: row.current_version,
+        cve_id: row.cve_id,
+        severity: row.severity,
+        description: row.description,
+        recommended_version: row.recommended_version,
+    })
+    .collect();
+
+    let last_scanned_at: Option<chrono::DateTime<chrono::Utc>> = sqlx::query_scalar(
+        "SELECT MAX(scanned_at) FROM contract_dependency_scan_runs WHERE contract_id = $1",
+    )
+    .bind(contract_id)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| db_internal_error("fetch last scan time", e))?;
+
+    let status = if last_scanned_at.is_none() {
+        "not_scanned"
+    } else if !findings.is_empty() {
+        "vulnerable"
+    } else {
+        "clean"
+    };
+
+    Ok(DependencyScanReport {
+        contract_id,
+        status: status.to_string(),
+        dependencies_scanned,
+        vulnerable_dependency_count: findings.len() as i64,
+        last_scanned_at,
+        findings,
+    })
+}

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -104,6 +104,8 @@ pub mod db_monitoring;
 pub mod db_pool;
 pub mod db_resilience;
 pub mod dependency;
+pub mod dependency_vulnerability;
+pub mod dependency_vulnerability_handlers;
 pub mod deprecated_contracts_handlers;
 pub mod elasticsearch_handlers;
 pub mod favorites_handlers;

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -7,7 +7,8 @@ use crate::{
     bulk_operations_handlers, canary_handlers, category_handlers, client_observability_handlers,
     clone_federation_handlers, collaborative_reviews, compatibility_testing_handlers,
     contract_events, contract_stats_handlers, contributor_handlers, custom_metrics_handlers,
-    db_pool, dependency_handlers, deprecated_contracts_handlers, deprecation_handlers,
+    db_pool, dependency_handlers, dependency_vulnerability_handlers,
+    deprecated_contracts_handlers, deprecation_handlers,
     elasticsearch_handlers, error_logging, feature_flags, formal_verification_handlers,
     formal_verification_integration, gas_estimation_handlers, governance_handlers,
     graph_analysis_handlers, handlers, integrity, interoperability_handlers,
@@ -575,6 +576,16 @@ pub fn contract_routes() -> Router<AppState> {
             "/api/contracts/:id/dependencies",
             get(crate::dependency_handlers::get_contract_dependencies)
                 .post(dependency_handlers::declare_contract_dependencies),
+        )
+        .route(
+            "/api/contracts/:id/package-dependencies",
+            get(dependency_vulnerability_handlers::get_package_dependencies)
+                .post(dependency_vulnerability_handlers::declare_package_dependencies),
+        )
+        .route(
+            "/api/contracts/:id/dependency-scan",
+            get(dependency_vulnerability_handlers::get_dependency_scan_report)
+                .post(dependency_vulnerability_handlers::trigger_dependency_scan),
         )
         .route(
             "/api/contracts/:id/graph",

--- a/backend/api/tests/dependency_vulnerability_tests.rs
+++ b/backend/api/tests/dependency_vulnerability_tests.rs
@@ -1,0 +1,94 @@
+// tests/dependency_vulnerability_tests.rs
+//
+// Dependency vulnerability scanning: compares a contract's declared
+// package/crate dependencies against the registry's curated advisory
+// database. These tests exercise the pure scanning engine directly (no
+// database required), covering both a contract with a clean dependency set
+// and one with a vulnerable dependency set, per the feature's acceptance
+// criteria.
+
+use api::dependency_vulnerability::scan_dependencies;
+use shared::PackageDependencyInput;
+
+fn package(name: &str, version: &str) -> PackageDependencyInput {
+    PackageDependencyInput {
+        package_name: name.to_string(),
+        version: version.to_string(),
+    }
+}
+
+#[test]
+fn contract_with_clean_dependencies_reports_no_vulnerabilities() {
+    // A contract that only pulls in patched versions of every crate we track
+    // advisories for should scan clean.
+    let declared = vec![
+        package("soroban-sdk", "21.0.0"),
+        package("time", "0.3.36"),
+        package("chrono", "0.4.38"),
+        package("smallvec", "1.13.2"),
+    ];
+
+    let findings = scan_dependencies(&declared);
+
+    assert!(
+        findings.is_empty(),
+        "expected no findings for an all-patched dependency set, got {:?}",
+        findings
+    );
+}
+
+#[test]
+fn contract_with_vulnerable_dependencies_reports_each_known_cve() {
+    // A contract still pinned to vulnerable releases of two tracked crates
+    // should surface one finding per affected dependency, each carrying the
+    // matching CVE/advisory id, severity and a remediation hint.
+    let declared = vec![
+        package("soroban-sdk", "21.0.0"),
+        package("time", "0.2.10"),
+        package("chrono", "0.4.19"),
+    ];
+
+    let findings = scan_dependencies(&declared);
+
+    assert_eq!(findings.len(), 2, "expected findings: {:?}", findings);
+
+    let time_finding = findings
+        .iter()
+        .find(|f| f.package_name == "time")
+        .expect("time finding present");
+    assert_eq!(time_finding.cve_id, "RUSTSEC-2020-0071");
+    assert_eq!(time_finding.severity, "high");
+    assert!(time_finding.recommended_version.is_some());
+
+    let chrono_finding = findings
+        .iter()
+        .find(|f| f.package_name == "chrono")
+        .expect("chrono finding present");
+    assert_eq!(chrono_finding.cve_id, "RUSTSEC-2020-0159");
+    assert_eq!(chrono_finding.severity, "medium");
+
+    assert!(
+        !findings.iter().any(|f| f.package_name == "soroban-sdk"),
+        "unrelated dependency should not be flagged"
+    );
+}
+
+#[test]
+fn contract_with_no_declared_dependencies_scans_clean() {
+    let findings = scan_dependencies(&[]);
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn mixed_dependency_set_only_flags_the_vulnerable_entries() {
+    let declared = vec![
+        package("time", "0.3.0"),   // patched
+        package("smallvec", "0.6.5"), // vulnerable (pre-0.6.14)
+    ];
+
+    let findings = scan_dependencies(&declared);
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].package_name, "smallvec");
+    assert_eq!(findings[0].cve_id, "RUSTSEC-2021-0003");
+}

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -1228,6 +1228,75 @@ pub struct ContractDependency {
     pub created_at: DateTime<Utc>,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Dependency vulnerability scanning
+//
+// Distinct from `ContractDependency` above (which tracks on-chain
+// contract-to-contract call relationships): these types describe declared
+// package/crate dependencies (Cargo-style name + version) and their exposure
+// to known vulnerabilities, similar to `npm audit` / crates.io advisories.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A single package/crate dependency declared for a contract.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, utoipa::ToSchema)]
+pub struct PackageDependency {
+    pub id: Uuid,
+    pub contract_id: Uuid,
+    pub package_name: String,
+    pub version: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// One package/version pair in a dependency declaration request.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct PackageDependencyInput {
+    pub package_name: String,
+    pub version: String,
+}
+
+/// Request body for declaring (replacing) a contract's package dependencies.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct DeclarePackageDependenciesRequest {
+    pub dependencies: Vec<PackageDependencyInput>,
+}
+
+/// A known vulnerability affecting a package, sourced from the registry's
+/// curated advisory database (`cve_vulnerabilities`).
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, utoipa::ToSchema)]
+pub struct CveVulnerability {
+    pub cve_id: String,
+    pub description: Option<String>,
+    pub severity: String,
+    pub package_name: String,
+    pub patched_versions: Vec<String>,
+    pub published_at: Option<DateTime<Utc>>,
+}
+
+/// One vulnerability finding surfaced for a specific declared dependency.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct DependencyVulnerabilityFinding {
+    pub package_name: String,
+    pub version: String,
+    pub cve_id: String,
+    pub severity: String,
+    pub description: Option<String>,
+    pub recommended_version: Option<String>,
+}
+
+/// Result of scanning a contract's declared dependencies against known
+/// vulnerability sources. Returned by both the re-scan trigger and the
+/// read-only status endpoint used to render warnings on contract pages.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct DependencyScanReport {
+    pub contract_id: Uuid,
+    /// One of "not_scanned", "clean", "vulnerable".
+    pub status: String,
+    pub dependencies_scanned: i64,
+    pub vulnerable_dependency_count: i64,
+    pub last_scanned_at: Option<DateTime<Utc>>,
+    pub findings: Vec<DependencyVulnerabilityFinding>,
+}
+
 /// Tracks migration scripts between contract versions
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, utoipa::ToSchema)]
 pub struct MigrationScript {

--- a/database/migrations/20260726000000_dependency_scan_runs.sql
+++ b/database/migrations/20260726000000_dependency_scan_runs.sql
@@ -1,0 +1,19 @@
+-- Track dependency vulnerability scan runs (backend dependency scanning feature).
+--
+-- Builds on 029_dependency_scanning.sql, which created
+-- `contract_package_dependencies`, `cve_vulnerabilities` and
+-- `contract_scan_results` but left nothing populating or reading them.
+-- This table records when each scan ran and by whom, so contract pages can
+-- show "last scanned" status and publishers get an auditable re-scan trigger.
+
+CREATE TABLE contract_dependency_scan_runs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contract_id UUID NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,
+    triggered_by VARCHAR(20) NOT NULL DEFAULT 'manual',
+    dependencies_scanned INT NOT NULL DEFAULT 0,
+    vulnerabilities_found INT NOT NULL DEFAULT 0,
+    scanned_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_contract_dependency_scan_runs_contract_id
+    ON contract_dependency_scan_runs(contract_id, scanned_at DESC);

--- a/frontend/app/contracts/[id]/page.tsx
+++ b/frontend/app/contracts/[id]/page.tsx
@@ -28,6 +28,7 @@ import CodeCopyButton from "@/components/CodeCopyButton";
 import { useParams, useSearchParams } from "next/navigation";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import FormalVerificationPanel from "@/components/FormalVerificationPanel";
+import DependencyVulnerabilityPanel from "@/components/DependencyVulnerabilityPanel";
 import Navbar from "@/components/Navbar";
 import MaintenanceBanner from "@/components/MaintenanceBanner";
 import DeprecationBanner from "@/components/DeprecationBanner";
@@ -852,6 +853,7 @@ function ContractDetailsContent() {
               </dl>
             </div>
             <FormalVerificationPanel contractId={contract.id} />
+            <DependencyVulnerabilityPanel contractId={contract.id} />
           </section>
         )}
 

--- a/frontend/components/DependencyVulnerabilityPanel.tsx
+++ b/frontend/components/DependencyVulnerabilityPanel.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api, DependencyVulnerabilityFinding } from "@/lib/api";
+import { useToast } from "@/hooks/useToast";
+import {
+  ShieldAlert,
+  ShieldCheck,
+  ShieldQuestion,
+  RefreshCw,
+} from "lucide-react";
+
+export default function DependencyVulnerabilityPanel({
+  contractId,
+}: {
+  contractId: string;
+}) {
+  const queryClient = useQueryClient();
+  const { showSuccess, showError } = useToast();
+
+  const {
+    data: report,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["dependency-scan", contractId],
+    queryFn: () => api.getDependencyScanReport(contractId),
+  });
+
+  const rescanMutation = useMutation({
+    mutationFn: () => api.triggerDependencyScan(contractId),
+    onSuccess: (data) => {
+      queryClient.setQueryData(["dependency-scan", contractId], data);
+      showSuccess("Dependency re-scan complete");
+    },
+    onError: (err: Error) => {
+      showError(err.message || "Failed to trigger dependency re-scan");
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="bg-card rounded-2xl border border-border p-6 animate-pulse">
+        <div className="h-6 bg-muted rounded w-1/2 mb-4"></div>
+        <div className="space-y-3">
+          <div className="h-4 bg-muted rounded"></div>
+          <div className="h-4 bg-muted rounded w-5/6"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <div className="bg-card rounded-2xl border border-border p-6 flex items-center justify-between text-muted-foreground">
+        <div className="flex items-center gap-3">
+          <ShieldQuestion className="w-5 h-5 text-muted-foreground" />
+          <span className="text-sm font-medium">
+            Dependency vulnerability scan unavailable
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const hasVulnerabilities = report.vulnerable_dependency_count > 0;
+
+  return (
+    <div className="bg-card rounded-2xl border border-border p-6">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <ShieldAlert className="w-5 h-5 text-foreground" />
+          <h3 className="font-semibold text-foreground">
+            Dependency Vulnerabilities
+          </h3>
+        </div>
+        {report.status === "not_scanned" ? (
+          <span className="flex items-center gap-1 text-xs font-semibold px-2 py-1 bg-accent text-muted-foreground rounded-full">
+            <ShieldQuestion className="w-3 h-3" /> Not Scanned
+          </span>
+        ) : hasVulnerabilities ? (
+          <span className="flex items-center gap-1 text-xs font-semibold px-2 py-1 bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 rounded-full">
+            <ShieldAlert className="w-3 h-3" /> Vulnerable
+          </span>
+        ) : (
+          <span className="flex items-center gap-1 text-xs font-semibold px-2 py-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 rounded-full">
+            <ShieldCheck className="w-3 h-3" /> Clean
+          </span>
+        )}
+      </div>
+
+      <p className="text-sm text-muted-foreground mb-4">
+        {report.dependencies_scanned > 0
+          ? `${report.dependencies_scanned} declared ${
+              report.dependencies_scanned === 1 ? "dependency" : "dependencies"
+            } checked against known vulnerability sources.`
+          : "No package dependencies have been declared for this contract yet."}
+      </p>
+
+      {hasVulnerabilities && (
+        <div className="space-y-3 mb-4">
+          {report.findings.map((finding) => (
+            <FindingRow key={`${finding.package_name}-${finding.cve_id}`} finding={finding} />
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between pt-4 border-t border-border">
+        <span className="text-xs text-muted-foreground">
+          {report.last_scanned_at
+            ? `Last scanned ${new Date(report.last_scanned_at).toLocaleDateString()}`
+            : "Never scanned"}
+        </span>
+        <button
+          onClick={() => rescanMutation.mutate()}
+          disabled={rescanMutation.isPending}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          <RefreshCw
+            className={`w-3.5 h-3.5 ${rescanMutation.isPending ? "animate-spin" : ""}`}
+          />
+          {rescanMutation.isPending ? "Scanning..." : "Re-scan Dependencies"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function FindingRow({ finding }: { finding: DependencyVulnerabilityFinding }) {
+  const severityClasses: Record<string, string> = {
+    critical: "border-red-300 dark:border-red-900/50 bg-red-50/50 dark:bg-red-900/10",
+    high: "border-orange-200 dark:border-orange-900/40 bg-orange-50/50 dark:bg-orange-900/10",
+    medium: "border-yellow-200 dark:border-yellow-900/40 bg-yellow-50/50 dark:bg-yellow-900/10",
+    low: "border-border bg-accent/50",
+  };
+
+  return (
+    <div
+      className={`border rounded-lg p-3 ${
+        severityClasses[finding.severity] ?? severityClasses.low
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <div className="text-sm font-medium text-foreground">
+            {finding.package_name}
+            <span className="text-muted-foreground font-normal"> @ {finding.version}</span>
+          </div>
+          <div className="text-xs text-muted-foreground mt-1 font-mono uppercase">
+            {finding.cve_id} • {finding.severity}
+          </div>
+        </div>
+      </div>
+      {finding.description && (
+        <p className="text-sm text-muted-foreground mt-2">{finding.description}</p>
+      )}
+      {finding.recommended_version && (
+        <p className="text-xs text-foreground mt-2">
+          Upgrade to <span className="font-mono font-medium">{finding.recommended_version}</span>{" "}
+          or later.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -263,6 +263,39 @@ export interface FormalVerificationReport {
   certificate?: ProofCertificate | null;
 }
 
+export interface PackageDependency {
+  id: string;
+  contract_id: string;
+  package_name: string;
+  version: string;
+  created_at: string;
+}
+
+export interface PackageDependencyInput {
+  package_name: string;
+  version: string;
+}
+
+export interface DependencyVulnerabilityFinding {
+  package_name: string;
+  version: string;
+  cve_id: string;
+  severity: string;
+  description?: string | null;
+  recommended_version?: string | null;
+}
+
+export type DependencyScanStatus = "not_scanned" | "clean" | "vulnerable";
+
+export interface DependencyScanReport {
+  contract_id: string;
+  status: DependencyScanStatus;
+  dependencies_scanned: number;
+  vulnerable_dependency_count: number;
+  last_scanned_at?: string | null;
+  findings: DependencyVulnerabilityFinding[];
+}
+
 export type InteroperabilityCapabilityKind = "bridge" | "adapter";
 
 export interface InteroperabilityProtocolMatch {
@@ -1438,6 +1471,62 @@ export async function fetchFormalVerificationResults(
   return [detail];
 }
 
+// ─── Dependency Vulnerability Scanning ────────────────────────────────────────
+
+export async function fetchDependencyScanReport(
+  contractId: string,
+): Promise<DependencyScanReport> {
+  if (USE_MOCKS) {
+    return {
+      contract_id: contractId,
+      status: "not_scanned",
+      dependencies_scanned: 0,
+      vulnerable_dependency_count: 0,
+      last_scanned_at: null,
+      findings: [],
+    };
+  }
+  return apiFetch<DependencyScanReport>(
+    `/api/contracts/${contractId}/dependency-scan`,
+  );
+}
+
+export async function triggerDependencyScan(
+  contractId: string,
+): Promise<DependencyScanReport> {
+  if (USE_MOCKS) {
+    return fetchDependencyScanReport(contractId);
+  }
+  return apiFetch<DependencyScanReport>(
+    `/api/contracts/${contractId}/dependency-scan`,
+    { method: "POST" },
+  );
+}
+
+export async function fetchPackageDependencies(
+  contractId: string,
+): Promise<PackageDependency[]> {
+  if (USE_MOCKS) {
+    return [];
+  }
+  return apiFetch<PackageDependency[]>(
+    `/api/contracts/${contractId}/package-dependencies`,
+  );
+}
+
+export async function declarePackageDependencies(
+  contractId: string,
+  dependencies: PackageDependencyInput[],
+): Promise<DependencyScanReport> {
+  return apiFetch<DependencyScanReport>(
+    `/api/contracts/${contractId}/package-dependencies`,
+    {
+      method: "POST",
+      body: JSON.stringify({ dependencies }),
+    },
+  );
+}
+
 // ─── Compatibility Testing ────────────────────────────────────────────────────
 
 export async function fetchCompatibilityMatrix(
@@ -1833,6 +1922,12 @@ export const api = {
   // Backward-compatible aliases for formal verification
   fetchFormalVerificationResults,
   getFormalVerificationResults: fetchFormalVerificationResults,
+  // Dependency vulnerability scanning
+  fetchDependencyScanReport,
+  getDependencyScanReport: fetchDependencyScanReport,
+  triggerDependencyScan,
+  fetchPackageDependencies,
+  declarePackageDependencies,
   // Backward-compatible aliases for compatibility testing
   fetchCompatibilityMatrix,
   getCompatibilityMatrix: fetchCompatibilityMatrix,


### PR DESCRIPTION
## Summary  [fixes #1048 ]

Adds dependency vulnerability scanning for published contract metadata, closing the gap where declared dependencies were never checked against known vulnerability sources.

The DB schema for this already existed (`029_dependency_scanning.sql` — `cve_vulnerabilities`, `contract_package_dependencies`, `contract_scan_results`), but nothing populated or read it aside from a partial risk-score endpoint. This PR builds the missing scan pipeline on top of it.

- Add scan step comparing declared dependencies against known vulnerability sources
- Display vulnerability warnings on contract pages
- Add opt-in re-scan trigger for publishers
- Add tests for contracts with clean and vulnerable dependency sets

## Changes

### Backend

- **`backend/api/src/dependency_vulnerability.rs`** (new) — pure scan engine:
  - Curated, offline advisory dataset (`RUSTSEC-2020-0071` / `time`, `RUSTSEC-2020-0159` / `chrono`, `RUSTSEC-2021-0003` / `smallvec`) — the same kind of data `cargo-audit` pulls from the RustSec Advisory Database.
  - `scan_dependencies()` / `is_patched()` — semver-aware matching, reusing the repo's existing `shared::SemVer` utility instead of adding a new external dependency.
  - `sync_known_advisories()` — upserts the curated dataset into `cve_vulnerabilities`.
  - 9 unit tests covering clean/vulnerable sets, patch-boundary edges, multi-branch advisories, and unparseable versions.

- **`backend/api/src/dependency_vulnerability_handlers.rs`** (new) — four endpoints:
  | Method | Path | Description |
  |---|---|---|
  | `POST` | `/api/contracts/:id/package-dependencies` | Publisher declares Cargo-style deps; declaring immediately triggers a scan |
  | `GET` | `/api/contracts/:id/package-dependencies` | List declared dependencies |
  | `GET` | `/api/contracts/:id/dependency-scan` | Public read of current warnings, for contract pages |
  | `POST` | `/api/contracts/:id/dependency-scan` | Opt-in re-scan trigger, restricted to the contract's publisher via `AuthClaims` |

- **`database/migrations/20260726000000_dependency_scan_runs.sql`** (new) — tracks scan run history (`triggered_by`, `dependencies_scanned`, `vulnerabilities_found`, `scanned_at`) so "last scanned"/status is knowable even when a contract is clean.

- **`backend/shared/src/models.rs`** — new request/response types: `PackageDependency`, `PackageDependencyInput`, `DeclarePackageDependenciesRequest`, `CveVulnerability`, `DependencyVulnerabilityFinding`, `DependencyScanReport`.

- **`backend/api/src/lib.rs`, `routes.rs`** — module registration and route wiring.

- **`backend/api/tests/dependency_vulnerability_tests.rs`** (new) — black-box tests for contracts with clean, vulnerable, mixed, and empty dependency sets.

### Frontend

- **`frontend/components/DependencyVulnerabilityPanel.tsx`** (new) — panel modeled on `FormalVerificationPanel`, showing scan status (clean / vulnerable / not scanned), findings with severity + remediation hints, and a "Re-scan Dependencies" button. Wired into the contract detail page's verification tab.
- **`frontend/lib/api.ts`** — new types (`PackageDependency`, `DependencyVulnerabilityFinding`, `DependencyScanReport`, …) and fetch functions (`getDependencyScanReport`, `triggerDependencyScan`, `declarePackageDependencies`, `fetchPackageDependencies`).

## Design notes

- Ownership check for the re-scan trigger mirrors the existing pattern in `org_handlers.rs` (`claims.publisher_id` vs. the contract's `publisher_id`, returning 403 otherwise).
- Version comparison reuses `shared::SemVer` (already in the codebase) rather than pulling in the external `semver` crate — same-major-line patch matching, falling back to "newer major than every known-vulnerable line ⇒ assumed patched" for versions with no matching advisory line.
- Advisory data is an offline curated snapshot (clearly documented as such in code comments), not a live external feed — kept the feature self-contained and testable without network calls.

