### PR TITLE
fix: resolve syntax error in handlers.rs query_as call

### DIFF
--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -4694,8 +4694,7 @@ async fn publish_contract_inner(
     let insert_result = sqlx::query_as::<_, Contract>(
         "INSERT INTO contracts (contract_id, wasm_hash, name, slug, description, publisher_id, network, category, tags, logical_id, network_configs, visibility, artifact_scan_status, artifact_scan_findings)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, CASE WHEN $12 = 'passed' THEN 'public'::visibility_type ELSE 'private'::visibility_type END, $12, $13)
-         RETURNING *")
-    
+         RETURNING *",
     )
     .bind(&req.contract_id)
     .bind(&wasm_hash)


### PR DESCRIPTION
## Summary

Fixes a Rust syntax error (`unexpected closing delimiter: '}'`) in `backend/api/src/handlers.rs` caused by a malformed `sqlx::query_as` string termination and an extra closing parenthesis.

## Related Issue

Closes #

## Type of Change

- [ ] Feature — new functionality
- [x] Bug fix — fixes an issue without changing existing behavior
- [ ] Documentation — updates or adds documentation only
- [ ] Refactor — code restructuring with no behavior change
- [ ] Test — adds or updates tests only
- [ ] Chore — build, CI, or tooling changes

## Changes Made

- **`backend/api/src/handlers.rs`**: Fixed line 4697 where `"RETURNING *")` had an embedded closing parenthesis inside the string boundary and an extra `)` on line 4699 inside the contract insertion `sqlx::query_as` call.

## How Has This Been Tested?

### Test Commands

```bash
cargo check --manifest-path backend/Cargo.toml
