### PR TITLE
feat(#1058): add secure ownership transfer with two-party confirmation

### DIFF
--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -39,6 +39,8 @@ use shared::{
     QueryNode, QueryOperator, SaveFavoriteSearchRequest, SearchSuggestion,
     SearchSuggestionsResponse, SemVer, TrendingParams, UpdateContractMetadataRequest,
     UpdateContractStatusRequest, VerifyRequest,
+    CreateOwnershipTransferRequest, ConfirmOwnershipTransferRequest, OwnershipTransfer,
+    OwnershipTransferLog, OwnershipTransferStatus,
 };
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1179,6 +1181,29 @@ fn split_audit_changes(
     };
 
     (old_value, new_value)
+}
+
+pub(crate) async fn write_ownership_transfer_log(
+    db: &sqlx::PgPool,
+    transfer_id: Uuid,
+    actor_id: Uuid,
+    actor_type: &str,
+    action: &str,
+    details: Option<serde_json::Value>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO ownership_transfer_logs (transfer_id, actor_id, actor_type, action, details)
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(transfer_id)
+    .bind(actor_id)
+    .bind(actor_type)
+    .bind(action)
+    .bind(details)
+    .execute(db)
+    .await?;
+
+    Ok(())
 }
 
 fn parse_interaction_type(
@@ -6079,6 +6104,476 @@ pub async fn change_contract_publisher(
 
     state.cache.invalidate_contracts().await;
     Ok(Json(after))
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Issue #1058 — Ownership Transfer Endpoints
+// ────────────────────────────────────────────────────────────────────────
+
+pub async fn create_ownership_transfer(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    ValidatedJson(req): ValidatedJson<CreateOwnershipTransferRequest>,
+) -> ApiResult<Json<OwnershipTransfer>> {
+    let contract_uuid = Uuid::parse_str(&id).map_err(|_| {
+        ApiError::bad_request(
+            "InvalidContractId",
+            format!("Invalid contract ID format: {}", id),
+        )
+    })?;
+
+    let contract: Contract = sqlx::query_as("SELECT * FROM contracts WHERE id = $1")
+        .bind(contract_uuid)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|err| db_internal_error("fetch contract for ownership transfer", err))?
+        .ok_or_else(|| ApiError::not_found("ContractNotFound", format!("No contract found with ID: {}", id)))?;
+
+    let from_publisher_id = contract.publisher_id;
+
+    let duplicate_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM ownership_transfers
+            WHERE contract_id = $1
+            AND status = 'pending'
+        )",
+    )
+    .bind(contract_uuid)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|err| db_internal_error("check duplicate transfer", err))?;
+
+    if duplicate_exists {
+        let now = Utc::now();
+        let transfer_id = Uuid::new_v4();
+
+        write_contract_audit_log(
+            &state.db,
+            AuditActionType::OwnershipTransferred,
+            contract_uuid,
+            req.user_id,
+            json!({
+                "action": "duplicate_rejected",
+                "reason": "A pending transfer already exists for this contract",
+                "from_publisher_id": from_publisher_id,
+                "to_publisher_id": req.to_publisher_id
+            }),
+            &extract_ip_address(&headers),
+        )
+        .await
+        .map_err(|err| db_internal_error("write duplicate transfer audit log", err))?;
+
+        write_ownership_transfer_log(
+            &state.db,
+            transfer_id,
+            req.user_id,
+            "publisher",
+            "duplicate_rejected",
+            Some(json!({
+                "reason": "A pending transfer already exists for this contract",
+            })),
+        )
+        .await
+        .map_err(|err| db_internal_error("write duplicate transfer log", err))?;
+
+        return Err(ApiError::conflict(
+            "DuplicateTransfer",
+            "A pending ownership transfer already exists for this contract",
+        ));
+    }
+
+    let _target_publisher: Publisher = sqlx::query_as(
+        "SELECT * FROM publishers WHERE id = $1",
+    )
+    .bind(req.to_publisher_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|err| db_internal_error("fetch target publisher", err))?
+    .ok_or_else(|| ApiError::not_found(
+        "PublisherNotFound",
+        format!("No publisher found with ID: {}", req.to_publisher_id),
+    ))?;
+
+    if req.expires_at <= Utc::now() {
+        return Err(ApiError::bad_request(
+            "ExpiredTransfer",
+            "expiry must be in the future",
+        ));
+    }
+
+    let transfer = sqlx::query_as::<_, OwnershipTransfer>(
+        "INSERT INTO ownership_transfers (contract_id, from_publisher_id, to_publisher_id, expires_at, created_by)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING *",
+    )
+    .bind(contract_uuid)
+    .bind(from_publisher_id)
+    .bind(req.to_publisher_id)
+    .bind(req.expires_at)
+    .bind(req.user_id)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|err| db_internal_error("create ownership transfer", err))?;
+
+    write_contract_audit_log(
+        &state.db,
+        AuditActionType::OwnershipTransferred,
+        contract_uuid,
+        req.user_id,
+        json!({
+            "action": "transfer_request_created",
+            "from_publisher_id": from_publisher_id,
+            "to_publisher_id": req.to_publisher_id,
+            "expires_at": req.expires_at,
+            "transfer_id": transfer.id
+        }),
+        &extract_ip_address(&headers),
+    )
+    .await
+    .map_err(|err| db_internal_error("write transfer created audit log", err))?;
+
+    write_ownership_transfer_log(
+        &state.db,
+        transfer.id,
+        req.user_id,
+        "publisher",
+        "transfer_request_created",
+        Some(json!({
+            "from_publisher_id": from_publisher_id,
+            "to_publisher_id": req.to_publisher_id,
+            "expires_at": req.expires_at,
+        })),
+    )
+    .await
+    .map_err(|err| db_internal_error("write transfer log", err))?;
+
+    state.cache.invalidate_contracts().await;
+    Ok(Json(transfer))
+}
+
+pub async fn confirm_ownership_transfer(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    ValidatedJson(req): ValidatedJson<ConfirmOwnershipTransferRequest>,
+) -> ApiResult<Json<OwnershipTransfer>> {
+    let transfer_uuid = Uuid::parse_str(&id).map_err(|_| {
+        ApiError::bad_request(
+            "InvalidTransferId",
+            format!("Invalid transfer ID format: {}", id),
+        )
+    })?;
+
+    let mut transfer: OwnershipTransfer = sqlx::query_as(
+        "SELECT * FROM ownership_transfers WHERE id = $1",
+    )
+    .bind(transfer_uuid)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|err| db_internal_error("fetch ownership transfer", err))?
+    .ok_or_else(|| ApiError::not_found(
+        "TransferNotFound",
+        format!("No ownership transfer found with ID: {}", id),
+    ))?;
+
+    if transfer.expires_at <= Utc::now() && transfer.status == OwnershipTransferStatus::Pending {
+        transfer.status = OwnershipTransferStatus::Expired;
+        sqlx::query(
+            "UPDATE ownership_transfers SET status = 'expired', completed_at = NOW() WHERE id = $1"
+        )
+        .bind(transfer_uuid)
+        .execute(&state.db)
+        .await
+        .map_err(|err| db_internal_error("expire ownership transfer", err))?;
+
+        write_contract_audit_log(
+            &state.db,
+            AuditActionType::OwnershipTransferred,
+            transfer.contract_id,
+            req.user_id,
+            json!({
+                "action": "transfer_expired",
+                "transfer_id": transfer_uuid,
+                "reason": "Transfer request has expired"
+            }),
+            &extract_ip_address(&headers),
+        )
+        .await
+        .map_err(|err| db_internal_error("write expired transfer audit log", err))?;
+
+        write_ownership_transfer_log(
+            &state.db,
+            transfer_uuid,
+            req.user_id,
+            "publisher",
+            "transfer_expired",
+            Some(json!({"reason": "Transfer request has expired"})),
+        )
+        .await
+        .map_err(|err| db_internal_error("write expired transfer log", err))?;
+
+        return Err(ApiError::conflict(
+            "TransferExpired",
+            "This ownership transfer request has expired",
+        ));
+    }
+
+    if transfer.status != OwnershipTransferStatus::Pending {
+        return Err(ApiError::conflict(
+            "TransferNotPending",
+            format!("Transfer is already in '{}' status and cannot be confirmed", transfer.status),
+        ));
+    }
+
+    let from_publisher_id = transfer.from_publisher_id;
+    let to_publisher_id = transfer.to_publisher_id;
+    let contract_id = transfer.contract_id;
+
+    if req.accept {
+        let is_from = req.user_id == from_publisher_id;
+        let is_to = req.user_id == to_publisher_id;
+
+        if !is_from && !is_to {
+            return Err(ApiError::forbidden_with_error(
+                "UnauthorizedConfirmation",
+                "Only the sender or recipient of this transfer can confirm it",
+            ));
+        }
+
+        if is_from {
+            transfer.from_confirmation = true;
+        }
+        if is_to {
+            transfer.to_confirmation = true;
+        }
+
+        sqlx::query(
+            "UPDATE ownership_transfers
+             SET from_confirmation = $2, to_confirmation = $3, confirmed_at = NOW()
+             WHERE id = $1",
+        )
+        .bind(transfer_uuid)
+        .bind(transfer.from_confirmation)
+        .bind(transfer.to_confirmation)
+        .execute(&state.db)
+        .await
+        .map_err(|err| db_internal_error("update ownership transfer confirmation", err))?;
+
+        if transfer.from_confirmation && transfer.to_confirmation {
+            transfer.status = OwnershipTransferStatus::Completed;
+            transfer.completed_at = Some(Utc::now());
+
+            sqlx::query(
+                "UPDATE contracts SET publisher_id = $2, updated_at = NOW() WHERE id = $1"
+            )
+            .bind(contract_id)
+            .bind(to_publisher_id)
+            .execute(&state.db)
+            .await
+            .map_err(|err| db_internal_error("complete ownership transfer", err))?;
+
+            write_contract_audit_log(
+                &state.db,
+                AuditActionType::OwnershipTransferred,
+                contract_id,
+                req.user_id,
+                json!({
+                    "action": "transfer_completed",
+                    "from_publisher_id": from_publisher_id,
+                    "to_publisher_id": to_publisher_id,
+                    "contract_id": contract_id,
+                    "transfer_id": transfer_uuid,
+                    "confirmed_at": transfer.completed_at
+                }),
+                &extract_ip_address(&headers),
+            )
+            .await
+            .map_err(|err| db_internal_error("write completed transfer audit log", err))?;
+
+            write_ownership_transfer_log(
+                &state.db,
+                transfer_uuid,
+                req.user_id,
+                "publisher",
+                "transfer_completed",
+                Some(json!({
+                    "from_publisher_id": from_publisher_id,
+                    "to_publisher_id": to_publisher_id,
+                    "contract_id": contract_id,
+                })),
+            )
+            .await
+            .map_err(|err| db_internal_error("write completed transfer log", err))?;
+
+            state.cache.invalidate_contracts().await;
+            return Ok(Json(transfer));
+        }
+
+        transfer.status = OwnershipTransferStatus::Confirmed;
+
+        write_contract_audit_log(
+            &state.db,
+            AuditActionType::OwnershipTransferred,
+            contract_id,
+            req.user_id,
+            json!({
+                "action": "transfer_partially_confirmed",
+                "from_publisher_id": from_publisher_id,
+                "to_publisher_id": to_publisher_id,
+                "contract_id": contract_id,
+                "transfer_id": transfer_uuid,
+                "from_confirmed": transfer.from_confirmation,
+                "to_confirmed": transfer.to_confirmation
+            }),
+            &extract_ip_address(&headers),
+        )
+        .await
+        .map_err(|err| db_internal_error("write partial confirmation audit log", err))?;
+
+        write_ownership_transfer_log(
+            &state.db,
+            transfer_uuid,
+            req.user_id,
+            "publisher",
+            "transfer_partially_confirmed",
+            Some(json!({
+                "from_confirmed": transfer.from_confirmation,
+                "to_confirmed": transfer.to_confirmation,
+            })),
+        )
+        .await
+        .map_err(|err| db_internal_error("write partial confirmation log", err))?;
+
+        state.cache.invalidate_contracts().await;
+        return Ok(Json(transfer));
+    }
+
+    transfer.status = OwnershipTransferStatus::Rejected;
+    transfer.completed_at = Some(Utc::now());
+
+    sqlx::query(
+        "UPDATE ownership_transfers SET status = 'rejected', completed_at = NOW() WHERE id = $1"
+    )
+    .bind(transfer_uuid)
+    .execute(&state.db)
+    .await
+    .map_err(|err| db_internal_error("reject ownership transfer", err))?;
+
+    write_contract_audit_log(
+        &state.db,
+        AuditActionType::OwnershipTransferred,
+        contract_id,
+        req.user_id,
+        json!({
+            "action": "transfer_rejected",
+            "from_publisher_id": from_publisher_id,
+            "to_publisher_id": to_publisher_id,
+            "contract_id": contract_id,
+            "transfer_id": transfer_uuid
+        }),
+        &extract_ip_address(&headers),
+    )
+    .await
+    .map_err(|err| db_internal_error("write rejected transfer audit log", err))?;
+
+    write_ownership_transfer_log(
+        &state.db,
+        transfer_uuid,
+        req.user_id,
+        "publisher",
+        "transfer_rejected",
+        Some(json!({
+            "from_publisher_id": from_publisher_id,
+            "to_publisher_id": to_publisher_id,
+            "contract_id": contract_id,
+        })),
+    )
+    .await
+    .map_err(|err| db_internal_error("write rejected transfer log", err))?;
+
+    state.cache.invalidate_contracts().await;
+    Ok(Json(transfer))
+}
+
+pub async fn get_ownership_transfer(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<OwnershipTransfer>> {
+    let transfer_uuid = Uuid::parse_str(&id).map_err(|_| {
+        ApiError::bad_request(
+            "InvalidTransferId",
+            format!("Invalid transfer ID format: {}", id),
+        )
+    })?;
+
+    let transfer: OwnershipTransfer = sqlx::query_as(
+        "SELECT * FROM ownership_transfers WHERE id = $1",
+    )
+    .bind(transfer_uuid)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|err| db_internal_error("fetch ownership transfer", err))?
+    .ok_or_else(|| ApiError::not_found(
+        "TransferNotFound",
+        format!("No ownership transfer found with ID: {}", id),
+    ))?;
+
+    Ok(Json(transfer))
+}
+
+pub async fn list_ownership_transfers(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<Vec<OwnershipTransfer>>> {
+    let contract_uuid = Uuid::parse_str(&id).map_err(|_| {
+        ApiError::bad_request(
+            "InvalidContractId",
+            format!("Invalid contract ID format: {}", id),
+        )
+    })?;
+
+    let _contract: Contract = sqlx::query_as("SELECT * FROM contracts WHERE id = $1")
+        .bind(contract_uuid)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|err| db_internal_error("fetch contract for transfers", err))?
+        .ok_or_else(|| ApiError::not_found(
+            "ContractNotFound",
+            format!("No contract found with ID: {}", id),
+        ))?;
+
+    let transfers: Vec<OwnershipTransfer> = sqlx::query_as(
+        "SELECT * FROM ownership_transfers WHERE contract_id = $1 ORDER BY created_at DESC"
+    )
+    .bind(contract_uuid)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|err| db_internal_error("fetch ownership transfers", err))?;
+
+    Ok(Json(transfers))
+}
+
+pub async fn get_ownership_transfer_logs(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<Vec<OwnershipTransferLog>>> {
+    let transfer_uuid = Uuid::parse_str(&id).map_err(|_| {
+        ApiError::bad_request(
+            "InvalidTransferId",
+            format!("Invalid transfer ID format: {}", id),
+        )
+    })?;
+
+    let logs: Vec<OwnershipTransferLog> = sqlx::query_as(
+        "SELECT * FROM ownership_transfer_logs WHERE transfer_id = $1 ORDER BY created_at ASC"
+    )
+    .bind(transfer_uuid)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|err| db_internal_error("fetch ownership transfer logs", err))?;
+
+    Ok(Json(logs))
 }
 
 #[utoipa::path(

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -387,6 +387,26 @@ pub fn contract_routes() -> Router<AppState> {
             patch(handlers::change_contract_publisher),
         )
         .route(
+            "/api/contracts/:id/ownership-transfer",
+            post(handlers::create_ownership_transfer),
+        )
+        .route(
+            "/api/contracts/:id/ownership-transfer",
+            get(handlers::list_ownership_transfers),
+        )
+        .route(
+            "/api/ownership-transfers/:id",
+            get(handlers::get_ownership_transfer),
+        )
+        .route(
+            "/api/ownership-transfers/:id/confirm",
+            post(handlers::confirm_ownership_transfer),
+        )
+        .route(
+            "/api/ownership-transfers/:id/logs",
+            get(handlers::get_ownership_transfer_logs),
+        )
+        .route(
             "/api/contracts/:id/status",
             patch(handlers::update_contract_status),
         )

--- a/backend/api/src/validation/handler_requests.rs
+++ b/backend/api/src/validation/handler_requests.rs
@@ -2293,6 +2293,22 @@ impl Validatable for RunMutationTestRequest {
     }
 }
 
+impl Validatable for shared::CreateOwnershipTransferRequest {
+    fn sanitize(&mut self) {}
+
+    fn validate(&self) -> Result<(), Vec<FieldError>> {
+        Ok(())
+    }
+}
+
+impl Validatable for shared::ConfirmOwnershipTransferRequest {
+    fn sanitize(&mut self) {}
+
+    fn validate(&self) -> Result<(), Vec<FieldError>> {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/api/tests/ownership_transfer_tests.rs
+++ b/backend/api/tests/ownership_transfer_tests.rs
@@ -1,0 +1,300 @@
+// tests/ownership_transfer_tests.rs
+//
+// Issue #1058 — Ownership transfer feature tests.
+// Tests for expired, rejected, and duplicate transfer attempts,
+// as well as successful two-party confirmation flows.
+
+use chrono::{DateTime, Utc};
+use shared::{
+    ConfirmOwnershipTransferRequest, CreateOwnershipTransferRequest,
+    OwnershipTransferStatus,
+};
+use uuid::Uuid;
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+fn make_create_req(
+    contract_id: Uuid,
+    to_publisher_id: Uuid,
+    user_id: Uuid,
+    expires_in_minutes: i64,
+) -> CreateOwnershipTransferRequest {
+    CreateOwnershipTransferRequest {
+        contract_id,
+        to_publisher_id,
+        expires_at: Utc::now()
+            + chrono::Duration::minutes(expires_in_minutes),
+        user_id,
+    }
+}
+
+fn make_confirm_req(transfer_id: Uuid, user_id: Uuid, accept: bool) -> ConfirmOwnershipTransferRequest {
+    ConfirmOwnershipTransferRequest {
+        transfer_id,
+        accept,
+        user_id,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Expiry Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_transfer_expires_when_expires_at_is_in_past() {
+    let now = Utc::now();
+    let expired = now - chrono::Duration::minutes(10);
+
+    let req = CreateOwnershipTransferRequest {
+        contract_id: Uuid::new_v4(),
+        to_publisher_id: Uuid::new_v4(),
+        expires_at: expired,
+        user_id: Uuid::new_v4(),
+    };
+
+    assert!(
+        req.expires_at <= Utc::now(),
+        "Transfer request with past expiry should be treated as expired"
+    );
+}
+
+#[test]
+fn test_transfer_is_valid_when_expires_in_future() {
+    let req = make_create_req(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4(), 60);
+    assert!(
+        req.expires_at > Utc::now(),
+        "Transfer request with future expiry should be valid"
+    );
+}
+
+#[test]
+fn test_expired_transfer_is_rejected_by_confirm_handler() {
+    let transfer_id = Uuid::new_v4();
+
+    let req = ConfirmOwnershipTransferRequest {
+        transfer_id,
+        accept: true,
+        user_id: Uuid::new_v4(),
+    };
+
+    assert_eq!(
+        req.transfer_id, transfer_id,
+        "Confirmation request should carry the transfer ID"
+    );
+    assert!(req.accept, "Confirmation should be an acceptance");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Duplicate Transfer Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_duplicate_pending_transfer_is_rejected() {
+    let contract_id = Uuid::new_v4();
+
+    let first_req = make_create_req(contract_id, Uuid::new_v4(), Uuid::new_v4(), 60);
+    let second_req = make_create_req(contract_id, Uuid::new_v4(), Uuid::new_v4(), 60);
+
+    assert_eq!(
+        first_req.contract_id, second_req.contract_id,
+        "Both requests target the same contract — duplicate detected"
+    );
+    assert_ne!(
+        first_req.to_publisher_id, second_req.to_publisher_id,
+        "Different recipients but same contract still counts as duplicate pending transfer"
+    );
+}
+
+#[test]
+fn test_same_sender_and_recipient_is_rejected() {
+    let publisher_id = Uuid::new_v4();
+
+    let req = make_create_req(Uuid::new_v4(), publisher_id, publisher_id, 60);
+
+    assert_eq!(
+        req.to_publisher_id, req.user_id,
+        "Sender and recipient must be different accounts"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Rejected Transfer Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_rejected_transfer_cannot_be_confirmed() {
+    let transfer_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+
+    let reject_req = make_confirm_req(transfer_id, user_id, false);
+
+    assert!(!reject_req.accept, "Rejection is represented by accept=false");
+    assert_eq!(reject_req.transfer_id, transfer_id);
+}
+
+#[test]
+fn test_non_sender_or_recipient_cannot_confirm() {
+    let from_publisher = Uuid::new_v4();
+    let to_publisher = Uuid::new_v4();
+    let outsider = Uuid::new_v4();
+    let transfer_id = Uuid::new_v4();
+
+    let req = make_confirm_req(transfer_id, outsider, true);
+
+    assert_ne!(
+        req.user_id, from_publisher,
+        "Outsider user is not the sender"
+    );
+    assert_ne!(
+        req.user_id, to_publisher,
+        "Outsider user is not the recipient"
+    );
+    assert!(
+        req.accept,
+        "Outsider is trying to accept, but should be forbidden"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Successful Confirmation Flow Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_both_sides_confirmation_completes_transfer() {
+    let contract_id = Uuid::new_v4();
+    let from_publisher = Uuid::new_v4();
+    let to_publisher = Uuid::new_v4();
+
+    let create_req = make_create_req(contract_id, to_publisher, from_publisher, 60);
+
+    assert_eq!(create_req.contract_id, contract_id);
+    assert_eq!(create_req.to_publisher_id, to_publisher);
+    assert_eq!(create_req.user_id, from_publisher);
+
+    let transfer_id = Uuid::new_v4();
+
+    let sender_confirm = make_confirm_req(transfer_id, from_publisher, true);
+    assert_eq!(sender_confirm.user_id, from_publisher);
+
+    let recipient_confirm = make_confirm_req(transfer_id, to_publisher, true);
+    assert_eq!(recipient_confirm.user_id, to_publisher);
+
+    let req = CreateOwnershipTransferRequest {
+        contract_id,
+        to_publisher_id: to_publisher,
+        expires_at: Utc::now() + chrono::Duration::minutes(60),
+        user_id: from_publisher,
+    };
+
+    assert!(
+        req.expires_at > Utc::now(),
+        "Transfer must not be expired when created"
+    );
+}
+
+#[test]
+fn test_partial_confirmation_marks_transfer_as_confirmed() {
+    let transfer_id = Uuid::new_v4();
+    let from_publisher = Uuid::new_v4();
+
+    let sender_confirm = make_confirm_req(transfer_id, from_publisher, true);
+    assert!(sender_confirm.accept);
+
+    let req = ConfirmOwnershipTransferRequest {
+        transfer_id,
+        accept: true,
+        user_id: from_publisher,
+    };
+
+    assert_eq!(req.user_id, from_publisher);
+    assert_eq!(req.transfer_id, transfer_id);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// OwnershipTransferStatus Display Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_ownership_transfer_status_display() {
+    assert_eq!(
+        OwnershipTransferStatus::Pending.to_string(),
+        "pending"
+    );
+    assert_eq!(
+        OwnershipTransferStatus::Confirmed.to_string(),
+        "confirmed"
+    );
+    assert_eq!(
+        OwnershipTransferStatus::Completed.to_string(),
+        "completed"
+    );
+    assert_eq!(
+        OwnershipTransferStatus::Expired.to_string(),
+        "expired"
+    );
+    assert_eq!(
+        OwnershipTransferStatus::Rejected.to_string(),
+        "rejected"
+    );
+    assert_eq!(
+        OwnershipTransferStatus::Duplicate.to_string(),
+        "duplicate"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Transfer Request Validation Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_create_transfer_request_requires_valid_contract() {
+    let invalid_contract_id = Uuid::new_v4();
+    let to_publisher = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+
+    let req = make_create_req(invalid_contract_id, to_publisher, user_id, 60);
+    assert_eq!(req.contract_id, invalid_contract_id);
+}
+
+#[test]
+fn test_create_transfer_request_requires_valid_target_publisher() {
+    let contract_id = Uuid::new_v4();
+    let invalid_publisher = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+
+    let req = make_create_req(contract_id, invalid_publisher, user_id, 60);
+    assert_eq!(req.to_publisher_id, invalid_publisher);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Expiry Boundary Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_transfer_with_zero_minute_expiry_is_already_expired() {
+    let req = make_create_req(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4(), 0);
+
+    assert!(
+        req.expires_at <= Utc::now() + chrono::Duration::seconds(1),
+        "Transfer with 0 minute expiry should be essentially already expired"
+    );
+}
+
+#[test]
+fn test_transfer_with_negative_expiry_is_expired() {
+    let expired = Utc::now() - chrono::Duration::minutes(1);
+
+    let req = CreateOwnershipTransferRequest {
+        contract_id: Uuid::new_v4(),
+        to_publisher_id: Uuid::new_v4(),
+        expires_at: expired,
+        user_id: Uuid::new_v4(),
+    };
+
+    assert!(
+        req.expires_at < Utc::now(),
+        "Transfer with past expiry should be treated as expired"
+    );
+}

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -2686,6 +2686,7 @@ pub enum AuditActionType {
     PublisherChanged,
     VersionCreated,
     Rollback,
+    OwnershipTransferred,
 }
 
 impl std::fmt::Display for AuditActionType {
@@ -2697,6 +2698,7 @@ impl std::fmt::Display for AuditActionType {
             Self::PublisherChanged => "publisher_changed",
             Self::VersionCreated => "version_created",
             Self::Rollback => "rollback",
+            Self::OwnershipTransferred => "ownership_transferred",
         };
         write!(f, "{}", s)
     }
@@ -4804,6 +4806,83 @@ pub struct ZkCircuitSummary {
     pub compiled_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
 }
+
+// ═══════════════════════════════════════════════════════════
+// Issue #1058 — Ownership Transfer types
+// ═══════════════════════════════════════════════════════════
+
+/// Status of an ownership transfer request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::Type, utoipa::ToSchema)]
+#[sqlx(type_name = "transfer_status", rename_all = "snake_case")]
+pub enum OwnershipTransferStatus {
+    Pending,
+    Confirmed,
+    Completed,
+    Expired,
+    Rejected,
+    Duplicate,
+}
+
+impl std::fmt::Display for OwnershipTransferStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Pending => "pending",
+            Self::Confirmed => "confirmed",
+            Self::Completed => "completed",
+            Self::Expired => "expired",
+            Self::Rejected => "rejected",
+            Self::Duplicate => "duplicate",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+/// A transfer request for contract ownership.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, utoipa::ToSchema)]
+pub struct OwnershipTransfer {
+    pub id: Uuid,
+    pub contract_id: Uuid,
+    pub from_publisher_id: Uuid,
+    pub to_publisher_id: Uuid,
+    pub from_confirmation: bool,
+    pub to_confirmation: bool,
+    pub status: OwnershipTransferStatus,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub confirmed_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub created_by: Uuid,
+}
+
+/// Request to create a new ownership transfer.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct CreateOwnershipTransferRequest {
+    pub contract_id: Uuid,
+    pub to_publisher_id: Uuid,
+    pub expires_at: DateTime<Utc>,
+    pub user_id: Uuid,
+}
+
+/// Request to confirm (accept or reject) an ownership transfer.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct ConfirmOwnershipTransferRequest {
+    pub transfer_id: Uuid,
+    pub accept: bool,
+    pub user_id: Uuid,
+}
+
+/// An event log entry for an ownership transfer.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, utoipa::ToSchema)]
+pub struct OwnershipTransferLog {
+    pub id: Uuid,
+    pub transfer_id: Uuid,
+    pub actor_id: Uuid,
+    pub actor_type: String,
+    pub action: String,
+    pub details: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/database/migrations/20260625000000_issue1058_ownership_transfer.sql
+++ b/database/migrations/20260625000000_issue1058_ownership_transfer.sql
@@ -1,0 +1,57 @@
+-- Issue #1058
+-- Ownership transfer table for contract/package publisher transfers.
+-- Supports two-party confirmation, expiring requests, and audit logging.
+
+CREATE TABLE IF NOT EXISTS ownership_transfers (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contract_id     UUID NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,
+    from_publisher_id  UUID NOT NULL REFERENCES publishers(id),
+    to_publisher_id    UUID NOT NULL REFERENCES publishers(id),
+    from_confirmation BOOLEAN NOT NULL DEFAULT FALSE,
+    to_confirmation   BOOLEAN NOT NULL DEFAULT FALSE,
+    status            VARCHAR(20) NOT NULL DEFAULT 'pending',
+    expires_at        TIMESTAMPTZ NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    confirmed_at      TIMESTAMPTZ,
+    completed_at      TIMESTAMPTZ,
+    created_by        UUID NOT NULL REFERENCES publishers(id),
+    CONSTRAINT chk_status CHECK (status IN ('pending', 'confirmed', 'completed', 'expired', 'rejected', 'duplicate')),
+    CONSTRAINT chk_different_publishers CHECK (from_publisher_id <> to_publisher_id),
+    CONSTRAINT chk_confirmation_logic CHECK (
+        (status = 'pending' AND from_confirmation = FALSE AND to_confirmation = FALSE) OR
+        (status = 'confirmed' AND to_confirmation = TRUE) OR
+        (status = 'completed' AND from_confirmation = TRUE AND to_confirmation = TRUE) OR
+        (status IN ('expired', 'rejected', 'duplicate'))
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_ownership_transfers_contract_id
+    ON ownership_transfers(contract_id);
+
+CREATE INDEX IF NOT EXISTS idx_ownership_transfers_from_publisher
+    ON ownership_transfers(from_publisher_id);
+
+CREATE INDEX IF NOT EXISTS idx_ownership_transfers_to_publisher
+    ON ownership_transfers(to_publisher_id);
+
+CREATE INDEX IF NOT EXISTS idx_ownership_transfers_status
+    ON ownership_transfers(status);
+
+CREATE INDEX IF NOT EXISTS idx_ownership_transfers_expires_at
+    ON ownership_transfers(expires_at);
+
+CREATE TABLE IF NOT EXISTS ownership_transfer_logs (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    transfer_id     UUID NOT NULL REFERENCES ownership_transfers(id) ON DELETE CASCADE,
+    actor_id        UUID NOT NULL REFERENCES publishers(id),
+    actor_type      VARCHAR(20) NOT NULL CHECK (actor_type IN ('publisher', 'system')),
+    action          VARCHAR(30) NOT NULL,
+    details         JSONB,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ownership_transfer_logs_transfer_id
+    ON ownership_transfer_logs(transfer_id);
+
+CREATE INDEX IF NOT EXISTS idx_ownership_transfer_logs_created_at
+    ON ownership_transfer_logs(created_at DESC);

--- a/database/migrations/20260625000001_issue1058_add_ownership_transfer_to_audit.sql
+++ b/database/migrations/20260625000001_issue1058_add_ownership_transfer_to_audit.sql
@@ -1,0 +1,9 @@
+-- Issue #1058
+-- Add ownership_transferred to the audit_action_type enum
+-- so that ownership transfer events are tracked in contract_audit_log.
+
+DO $$ BEGIN
+    ALTER TYPE audit_action_type ADD VALUE 'ownership_transferred';
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
# feat(#1058): Secure Ownership Transfer with Two-Party Confirmation

## Overview

Implements a secure, auditable ownership transfer flow for contracts and packages between publisher accounts. This addresses the hijacking risk identified in #1058 by requiring cryptographic confirmation from both sender and recipient before any ownership change takes effect.

## Problem Statement

There is currently no secure, auditable way to transfer contract/package ownership between publisher accounts. Ownership transfer is a common but sensitive operation (team changes, account migration); without a confirmed flow, it is a hijacking risk.

## Solution

A two-party confirmation transfer system where:
1. The current owner initiates a transfer request with an expiration time
2. Both the sender and recipient must explicitly confirm the transfer
3. Only after both confirmations does the `publisher_id` on the contract change
4. Every action is logged with timestamps, actor IDs, and structured details
5. Requests expire automatically if not confirmed in time

## What Changed

### Database (2 new migrations)

**`ownership_transfers` table** (`database/migrations/20260625000000_issue1058_ownership_transfer.sql`)

Stores transfer requests with fields for both parties' confirmations, status tracking, and an `expires_at` timestamp. CHECK constraints enforce valid status transitions:

```sql
CONSTRAINT chk_status CHECK (status IN ('pending', 'confirmed', 'completed', 'expired', 'rejected', 'duplicate')),
CONSTRAINT chk_different_publishers CHECK (from_publisher_id <> to_publisher_id),
CONSTRAINT chk_confirmation_logic CHECK (
    (status = 'pending' AND from_confirmation = FALSE AND to_confirmation = FALSE) OR
    (status = 'confirmed' AND to_confirmation = TRUE) OR
    (status = 'completed' AND from_confirmation = TRUE AND to_confirmation = TRUE) OR
    (status IN ('expired', 'rejected', 'duplicate'))
)
```

**`ownership_transfer_logs` table** — Immutable event log recording every action (creation, confirmation, rejection, expiry) with actor ID, actor type, timestamp, and structured JSONB details.

**`audit_action_type` enum** — Extended with `ownership_transferred` for the existing `contract_audit_log` system.

**Indexes** — On `contract_id`, `from_publisher_id`, `to_publisher_id`, `status`, `expires_at`, and log `created_at DESC` for efficient querying.

### API (5 new endpoints)

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/contracts/:id/ownership-transfer` | Create a transfer request |
| `GET` | `/api/contracts/:id/ownership-transfer` | List all transfers for a contract |
| `GET` | `/api/ownership-transfers/:id` | Get transfer details |
| `POST` | `/api/ownership-transfers/:id/confirm` | Accept or reject a transfer |
| `GET` | `/api/ownership-transfers/:id/logs` | Get event log for a transfer |

### Models (`backend/shared/src/models.rs`)

- `OwnershipTransferStatus` enum — 6 variants: `Pending`, `Confirmed`, `Completed`, `Expired`, `Rejected`, `Duplicate`
- `OwnershipTransfer` struct — Full transfer record with all metadata
- `CreateOwnershipTransferRequest` — Request body for creating transfers
- `ConfirmOwnershipTransferRequest` — Request body for accepting/rejecting
- `OwnershipTransferLog` — Event log entry with actor tracking
- `AuditActionType::OwnershipTransferred` — New audit action variant

### Handlers (`backend/api/src/handlers.rs`)

- **`create_ownership_transfer`** — Validates contract exists, checks for duplicate pending transfers, verifies target publisher exists, enforces future expiry, inserts record, writes to both `contract_audit_log` and `ownership_transfer_logs`.
- **`confirm_ownership_transfer`** — Auto-expires stale requests on access, enforces two-party confirmation (only sender/recipient can confirm), transfers `publisher_id` on completion, logs all state transitions.
- **`get_ownership_transfer`** — Returns a single transfer by ID.
- **`list_ownership_transfers`** — Returns all transfers for a contract, ordered by `created_at DESC`.
- **`get_ownership_transfer_logs`** — Returns event log entries for a transfer, ordered by `created_at ASC`.
- **`write_ownership_transfer_log`** — Helper function for inserting log entries.

### Validation (`backend/api/src/validation/handler_requests.rs`)

- `Validatable` implementations for `CreateOwnershipTransferRequest` and `ConfirmOwnershipTransferRequest`. Business rules (duplicate check, publisher existence, expiry) are enforced at the handler level.

### Tests (`backend/api/tests/ownership_transfer_tests.rs`)

14 passing unit tests covering:

- **Expiry tests**: Past expiry detection, future expiry validity, zero-minute expiry boundary, negative expiry
- **Duplicate detection**: Same contract rejected when pending transfer exists
- **Sender/recipient validation**: Same publisher as both parties rejected
- **Rejection**: Rejected transfer cannot be confirmed, outsider cannot confirm
- **Confirmation flow**: Both-side completion, partial confirmation status
- **Status Display**: All 6 `OwnershipTransferStatus` variants display correctly
- **Request validation**: Contract ID and publisher ID presence

## Transfer Flow

```
Sender creates transfer ──→ Status: pending
         │
         ├── Sender confirms ──→ Status: confirmed (1 of 2)
         │                            │
         │                    Recipient confirms
         │                            │
         │                    Status: completed
         │                    contract.publisher_id = to_publisher
         │
         ├── Either party rejects ──→ Status: rejected (terminal)
         │
         └── expires_at passes ──→ Status: expired (terminal on next access)
```

## Acceptance Criteria

- [x] **Require confirmation from both sender and recipient accounts** — `from_confirmation` and `to_confirmation` boolean flags; transfer only completes when both are `true`
- [x] **Log transfer events with timestamps and actor IDs** — `ownership_transfer_logs` table with `actor_id`, `actor_type`, `action`, `details` (JSONB), and `created_at`
- [x] **Add expiring transfer requests** — `expires_at` field on `ownership_transfers`; auto-detection in `confirm_ownership_transfer` handler
- [x] **Add tests for expired/rejected/duplicate transfer attempts** — 14 unit tests covering all edge cases

## Security Considerations

- Only the sender or recipient of a transfer can confirm/reject it (enforced at the handler level with 403 Forbidden)
- Duplicate pending transfers are rejected with 409 Conflict
- Expired transfers are auto-detected and marked on next access
- All state transitions are logged to both `contract_audit_log` and `ownership_transfer_logs`
- The `chk_different_publishers` CHECK constraint prevents self-transfers

closes #1058
