### PR TITLE
Feat: Fix contract search filter parsing for network and category

### DIFF
--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -1016,6 +1016,68 @@ fn validate_contract_list_pagination(
     Ok((limit, offset, page))
 }
 
+fn normalized_contract_categories(params: &ContractSearchParams) -> Vec<String> {
+    params
+        .categories
+        .iter()
+        .flatten()
+        .chain(params.category.iter())
+        .flat_map(|value| value.split(','))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn normalized_contract_networks(params: &ContractSearchParams) -> Vec<shared::Network> {
+    params
+        .networks
+        .iter()
+        .flatten()
+        .chain(params.network.iter())
+        .copied()
+        .collect()
+}
+
+#[cfg(test)]
+mod contract_filter_tests {
+    use super::*;
+
+    #[test]
+    fn list_filters_merge_plural_and_singular_values() {
+        let params = ContractSearchParams {
+            networks: Some(vec![shared::Network::Testnet]),
+            network: Some(shared::Network::Mainnet),
+            categories: Some(vec!["NFT".to_string(), " lending ".to_string()]),
+            category: Some("DeFi, ,".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            normalized_contract_networks(&params),
+            vec![shared::Network::Testnet, shared::Network::Mainnet]
+        );
+        assert_eq!(
+            normalized_contract_categories(&params),
+            vec!["NFT", "lending", "DeFi"]
+        );
+    }
+
+    #[test]
+    fn list_offset_is_not_rounded_to_a_page_boundary() {
+        let params = ContractSearchParams {
+            limit: Some(10),
+            offset: Some(5),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            validate_contract_list_pagination(&params).unwrap(),
+            (10, 5, 1)
+        );
+    }
+}
+
 pub(crate) fn extract_ip_address(headers: &HeaderMap) -> String {
     if let Some(forwarded_for) = headers
         .get("x-forwarded-for")
@@ -1925,11 +1987,7 @@ pub async fn list_contracts(
         qb.push_bind(status);
     }
 
-    let mut categories = params.categories.clone().unwrap_or_default();
-    if let Some(category) = &params.category {
-        categories.push(category.clone());
-    }
-    categories.retain(|category| !category.trim().is_empty());
+    let categories = normalized_contract_categories(&params);
     if !categories.is_empty() {
         qb.push(" AND c.category IN (");
         let mut separated = qb.separated(", ");
@@ -1939,13 +1997,8 @@ pub async fn list_contracts(
         separated.push_unseparated(")");
     }
 
-    if let Some(networks) = params
-        .networks
-        .as_ref()
-        .filter(|n| !n.is_empty())
-        .cloned()
-        .or_else(|| params.network.clone().map(|n| vec![n]))
-    {
+    let networks = normalized_contract_networks(&params);
+    if !networks.is_empty() {
         qb.push(" AND c.network IN (");
         let mut separated = qb.separated(", ");
         for network in networks {
@@ -2105,11 +2158,7 @@ pub async fn list_contracts(
         count_qb.push(" AND c.verification_status = ");
         count_qb.push_bind(status);
     }
-    let mut count_categories = params.categories.clone().unwrap_or_default();
-    if let Some(cat) = &params.category {
-        count_categories.push(cat.clone());
-    }
-    count_categories.retain(|c| !c.trim().is_empty());
+    let count_categories = normalized_contract_categories(&params);
     if !count_categories.is_empty() {
         count_qb.push(" AND c.category IN (");
         let mut sep = count_qb.separated(", ");
@@ -2119,13 +2168,8 @@ pub async fn list_contracts(
         sep.push_unseparated(")");
     }
 
-    if let Some(count_networks) = params
-        .networks
-        .as_ref()
-        .filter(|n| !n.is_empty())
-        .cloned()
-        .or_else(|| params.network.clone().map(|n| vec![n]))
-    {
+    let count_networks = normalized_contract_networks(&params);
+    if !count_networks.is_empty() {
         count_qb.push(" AND c.network IN (");
         let mut sep = count_qb.separated(", ");
         for net in count_networks {
@@ -2168,14 +2212,17 @@ pub async fn list_contracts(
     // Populate active filter metadata
     {
         let mut networks: Option<Vec<String>> = None;
-        if let Some(n) = &params.networks {
-            if !n.is_empty() {
-                networks = Some(n.iter().map(|net| net.to_string()).collect());
-            }
-        } else if let Some(n) = &params.network {
-            networks = Some(vec![n.to_string()]);
+        let normalized_networks = normalized_contract_networks(&params);
+        if !normalized_networks.is_empty() {
+            networks = Some(
+                normalized_networks
+                    .iter()
+                    .map(|net| net.to_string())
+                    .collect(),
+            );
         }
-        let categories = params.categories.clone().filter(|c| !c.is_empty());
+        let categories = (!normalized_contract_categories(&params).is_empty())
+            .then(|| normalized_contract_categories(&params));
         let tags = params.tags.clone().filter(|t| !t.is_empty());
         let verified_only = params.verified_only;
         let verification_status = params

--- a/backend/api/src/search_postgres.rs
+++ b/backend/api/src/search_postgres.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use shared::models::Network;
+use shared::models::{deserialize_optional_networks, deserialize_optional_string_list, Network};
 use shared::pagination::Cursor;
 use sqlx::PgPool;
 
@@ -392,24 +392,13 @@ pub async fn fulltext_search_handler(
         }
     }
 
+    let categories = merge_filter_values(params.categories.clone(), params.category.clone());
+    let networks = merge_filter_values(params.networks.clone(), params.network.clone());
+
     let search_req = SearchQuery {
         query: query.to_string(),
-        categories: params.category.as_ref().map(|c| {
-            c.split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect::<Vec<String>>()
-        }),
-        networks: params.network.as_ref().map(|n| {
-            n.split(',')
-                .filter_map(|s| match s {
-                    "mainnet" => Some(Network::Mainnet),
-                    "testnet" => Some(Network::Testnet),
-                    "futurenet" => Some(Network::Futurenet),
-                    _ => None,
-                })
-                .collect::<Vec<Network>>()
-        }),
+        categories,
+        networks,
         verified_only: params.verified_only,
         tags: params
             .tags
@@ -433,11 +422,25 @@ pub async fn fulltext_search_handler(
     Ok(Json(result))
 }
 
+fn merge_filter_values<T>(plural: Option<Vec<T>>, singular: Option<Vec<T>>) -> Option<Vec<T>> {
+    let mut values = plural.unwrap_or_default();
+    values.extend(singular.unwrap_or_default());
+    (!values.is_empty()).then_some(values)
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SearchQueryParams {
     pub q: Option<String>,
-    pub category: Option<String>,
-    pub network: Option<String>,
+    /// Singular aliases are retained for compatibility. Both singular and
+    /// plural forms accept comma-separated and repeated query values.
+    #[serde(default, deserialize_with = "deserialize_optional_string_list")]
+    pub category: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_optional_string_list")]
+    pub categories: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_optional_networks")]
+    pub network: Option<Vec<Network>>,
+    #[serde(default, deserialize_with = "deserialize_optional_networks")]
+    pub networks: Option<Vec<Network>>,
     pub verified_only: Option<bool>,
     pub tags: Option<String>,
     pub limit: Option<i64>,
@@ -445,4 +448,51 @@ pub struct SearchQueryParams {
     /// Opaque keyset cursor. Present (even empty) switches this endpoint to
     /// stable cursor pagination; pass back the `next_cursor` from the response.
     pub cursor: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn combined_filter_aliases_are_preserved() {
+        let params: SearchQueryParams = serde_json::from_value(serde_json::json!({
+            "q": "swap",
+            "network": " testnet,mainnet ",
+            "networks": "futurenet",
+            "category": " DeFi ",
+            "categories": "NFT, lending",
+        }))
+        .expect("filter query should deserialize");
+
+        assert_eq!(
+            params.network,
+            Some(vec![Network::Testnet, Network::Mainnet])
+        );
+        assert_eq!(params.networks, Some(vec![Network::Futurenet]));
+        assert_eq!(params.category, Some(vec!["DeFi".to_string()]));
+        assert_eq!(
+            params.categories,
+            Some(vec!["NFT".to_string(), "lending".to_string()])
+        );
+
+        let categories = merge_filter_values(params.categories, params.category).unwrap();
+        let networks = merge_filter_values(params.networks, params.network).unwrap();
+        assert_eq!(categories, vec!["NFT", "lending", "DeFi"]);
+        assert_eq!(
+            networks,
+            vec![Network::Futurenet, Network::Testnet, Network::Mainnet]
+        );
+    }
+
+    #[test]
+    fn invalid_network_filter_is_rejected_during_deserialization() {
+        let result = serde_json::from_value::<SearchQueryParams>(serde_json::json!({
+            "q": "swap",
+            "networks": "testnet,not-a-network",
+        }));
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid network"));
+    }
 }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1046,8 +1046,8 @@ pub async fn contract_list(
     format: &str,
 ) -> Result<()> {
     let mut query: Vec<(&str, String)> = vec![
-        ("page_size", limit.to_string()),
-        ("page", ((offset / limit) + 1).to_string()),
+        ("limit", limit.to_string()),
+        ("offset", offset.to_string()),
     ];
 
     // Normalize before sending so comma-separated `--networks`/`--category` and


### PR DESCRIPTION
## Summary  [ Fixes #988 ]

- Normalized comma-separated network and category filters across search and list endpoints.
- Ensured singular and plural filter parameters are merged consistently.
- Added clear validation for invalid network filter values.
- Fixed CLI list pagination to preserve arbitrary offsets.
- Added regression tests for combined filters, invalid networks, and pagination stability.

## Testing

- `git diff --check` passed.