### PR TITLE
fix: resolve 4 backend compilation errors breaking CI

### DIFF
--- a/backend/api/src/dependency_vulnerability_handlers.rs
+++ b/backend/api/src/dependency_vulnerability_handlers.rs
@@ -25,7 +25,6 @@ use crate::{
     error::{ApiError, ApiResult},
     handlers::db_internal_error,
     state::AppState,
-    validation::extractors::ValidatedJson,
 };
 
 const MAX_DECLARED_DEPENDENCIES: usize = 200;
@@ -78,7 +77,7 @@ pub async fn declare_package_dependencies(
     State(state): State<AppState>,
     claims: AuthClaims,
     Path(id): Path<Uuid>,
-    ValidatedJson(body): ValidatedJson<DeclarePackageDependenciesRequest>,
+    Json(body): Json<DeclarePackageDependenciesRequest>,
 ) -> ApiResult<(StatusCode, Json<DependencyScanReport>)> {
     require_contract_owner(&state, id, &claims).await?;
 

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -216,7 +216,7 @@ pub struct NetworkHealthResponse {
 }
 
 /// Network where the contract is deployed
-#[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type, utoipa::ToSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, sqlx::Type, utoipa::ToSchema, PartialEq, Eq)]
 #[sqlx(type_name = "network_type", rename_all = "lowercase")]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
@@ -246,7 +246,7 @@ fn parse_network_value<E: de::Error>(value: &str) -> Result<Network, E> {
     }
 }
 
-fn deserialize_optional_networks<'de, D>(deserializer: D) -> Result<Option<Vec<Network>>, D::Error>
+pub fn deserialize_optional_networks<'de, D>(deserializer: D) -> Result<Option<Vec<Network>>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {


### PR DESCRIPTION
## Summary

Fixes 4 Rust compilation errors (`E0603`, `E0277`, `E0599`) in the `api` crate that cause the **Deploy Backend / Build** CI job to fail on every push to `main`.

## Type of Change

- [ ] Feature — new functionality
- [x] Bug fix — fixes an issue without changing existing behavior
- [ ] Documentation — updates or adds documentation only
- [ ] Refactor — code restructuring with no behavior change
- [ ] Test — adds or updates tests only
- [ ] Chore — build, CI, or tooling changes

## Changes Made

- **`backend/shared/src/models.rs`**: Made `deserialize_optional_networks` public (`fn` -> `pub fn`) — it was private but imported cross-crate by `search_postgres.rs` (E0603)
- **`backend/shared/src/models.rs`**: Added `Copy` to the derive list for `enum Network` — required by `.copied()` iterator call in `handlers.rs` (E0277/E0599). Safe because `Network` is a simple fieldless enum
- **`backend/api/src/dependency_vulnerability_handlers.rs`**: Replaced `ValidatedJson` extractor with standard `Json` in `declare_package_dependencies` handler — resolves a dual axum version conflict (axum 0.7 direct dep vs axum 0.8 pulled by `async-graphql-axum`) that made the handler fail the `Handler` trait bound (E0277). The handler already performs its own manual validation

## How Has This Been Tested?

### Test Commands

```bash
cargo check --manifest-path backend/Cargo.toml
