### PR TITLE
Feat/issue 1094 signed ownership transfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ storybook-static
 CLAUDE.md
 plan.md
 tasks/
+ASSUMPTIONS.md

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -79,12 +79,14 @@ pub struct ContractStatsResponse {
 
 use crate::{
     analytics,
+    auth::AuthClaims,
     breaking_changes::{diff_abi, has_breaking_changes, resolve_abi},
     cache::IdempotencyClaim,
     contract_events::ContractEventEnvelope,
     dependency,
     error::{ApiError, ApiResult},
     onchain_verification::OnChainVerifier,
+    ownership_transfer as transfer,
     state::{AppState, ContractEventVisibility},
 };
 
@@ -1155,14 +1157,22 @@ fn contract_to_filtered_value(contract: &Contract, fields: Option<&HashSet<Strin
     Value::Object(out)
 }
 
-pub(crate) async fn write_contract_audit_log(
-    db: &sqlx::PgPool,
+/// Append a row to `contract_audit_log`.
+///
+/// Generic over the executor so a caller inside a transaction can pass `&mut *tx` and have
+/// the audit row committed or rolled back with the change it describes. Passing `&PgPool`
+/// still works and remains the right choice for autocommit call sites.
+pub(crate) async fn write_contract_audit_log<'e, E>(
+    db: E,
     action_type: AuditActionType,
     contract_id: Uuid,
     user_id: Uuid,
     changes: serde_json::Value,
     ip_address: &str,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
     let (old_value, new_value) = split_audit_changes(&changes, ip_address);
 
     sqlx::query(
@@ -1246,14 +1256,23 @@ fn split_audit_changes(
     (old_value, new_value)
 }
 
-pub(crate) async fn write_ownership_transfer_log(
-    db: &sqlx::PgPool,
+/// Append a row to the append-only `ownership_transfer_logs` history.
+///
+/// Generic over the executor for the same reason as `write_contract_audit_log`: every
+/// ownership-transfer state change writes its history row in the transaction that made the
+/// change, so history and state cannot diverge. `actor_id` is `None` for system actions
+/// such as expiry, which have no acting publisher.
+pub(crate) async fn write_ownership_transfer_log<'e, E>(
+    db: E,
     transfer_id: Uuid,
-    actor_id: Uuid,
+    actor_id: Option<Uuid>,
     actor_type: &str,
     action: &str,
     details: Option<serde_json::Value>,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
     sqlx::query(
         "INSERT INTO ownership_transfer_logs (transfer_id, actor_id, actor_type, action, details)
          VALUES ($1, $2, $3, $4, $5)",
@@ -6356,12 +6375,137 @@ pub async fn change_contract_publisher(
 }
 
 // ────────────────────────────────────────────────────────────────────────
-// Issue #1058 — Ownership Transfer Endpoints
+// Issue #1058 / #1094 — Ownership Transfer Endpoints
+//
+//   POST /api/contracts/:id/ownership-transfer     initiate (signed by current owner)
+//   GET  /api/contracts/:id/ownership-transfer     history for one contract
+//   GET  /api/ownership-transfers/:id              one transfer
+//   POST /api/ownership-transfers/:id/confirm      accept or reject (signed)
+//   GET  /api/ownership-transfers/:id/logs         append-only provenance chain
+//
+// Ownership is a takeover-sensitive operation, so the invariants are stated here rather
+// than left implicit (issue #1094):
+//
+//   I1  `contracts.publisher_id` changes through this feature only inside a transaction
+//       that has already verified two distinct ed25519 signatures, over two
+//       domain-separated payloads, against two distinct `publishers.stellar_address`.
+//   I2  `pending -> completed` happens at most once per transfer, ever.
+//   I3  A transfer whose `expires_at` has passed never reaches `completed`.
+//   I4  At most one live transfer exists per contract
+//       (`uq_ownership_transfers_one_live_per_contract`).
+//   I5  History is append-only: terminal states are reached only by an UPDATE guarded on
+//       the prior state, and every transition writes its `ownership_transfer_logs` row in
+//       the same transaction.
+//   I6  Signatures are single-use: `uq_ownership_transfers_request_nonce`,
+//       `uq_ownership_transfers_decision_nonce`, plus I2.
+//   I7  The verifying key is always the acting identity's own key, resolved from the
+//       bearer token's subject. No address in a request body ever selects a verifying key.
+//
+// Both write handlers lock `contracts` and then `ownership_transfers`, in that order. The
+// order is the only thing preventing a deadlock between a concurrent initiate and confirm,
+// so do not reorder the locks.
+//
+// Reads are deliberately unauthenticated. Provenance in a public registry is public, and
+// the stored payload/signature pairs are exactly what a third party needs to audit a
+// completed takeover without trusting this API.
+//
+// Known bypass, unchanged by #1094: `PATCH /api/contracts/:id/publisher`
+// (`change_contract_publisher`) still moves ownership in a single call behind an
+// `x-multisig-proposal-id` header. The accept path compare-and-swaps on the expected
+// current owner so that endpoint cannot silently invalidate a transfer mid-flight.
 // ────────────────────────────────────────────────────────────────────────
 
+/// A publisher's identity as it matters to a transfer: the row id we authorize against and
+/// the on-chain account we verify signatures against.
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct TransferParty {
+    id: Uuid,
+    stellar_address: String,
+}
+
+async fn resolve_publisher_by_address(
+    conn: &mut sqlx::PgConnection,
+    address: &str,
+) -> Result<Option<TransferParty>, sqlx::Error> {
+    sqlx::query_as::<_, TransferParty>(
+        "SELECT id, stellar_address FROM publishers WHERE stellar_address = $1",
+    )
+    .bind(address)
+    .fetch_optional(conn)
+    .await
+}
+
+async fn resolve_publisher_by_id(
+    conn: &mut sqlx::PgConnection,
+    publisher_id: Uuid,
+) -> Result<Option<TransferParty>, sqlx::Error> {
+    sqlx::query_as::<_, TransferParty>(
+        "SELECT id, stellar_address FROM publishers WHERE id = $1",
+    )
+    .bind(publisher_id)
+    .fetch_optional(conn)
+    .await
+}
+
+/// Resolve the caller's publisher row from the bearer token subject.
+///
+/// `AuthClaims::sub` holds the Stellar address the session authenticated with. Note this
+/// deliberately does not use the `AuthenticatedUser` extractor: its `publisher_id` is
+/// produced by `Uuid::parse_str(&claims.sub).unwrap_or(Uuid::nil())`, and `sub` is a `G...`
+/// address, so that field is always nil.
+async fn resolve_actor(
+    conn: &mut sqlx::PgConnection,
+    claims: &AuthClaims,
+) -> ApiResult<TransferParty> {
+    resolve_publisher_by_address(conn, &claims.sub)
+        .await
+        .map_err(|err| db_internal_error("resolve acting publisher", err))?
+        .ok_or_else(|| {
+            ApiError::forbidden_with_error(
+                "UnknownPublisher",
+                "the authenticated account is not registered as a publisher",
+            )
+        })
+}
+
+/// Translate a unique-violation on the transfer table into the specific 409 it means.
+///
+/// #1058 returned a 500 here: its duplicate branch wrote a history row against a freshly
+/// generated `Uuid::new_v4()` that had no parent transfer, so the foreign key fired before
+/// the intended conflict response was ever reached.
+fn map_transfer_conflict(operation: &str, err: sqlx::Error) -> ApiError {
+    if let sqlx::Error::Database(db_err) = &err {
+        if db_err.is_unique_violation() {
+            return match db_err.constraint() {
+                Some("uq_ownership_transfers_request_nonce")
+                | Some("uq_ownership_transfers_decision_nonce") => ApiError::conflict(
+                    "NonceAlreadyUsed",
+                    "this nonce has already been used; sign a fresh request",
+                ),
+                Some("uq_ownership_transfers_one_live_per_contract") => ApiError::conflict(
+                    "DuplicateTransfer",
+                    "a pending ownership transfer already exists for this contract",
+                ),
+                _ => ApiError::conflict(
+                    "TransferConflict",
+                    "this ownership transfer conflicts with an existing record",
+                ),
+            };
+        }
+    }
+    db_internal_error(operation, err)
+}
+
+/// Phase 1: the current owner opens a transfer by signing it.
+///
+/// The row is created with `from_confirmation = TRUE` because creating it *is* the sender's
+/// signature. `pending` therefore means "one signature verified", and `completed` means
+/// "two". Verification happens before any write, so a bad signature leaves no trace beyond
+/// the request log.
 pub async fn create_ownership_transfer(
     State(state): State<AppState>,
     Path(id): Path<String>,
+    claims: AuthClaims,
     headers: HeaderMap,
     ValidatedJson(req): ValidatedJson<CreateOwnershipTransferRequest>,
 ) -> ApiResult<Json<OwnershipTransfer>> {
@@ -6372,138 +6516,219 @@ pub async fn create_ownership_transfer(
         )
     })?;
 
-    let contract: Contract = sqlx::query_as("SELECT * FROM contracts WHERE id = $1")
-        .bind(contract_uuid)
-        .fetch_optional(&state.db)
+    let algorithm = transfer::resolve_algorithm(req.signature_algorithm.as_deref())?;
+
+    let now = Utc::now();
+    transfer::check_signature_freshness(req.signed_at_unix, now.timestamp())?;
+
+    let expires_at = DateTime::from_timestamp(req.expires_at_unix, 0).ok_or_else(|| {
+        ApiError::bad_request(
+            "InvalidExpiry",
+            "expires_at_unix is not a representable unix timestamp",
+        )
+    })?;
+
+    let ttl = req.expires_at_unix - now.timestamp();
+    let min_ttl = transfer::min_expiry_window_secs();
+    if ttl < min_ttl {
+        return Err(ApiError::bad_request(
+            "InvalidExpiry",
+            format!("expiry must be at least {}s in the future", min_ttl),
+        ));
+    }
+    if ttl > transfer::MAX_EXPIRY_WINDOW_SECS {
+        return Err(ApiError::bad_request(
+            "InvalidExpiry",
+            format!(
+                "expiry must be no more than {}s in the future",
+                transfer::MAX_EXPIRY_WINDOW_SECS
+            ),
+        ));
+    }
+
+    let mut tx = state.db.begin().await.map_err(|err| {
+        db_internal_error("begin ownership transfer creation transaction", err)
+    })?;
+
+    // Lock `contracts` first. Serialising two concurrent initiations on the contract row
+    // means the loser observes the winner's committed transfer instead of racing it, and
+    // keeping this lock ahead of `ownership_transfers` matches the order used by
+    // `confirm_ownership_transfer`.
+    let contract: Contract =
+        sqlx::query_as("SELECT * FROM contracts WHERE id = $1 FOR UPDATE")
+            .bind(contract_uuid)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|err| db_internal_error("lock contract for ownership transfer", err))?
+            .ok_or_else(|| {
+                ApiError::not_found(
+                    "ContractNotFound",
+                    format!("No contract found with ID: {}", id),
+                )
+            })?;
+
+    let actor = resolve_actor(&mut tx, &claims).await?;
+
+    if actor.id != contract.publisher_id {
+        return Err(ApiError::forbidden_with_error(
+            "NotContractOwner",
+            "only the current publisher of this contract can initiate an ownership transfer",
+        ));
+    }
+
+    let recipient = resolve_publisher_by_address(&mut tx, &req.to_publisher_address)
         .await
-        .map_err(|err| db_internal_error("fetch contract for ownership transfer", err))?
-        .ok_or_else(|| ApiError::not_found("ContractNotFound", format!("No contract found with ID: {}", id)))?;
+        .map_err(|err| db_internal_error("resolve transfer recipient", err))?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "PublisherNotFound",
+                format!(
+                    "No publisher is registered for address: {}",
+                    req.to_publisher_address
+                ),
+            )
+        })?;
 
-    let from_publisher_id = contract.publisher_id;
+    if recipient.id == actor.id {
+        return Err(ApiError::bad_request(
+            "SelfTransfer",
+            "a contract cannot be transferred to its current publisher",
+        ));
+    }
 
-    let duplicate_exists: bool = sqlx::query_scalar(
+    // Reported explicitly rather than letting the unique index surface it, so the caller
+    // gets an actionable message. The index below is still the authority under concurrency.
+    let live_exists: bool = sqlx::query_scalar(
         "SELECT EXISTS(
-            SELECT 1 FROM ownership_transfers
-            WHERE contract_id = $1
-            AND status = 'pending'
-        )",
+             SELECT 1 FROM ownership_transfers
+             WHERE contract_id = $1 AND status IN ('pending', 'confirmed')
+         )",
     )
     .bind(contract_uuid)
-    .fetch_one(&state.db)
+    .fetch_one(&mut *tx)
     .await
-    .map_err(|err| db_internal_error("check duplicate transfer", err))?;
+    .map_err(|err| db_internal_error("check for a live ownership transfer", err))?;
 
-    if duplicate_exists {
-        let now = Utc::now();
-        let transfer_id = Uuid::new_v4();
-
-        write_contract_audit_log(
-            &state.db,
-            AuditActionType::OwnershipTransferred,
-            contract_uuid,
-            req.user_id,
-            json!({
-                "action": "duplicate_rejected",
-                "reason": "A pending transfer already exists for this contract",
-                "from_publisher_id": from_publisher_id,
-                "to_publisher_id": req.to_publisher_id
-            }),
-            &extract_ip_address(&headers),
-        )
-        .await
-        .map_err(|err| db_internal_error("write duplicate transfer audit log", err))?;
-
-        write_ownership_transfer_log(
-            &state.db,
-            transfer_id,
-            req.user_id,
-            "publisher",
-            "duplicate_rejected",
-            Some(json!({
-                "reason": "A pending transfer already exists for this contract",
-            })),
-        )
-        .await
-        .map_err(|err| db_internal_error("write duplicate transfer log", err))?;
-
+    if live_exists {
         return Err(ApiError::conflict(
             "DuplicateTransfer",
-            "A pending ownership transfer already exists for this contract",
+            "a pending ownership transfer already exists for this contract",
         ));
     }
 
-    let _target_publisher: Publisher = sqlx::query_as(
-        "SELECT * FROM publishers WHERE id = $1",
-    )
-    .bind(req.to_publisher_id)
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|err| db_internal_error("fetch target publisher", err))?
-    .ok_or_else(|| ApiError::not_found(
-        "PublisherNotFound",
-        format!("No publisher found with ID: {}", req.to_publisher_id),
-    ))?;
+    // Built from values the server resolved, never from the request body, and stored
+    // verbatim so the signature can be re-checked later without reconstructing it.
+    let payload = transfer::initiate_payload(
+        contract_uuid,
+        &actor.stellar_address,
+        &recipient.stellar_address,
+        req.expires_at_unix,
+        &req.nonce,
+        req.signed_at_unix,
+    );
 
-    if req.expires_at <= Utc::now() {
-        return Err(ApiError::bad_request(
-            "ExpiredTransfer",
-            "expiry must be in the future",
-        ));
-    }
+    transfer::verify_transfer_signature(&actor.stellar_address, &payload, &req.signature)?;
 
-    let transfer = sqlx::query_as::<_, OwnershipTransfer>(
-        "INSERT INTO ownership_transfers (contract_id, from_publisher_id, to_publisher_id, expires_at, created_by)
-         VALUES ($1, $2, $3, $4, $5)
+    let signed_at = DateTime::from_timestamp(req.signed_at_unix, 0).ok_or_else(|| {
+        ApiError::bad_request(
+            "InvalidSignedAt",
+            "signed_at_unix is not a representable unix timestamp",
+        )
+    })?;
+
+    let transfer_row = sqlx::query_as::<_, OwnershipTransfer>(
+        "INSERT INTO ownership_transfers (
+             contract_id, from_publisher_id, to_publisher_id,
+             from_confirmation, to_confirmation, status, expires_at, created_by,
+             signature_algorithm, request_nonce, from_signature,
+             from_signer_address, from_signed_at, from_signed_payload
+         )
+         VALUES ($1, $2, $3, TRUE, FALSE, 'pending', $4, $2, $5, $6, $7, $8, $9, $10)
          RETURNING *",
     )
     .bind(contract_uuid)
-    .bind(from_publisher_id)
-    .bind(req.to_publisher_id)
-    .bind(req.expires_at)
-    .bind(req.user_id)
-    .fetch_one(&state.db)
+    .bind(actor.id)
+    .bind(recipient.id)
+    .bind(expires_at)
+    .bind(algorithm)
+    .bind(&req.nonce)
+    .bind(&req.signature)
+    .bind(&actor.stellar_address)
+    .bind(signed_at)
+    .bind(&payload)
+    .fetch_one(&mut *tx)
     .await
-    .map_err(|err| db_internal_error("create ownership transfer", err))?;
+    .map_err(|err| map_transfer_conflict("create ownership transfer", err))?;
+
+    let ip_address = extract_ip_address(&headers);
 
     write_contract_audit_log(
-        &state.db,
+        &mut *tx,
         AuditActionType::OwnershipTransferred,
         contract_uuid,
-        req.user_id,
+        actor.id,
         json!({
             "action": "transfer_request_created",
-            "from_publisher_id": from_publisher_id,
-            "to_publisher_id": req.to_publisher_id,
-            "expires_at": req.expires_at,
-            "transfer_id": transfer.id
+            "transfer_id": transfer_row.id,
+            "from_publisher_id": actor.id,
+            "from_signer_address": actor.stellar_address,
+            "to_publisher_id": recipient.id,
+            "to_publisher_address": recipient.stellar_address,
+            "expires_at": expires_at,
         }),
-        &extract_ip_address(&headers),
+        &ip_address,
     )
     .await
     .map_err(|err| db_internal_error("write transfer created audit log", err))?;
 
     write_ownership_transfer_log(
-        &state.db,
-        transfer.id,
-        req.user_id,
+        &mut *tx,
+        transfer_row.id,
+        Some(actor.id),
         "publisher",
         "transfer_request_created",
         Some(json!({
-            "from_publisher_id": from_publisher_id,
-            "to_publisher_id": req.to_publisher_id,
-            "expires_at": req.expires_at,
+            "from_publisher_id": actor.id,
+            "from_signer_address": actor.stellar_address,
+            "to_publisher_id": recipient.id,
+            "to_publisher_address": recipient.stellar_address,
+            "expires_at": expires_at,
+            "request_nonce": req.nonce,
+            "signature_algorithm": algorithm,
+            "signed_payload": payload,
         })),
     )
     .await
-    .map_err(|err| db_internal_error("write transfer log", err))?;
+    .map_err(|err| db_internal_error("write transfer created log", err))?;
+
+    tx.commit()
+        .await
+        .map_err(|err| db_internal_error("commit ownership transfer creation", err))?;
+
+    tracing::info!(
+        target: "ownership_transfer",
+        transfer_id = %transfer_row.id,
+        contract_id = %contract_uuid,
+        from_publisher_id = %actor.id,
+        to_publisher_id = %recipient.id,
+        expires_at = %expires_at,
+        "ownership transfer initiated and sender signature verified"
+    );
 
     state.cache.invalidate_contracts().await;
-    Ok(Json(transfer))
+    Ok(Json(transfer_row))
 }
 
+/// Phase 2: the recipient accepts (or either party rejects) by signing the decision.
+///
+/// An accepted transfer completes and moves `contracts.publisher_id` in the same
+/// transaction. There is no intermediate `confirmed` state to get stranded in, which is
+/// what #1058's partial-confirm UPDATE tried to express and what made it violate
+/// `chk_confirmation_logic`.
 pub async fn confirm_ownership_transfer(
     State(state): State<AppState>,
     Path(id): Path<String>,
+    claims: AuthClaims,
     headers: HeaderMap,
     ValidatedJson(req): ValidatedJson<ConfirmOwnershipTransferRequest>,
 ) -> ApiResult<Json<OwnershipTransfer>> {
@@ -6514,235 +6739,393 @@ pub async fn confirm_ownership_transfer(
         )
     })?;
 
-    let mut transfer: OwnershipTransfer = sqlx::query_as(
-        "SELECT * FROM ownership_transfers WHERE id = $1",
-    )
-    .bind(transfer_uuid)
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|err| db_internal_error("fetch ownership transfer", err))?
-    .ok_or_else(|| ApiError::not_found(
-        "TransferNotFound",
-        format!("No ownership transfer found with ID: {}", id),
-    ))?;
+    let algorithm = transfer::resolve_algorithm(req.signature_algorithm.as_deref())?;
+    let decision = transfer::TransferDecision::from_accept_flag(req.accept);
 
-    if transfer.expires_at <= Utc::now() && transfer.status == OwnershipTransferStatus::Pending {
-        transfer.status = OwnershipTransferStatus::Expired;
+    let now = Utc::now();
+    transfer::check_signature_freshness(req.signed_at_unix, now.timestamp())?;
+
+    let signed_at = DateTime::from_timestamp(req.signed_at_unix, 0).ok_or_else(|| {
+        ApiError::bad_request(
+            "InvalidSignedAt",
+            "signed_at_unix is not a representable unix timestamp",
+        )
+    })?;
+
+    // Unlocked read purely to learn which contract to lock first. Everything this value is
+    // used for is re-read under `FOR UPDATE` below.
+    let contract_id: Uuid =
+        sqlx::query_scalar("SELECT contract_id FROM ownership_transfers WHERE id = $1")
+            .bind(transfer_uuid)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|err| db_internal_error("locate ownership transfer", err))?
+            .ok_or_else(|| {
+                ApiError::not_found(
+                    "TransferNotFound",
+                    format!("No ownership transfer found with ID: {}", id),
+                )
+            })?;
+
+    let mut tx = state
+        .db
+        .begin()
+        .await
+        .map_err(|err| db_internal_error("begin ownership transfer confirmation", err))?;
+
+    // Same lock order as `create_ownership_transfer`: contracts, then ownership_transfers.
+    let locked_owner: Uuid =
+        sqlx::query_scalar("SELECT publisher_id FROM contracts WHERE id = $1 FOR UPDATE")
+            .bind(contract_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|err| db_internal_error("lock contract for transfer confirmation", err))?
+            .ok_or_else(|| {
+                ApiError::not_found(
+                    "ContractNotFound",
+                    "the contract this transfer refers to no longer exists",
+                )
+            })?;
+
+    let transfer_row: OwnershipTransfer =
+        sqlx::query_as("SELECT * FROM ownership_transfers WHERE id = $1 FOR UPDATE")
+            .bind(transfer_uuid)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|err| db_internal_error("lock ownership transfer", err))?
+            .ok_or_else(|| {
+                ApiError::not_found(
+                    "TransferNotFound",
+                    format!("No ownership transfer found with ID: {}", id),
+                )
+            })?;
+
+    let actor = resolve_actor(&mut tx, &claims).await?;
+
+    // Authorization is checked once, ahead of the accept/reject split. #1058 checked it
+    // only inside the accept branch, so any caller could reject anyone's transfer.
+    let is_sender = actor.id == transfer_row.from_publisher_id;
+    let is_recipient = actor.id == transfer_row.to_publisher_id;
+
+    if !is_sender && !is_recipient {
+        return Err(ApiError::forbidden_with_error(
+            "UnauthorizedConfirmation",
+            "only the sender or the recipient of this transfer can act on it",
+        ));
+    }
+
+    // Accepting is the recipient's alone: the sender's consent is already recorded as the
+    // phase-1 signature, and letting the sender also accept would collapse the two-party
+    // requirement into one.
+    if req.accept && !is_recipient {
+        return Err(ApiError::forbidden_with_error(
+            "UnauthorizedConfirmation",
+            "only the recipient of this transfer can accept it",
+        ));
+    }
+
+    // Expiry is applied here, under the row lock, and the write is committed even though
+    // the response is an error; otherwise the expiry would roll back with the 409 and the
+    // row would stay `pending` forever. Same shape as `multisig_handlers::sign_proposal`.
+    if transfer_row.status.is_live() && transfer_row.expires_at <= now {
         sqlx::query(
-            "UPDATE ownership_transfers SET status = 'expired', completed_at = NOW() WHERE id = $1"
+            "UPDATE ownership_transfers
+             SET status = 'expired', completed_at = NOW()
+             WHERE id = $1 AND status IN ('pending', 'confirmed')",
         )
         .bind(transfer_uuid)
-        .execute(&state.db)
+        .execute(&mut *tx)
         .await
         .map_err(|err| db_internal_error("expire ownership transfer", err))?;
 
-        write_contract_audit_log(
-            &state.db,
-            AuditActionType::OwnershipTransferred,
-            transfer.contract_id,
-            req.user_id,
-            json!({
-                "action": "transfer_expired",
-                "transfer_id": transfer_uuid,
-                "reason": "Transfer request has expired"
-            }),
-            &extract_ip_address(&headers),
-        )
-        .await
-        .map_err(|err| db_internal_error("write expired transfer audit log", err))?;
-
         write_ownership_transfer_log(
-            &state.db,
+            &mut *tx,
             transfer_uuid,
-            req.user_id,
-            "publisher",
+            None,
+            "system",
             "transfer_expired",
-            Some(json!({"reason": "Transfer request has expired"})),
+            Some(json!({
+                "reason": "Transfer request passed its expiry without a verified acceptance",
+                "observed_by_publisher_id": actor.id,
+            })),
         )
         .await
         .map_err(|err| db_internal_error("write expired transfer log", err))?;
 
+        tx.commit()
+            .await
+            .map_err(|err| db_internal_error("commit ownership transfer expiry", err))?;
+
+        tracing::info!(
+            target: "ownership_transfer",
+            transfer_id = %transfer_uuid,
+            "ownership transfer expired on access"
+        );
+
         return Err(ApiError::conflict(
             "TransferExpired",
-            "This ownership transfer request has expired",
+            "this ownership transfer request has expired",
         ));
     }
 
-    if transfer.status != OwnershipTransferStatus::Pending {
+    if transfer_row.status != OwnershipTransferStatus::Pending {
         return Err(ApiError::conflict(
             "TransferNotPending",
-            format!("Transfer is already in '{}' status and cannot be confirmed", transfer.status),
+            format!(
+                "transfer is already in '{}' status and cannot be confirmed",
+                transfer_row.status
+            ),
         ));
     }
 
-    let from_publisher_id = transfer.from_publisher_id;
-    let to_publisher_id = transfer.to_publisher_id;
-    let contract_id = transfer.contract_id;
+    let request_nonce = transfer_row.request_nonce.clone().ok_or_else(|| {
+        // Only reachable for rows predating #1094; the migration expired all of those.
+        ApiError::conflict(
+            "UnsignedTransfer",
+            "this transfer predates signature-anchored confirmation and cannot be completed",
+        )
+    })?;
+
+    let sender = resolve_publisher_by_id(&mut tx, transfer_row.from_publisher_id)
+        .await
+        .map_err(|err| db_internal_error("resolve transfer sender", err))?
+        .ok_or_else(|| ApiError::internal("the sending publisher no longer exists"))?;
+
+    let recipient = resolve_publisher_by_id(&mut tx, transfer_row.to_publisher_id)
+        .await
+        .map_err(|err| db_internal_error("resolve transfer recipient", err))?
+        .ok_or_else(|| ApiError::internal("the receiving publisher no longer exists"))?;
+
+    let payload = transfer::decision_payload(
+        decision,
+        transfer_uuid,
+        transfer_row.contract_id,
+        &sender.stellar_address,
+        &recipient.stellar_address,
+        &request_nonce,
+        &req.nonce,
+        req.signed_at_unix,
+    );
+
+    // Verified before any state change, so a forged signature mutates nothing.
+    transfer::verify_transfer_signature(&actor.stellar_address, &payload, &req.signature)?;
+
+    let ip_address = extract_ip_address(&headers);
 
     if req.accept {
-        let is_from = req.user_id == from_publisher_id;
-        let is_to = req.user_id == to_publisher_id;
+        // Single-shot: the guard carries every precondition, so exactly one caller can
+        // move a transfer out of `pending` (I2), and the expiry check is evaluated here
+        // under the lock rather than trusted from the earlier read (I3).
+        let completed: OwnershipTransfer = sqlx::query_as(
+            "UPDATE ownership_transfers
+             SET status = 'completed',
+                 to_confirmation = TRUE,
+                 confirmed_at = NOW(),
+                 completed_at = NOW(),
+                 decision_nonce = $2,
+                 decision_signature = $3,
+                 decision_signer_address = $4,
+                 decision_signed_at = $5,
+                 decision_signed_payload = $6,
+                 decision_by = $7,
+                 signature_algorithm = $8
+             WHERE id = $1
+               AND status = 'pending'
+               AND from_confirmation = TRUE
+               AND to_confirmation = FALSE
+               AND expires_at > NOW()
+             RETURNING *",
+        )
+        .bind(transfer_uuid)
+        .bind(&req.nonce)
+        .bind(&req.signature)
+        .bind(&actor.stellar_address)
+        .bind(signed_at)
+        .bind(&payload)
+        .bind(actor.id)
+        .bind(algorithm)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|err| map_transfer_conflict("complete ownership transfer", err))?
+        .ok_or_else(|| {
+            ApiError::conflict(
+                "TransferNoLongerAcceptable",
+                "this transfer was already decided or expired before the acceptance was applied",
+            )
+        })?;
 
-        if !is_from && !is_to {
-            return Err(ApiError::forbidden_with_error(
-                "UnauthorizedConfirmation",
-                "Only the sender or recipient of this transfer can confirm it",
+        // Compare-and-swap on the owner we locked. If anything moved ownership in the
+        // meantime -- notably the `PATCH /publisher` bypass -- this affects zero rows and
+        // the whole transaction rolls back rather than overwriting an owner the sender
+        // never consented to hand off from.
+        let moved = sqlx::query(
+            "UPDATE contracts
+             SET publisher_id = $2, updated_at = NOW()
+             WHERE id = $1 AND publisher_id = $3",
+        )
+        .bind(transfer_row.contract_id)
+        .bind(recipient.id)
+        .bind(transfer_row.from_publisher_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|err| db_internal_error("move contract ownership", err))?;
+
+        if moved.rows_affected() == 0 {
+            tracing::warn!(
+                target: "ownership_transfer",
+                transfer_id = %transfer_uuid,
+                contract_id = %transfer_row.contract_id,
+                expected_owner = %transfer_row.from_publisher_id,
+                actual_owner = %locked_owner,
+                "refused to complete ownership transfer: contract owner changed since the request"
+            );
+            return Err(ApiError::conflict(
+                "OwnershipChangedConcurrently",
+                "the contract's publisher changed after this transfer was requested; \
+                 the transfer was not applied",
             ));
         }
 
-        if is_from {
-            transfer.from_confirmation = true;
-        }
-        if is_to {
-            transfer.to_confirmation = true;
-        }
-
-        sqlx::query(
-            "UPDATE ownership_transfers
-             SET from_confirmation = $2, to_confirmation = $3, confirmed_at = NOW()
-             WHERE id = $1",
-        )
-        .bind(transfer_uuid)
-        .bind(transfer.from_confirmation)
-        .bind(transfer.to_confirmation)
-        .execute(&state.db)
-        .await
-        .map_err(|err| db_internal_error("update ownership transfer confirmation", err))?;
-
-        if transfer.from_confirmation && transfer.to_confirmation {
-            transfer.status = OwnershipTransferStatus::Completed;
-            transfer.completed_at = Some(Utc::now());
-
-            sqlx::query(
-                "UPDATE contracts SET publisher_id = $2, updated_at = NOW() WHERE id = $1"
-            )
-            .bind(contract_id)
-            .bind(to_publisher_id)
-            .execute(&state.db)
-            .await
-            .map_err(|err| db_internal_error("complete ownership transfer", err))?;
-
-            write_contract_audit_log(
-                &state.db,
-                AuditActionType::OwnershipTransferred,
-                contract_id,
-                req.user_id,
-                json!({
-                    "action": "transfer_completed",
-                    "from_publisher_id": from_publisher_id,
-                    "to_publisher_id": to_publisher_id,
-                    "contract_id": contract_id,
-                    "transfer_id": transfer_uuid,
-                    "confirmed_at": transfer.completed_at
-                }),
-                &extract_ip_address(&headers),
-            )
-            .await
-            .map_err(|err| db_internal_error("write completed transfer audit log", err))?;
-
-            write_ownership_transfer_log(
-                &state.db,
-                transfer_uuid,
-                req.user_id,
-                "publisher",
-                "transfer_completed",
-                Some(json!({
-                    "from_publisher_id": from_publisher_id,
-                    "to_publisher_id": to_publisher_id,
-                    "contract_id": contract_id,
-                })),
-            )
-            .await
-            .map_err(|err| db_internal_error("write completed transfer log", err))?;
-
-            state.cache.invalidate_contracts().await;
-            return Ok(Json(transfer));
-        }
-
-        transfer.status = OwnershipTransferStatus::Confirmed;
-
         write_contract_audit_log(
-            &state.db,
+            &mut *tx,
             AuditActionType::OwnershipTransferred,
-            contract_id,
-            req.user_id,
+            transfer_row.contract_id,
+            actor.id,
             json!({
-                "action": "transfer_partially_confirmed",
-                "from_publisher_id": from_publisher_id,
-                "to_publisher_id": to_publisher_id,
-                "contract_id": contract_id,
+                "action": "transfer_completed",
                 "transfer_id": transfer_uuid,
-                "from_confirmed": transfer.from_confirmation,
-                "to_confirmed": transfer.to_confirmation
+                "publisher_id": {
+                    "before": transfer_row.from_publisher_id,
+                    "after": recipient.id,
+                },
+                "from_signer_address": sender.stellar_address,
+                "decision_signer_address": actor.stellar_address,
             }),
-            &extract_ip_address(&headers),
+            &ip_address,
         )
         .await
-        .map_err(|err| db_internal_error("write partial confirmation audit log", err))?;
+        .map_err(|err| db_internal_error("write completed transfer audit log", err))?;
 
         write_ownership_transfer_log(
-            &state.db,
+            &mut *tx,
             transfer_uuid,
-            req.user_id,
+            Some(actor.id),
             "publisher",
-            "transfer_partially_confirmed",
+            "transfer_completed",
             Some(json!({
-                "from_confirmed": transfer.from_confirmation,
-                "to_confirmed": transfer.to_confirmation,
+                "from_publisher_id": transfer_row.from_publisher_id,
+                "to_publisher_id": recipient.id,
+                "contract_id": transfer_row.contract_id,
+                "decision_nonce": req.nonce,
+                "decision_signer_address": actor.stellar_address,
+                "signature_algorithm": algorithm,
+                "signed_payload": payload,
             })),
         )
         .await
-        .map_err(|err| db_internal_error("write partial confirmation log", err))?;
+        .map_err(|err| db_internal_error("write completed transfer log", err))?;
+
+        tx.commit()
+            .await
+            .map_err(|err| db_internal_error("commit ownership transfer completion", err))?;
+
+        tracing::info!(
+            target: "ownership_transfer",
+            transfer_id = %transfer_uuid,
+            contract_id = %transfer_row.contract_id,
+            from_publisher_id = %transfer_row.from_publisher_id,
+            to_publisher_id = %recipient.id,
+            "ownership transfer completed: both signatures verified, ownership moved"
+        );
 
         state.cache.invalidate_contracts().await;
-        return Ok(Json(transfer));
+        return Ok(Json(completed));
     }
 
-    transfer.status = OwnershipTransferStatus::Rejected;
-    transfer.completed_at = Some(Utc::now());
-
-    sqlx::query(
-        "UPDATE ownership_transfers SET status = 'rejected', completed_at = NOW() WHERE id = $1"
+    let rejected: OwnershipTransfer = sqlx::query_as(
+        "UPDATE ownership_transfers
+         SET status = 'rejected',
+             completed_at = NOW(),
+             decision_nonce = $2,
+             decision_signature = $3,
+             decision_signer_address = $4,
+             decision_signed_at = $5,
+             decision_signed_payload = $6,
+             decision_by = $7,
+             signature_algorithm = $8
+         WHERE id = $1 AND status = 'pending'
+         RETURNING *",
     )
     .bind(transfer_uuid)
-    .execute(&state.db)
+    .bind(&req.nonce)
+    .bind(&req.signature)
+    .bind(&actor.stellar_address)
+    .bind(signed_at)
+    .bind(&payload)
+    .bind(actor.id)
+    .bind(algorithm)
+    .fetch_optional(&mut *tx)
     .await
-    .map_err(|err| db_internal_error("reject ownership transfer", err))?;
+    .map_err(|err| map_transfer_conflict("reject ownership transfer", err))?
+    .ok_or_else(|| {
+        ApiError::conflict(
+            "TransferNotPending",
+            "this transfer was already decided before the rejection was applied",
+        )
+    })?;
 
     write_contract_audit_log(
-        &state.db,
+        &mut *tx,
         AuditActionType::OwnershipTransferred,
-        contract_id,
-        req.user_id,
+        transfer_row.contract_id,
+        actor.id,
         json!({
             "action": "transfer_rejected",
-            "from_publisher_id": from_publisher_id,
-            "to_publisher_id": to_publisher_id,
-            "contract_id": contract_id,
-            "transfer_id": transfer_uuid
+            "transfer_id": transfer_uuid,
+            "rejected_by": if is_recipient { "recipient" } else { "sender" },
+            "from_publisher_id": transfer_row.from_publisher_id,
+            "to_publisher_id": transfer_row.to_publisher_id,
+            "decision_signer_address": actor.stellar_address,
         }),
-        &extract_ip_address(&headers),
+        &ip_address,
     )
     .await
     .map_err(|err| db_internal_error("write rejected transfer audit log", err))?;
 
     write_ownership_transfer_log(
-        &state.db,
+        &mut *tx,
         transfer_uuid,
-        req.user_id,
+        Some(actor.id),
         "publisher",
         "transfer_rejected",
         Some(json!({
-            "from_publisher_id": from_publisher_id,
-            "to_publisher_id": to_publisher_id,
-            "contract_id": contract_id,
+            "rejected_by": if is_recipient { "recipient" } else { "sender" },
+            "from_publisher_id": transfer_row.from_publisher_id,
+            "to_publisher_id": transfer_row.to_publisher_id,
+            "contract_id": transfer_row.contract_id,
+            "decision_nonce": req.nonce,
+            "decision_signer_address": actor.stellar_address,
+            "signature_algorithm": algorithm,
+            "signed_payload": payload,
         })),
     )
     .await
     .map_err(|err| db_internal_error("write rejected transfer log", err))?;
 
+    tx.commit()
+        .await
+        .map_err(|err| db_internal_error("commit ownership transfer rejection", err))?;
+
+    tracing::info!(
+        target: "ownership_transfer",
+        transfer_id = %transfer_uuid,
+        contract_id = %transfer_row.contract_id,
+        rejected_by_publisher_id = %actor.id,
+        "ownership transfer rejected with a verified signature"
+    );
+
     state.cache.invalidate_contracts().await;
-    Ok(Json(transfer))
+    Ok(Json(rejected))
 }
 
 pub async fn get_ownership_transfer(
@@ -6756,21 +7139,29 @@ pub async fn get_ownership_transfer(
         )
     })?;
 
-    let transfer: OwnershipTransfer = sqlx::query_as(
-        "SELECT * FROM ownership_transfers WHERE id = $1",
-    )
-    .bind(transfer_uuid)
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|err| db_internal_error("fetch ownership transfer", err))?
-    .ok_or_else(|| ApiError::not_found(
-        "TransferNotFound",
-        format!("No ownership transfer found with ID: {}", id),
-    ))?;
+    // Lazy expiry: a read must never report a past-due transfer as still actionable, and
+    // the background sweeper only guarantees eventual consistency.
+    transfer::expire_transfer_if_due(&state.db, transfer_uuid)
+        .await
+        .map_err(|err| db_internal_error("expire ownership transfer on read", err))?;
 
-    Ok(Json(transfer))
+    let transfer_row: OwnershipTransfer =
+        sqlx::query_as("SELECT * FROM ownership_transfers WHERE id = $1")
+            .bind(transfer_uuid)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|err| db_internal_error("fetch ownership transfer", err))?
+            .ok_or_else(|| {
+                ApiError::not_found(
+                    "TransferNotFound",
+                    format!("No ownership transfer found with ID: {}", id),
+                )
+            })?;
+
+    Ok(Json(transfer_row))
 }
 
+/// Full transfer history for one contract, newest first (append-only; nothing is removed).
 pub async fn list_ownership_transfers(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -6782,18 +7173,26 @@ pub async fn list_ownership_transfers(
         )
     })?;
 
-    let _contract: Contract = sqlx::query_as("SELECT * FROM contracts WHERE id = $1")
-        .bind(contract_uuid)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|err| db_internal_error("fetch contract for transfers", err))?
-        .ok_or_else(|| ApiError::not_found(
+    let contract_exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM contracts WHERE id = $1)")
+            .bind(contract_uuid)
+            .fetch_one(&state.db)
+            .await
+            .map_err(|err| db_internal_error("check contract for transfers", err))?;
+
+    if !contract_exists {
+        return Err(ApiError::not_found(
             "ContractNotFound",
             format!("No contract found with ID: {}", id),
-        ))?;
+        ));
+    }
+
+    transfer::expire_due_transfers_for_contract(&state.db, contract_uuid)
+        .await
+        .map_err(|err| db_internal_error("expire ownership transfers on read", err))?;
 
     let transfers: Vec<OwnershipTransfer> = sqlx::query_as(
-        "SELECT * FROM ownership_transfers WHERE contract_id = $1 ORDER BY created_at DESC"
+        "SELECT * FROM ownership_transfers WHERE contract_id = $1 ORDER BY created_at DESC",
     )
     .bind(contract_uuid)
     .fetch_all(&state.db)
@@ -6803,6 +7202,7 @@ pub async fn list_ownership_transfers(
     Ok(Json(transfers))
 }
 
+/// The provenance chain for one transfer, oldest first.
 pub async fn get_ownership_transfer_logs(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -6814,8 +7214,14 @@ pub async fn get_ownership_transfer_logs(
         )
     })?;
 
+    // Expire first so a caller reading the chain sees the expiry entry rather than a
+    // history that stops at `transfer_request_created`.
+    transfer::expire_transfer_if_due(&state.db, transfer_uuid)
+        .await
+        .map_err(|err| db_internal_error("expire ownership transfer on log read", err))?;
+
     let logs: Vec<OwnershipTransferLog> = sqlx::query_as(
-        "SELECT * FROM ownership_transfer_logs WHERE transfer_id = $1 ORDER BY created_at ASC"
+        "SELECT * FROM ownership_transfer_logs WHERE transfer_id = $1 ORDER BY created_at ASC",
     )
     .bind(transfer_uuid)
     .fetch_all(&state.db)

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -61,6 +61,7 @@ pub mod notification_routes;
 pub mod onchain_verification;
 pub mod openapi;
 pub mod org_handlers;
+pub mod ownership_transfer;
 pub mod pagination;
 pub mod patch_handlers;
 pub mod performance_handlers;

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -198,6 +198,11 @@ async fn main() -> Result<()> {
     // Spawn the query-analysis flush + N+1 persistence task (Issue #887)
     api::query_analysis::spawn_query_analysis_task(pool.clone());
 
+    // Spawn the ownership-transfer expiry sweeper (Issue #1094). Expiry is also applied
+    // lazily on every read and write path; this is the backstop for transfers nobody
+    // looks at again.
+    api::ownership_transfer::spawn_ownership_transfer_expiry_task(pool.clone());
+
     // Create prometheus registry for metrics
     let registry = Registry::new();
     if let Err(e) = api::metrics::register_all(&registry) {

--- a/backend/api/src/ownership_transfer.rs
+++ b/backend/api/src/ownership_transfer.rs
@@ -1,0 +1,482 @@
+//! Signature-anchored ownership transfer support (issue #1094).
+//!
+//! Owns the pieces of the two-phase transfer flow that are not HTTP handling:
+//!
+//!   * the canonical signing payloads both parties sign,
+//!   * the freshness window for a signature,
+//!   * signature verification against a publisher's on-chain Stellar account,
+//!   * expiry, both lazily (on read/write paths) and via a background sweeper.
+//!
+//! The handlers live in `handlers.rs` alongside the rest of the #1058 endpoints; this
+//! module exists so the crypto and payload construction can be exercised directly by
+//! tests and reused by the CLI later.
+//!
+//! Design notes worth keeping:
+//!
+//! * **"On-chain-anchored" here means the signing key is the on-chain account key.** A
+//!   transfer is authorised by an ed25519 signature that verifies against
+//!   `publishers.stellar_address`, which is a Stellar `G...` account. No RPC or Horizon
+//!   call is made, and no transaction hash is recorded. Anchoring is to the keypair that
+//!   controls the account, not to a specific ledger entry.
+//! * **Payloads are colon-joined ASCII, not JSON.** This matches the existing signing
+//!   conventions in `signing_handlers.rs` and `handlers/validators.rs`, and sidesteps
+//!   canonical-JSON key-ordering entirely. Nonces are restricted to an alphabet without
+//!   `:` (see `validation::handler_requests`) so the encoding stays unambiguous.
+//! * **Timestamps in payloads are unix seconds.** An RFC3339 round-trip through serde can
+//!   change offset or sub-second precision, which would change the signed bytes.
+//! * **Every segment that identifies the transfer is inside the payload**: domain,
+//!   version, and action, so a phase-1 signature cannot be replayed as a phase-2 one and
+//!   an `accept` cannot be replayed as a `reject`.
+
+use std::time::Duration;
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::error::ApiError;
+use crate::signature_verification::{verify_signature, SigError, SignatureAlgorithm};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Domain separator. Any change here invalidates every previously issued signature, so
+/// bump the version segment instead of editing this.
+const PAYLOAD_DOMAIN: &str = "soroban-registry:ownership-transfer";
+const PAYLOAD_VERSION: &str = "v1";
+
+/// An ed25519 signature is always exactly 64 bytes.
+const ED25519_SIGNATURE_LEN: usize = 64;
+
+/// Bounds on the client-supplied nonce. Long enough to be unguessable, short enough to
+/// index; the column is `VARCHAR(128)`.
+pub const MIN_NONCE_LEN: usize = 16;
+pub const MAX_NONCE_LEN: usize = 128;
+
+/// Upper bound on how far in the future a transfer may be set to expire. A transfer is a
+/// standing offer to take over a contract, so it should not be able to sit open forever.
+pub const MAX_EXPIRY_WINDOW_SECS: i64 = 90 * 24 * 60 * 60;
+
+/// Default lower bound, so a caller cannot create a transfer that is already unusable by
+/// the time the recipient sees it.
+pub const DEFAULT_MIN_EXPIRY_WINDOW_SECS: i64 = 60;
+
+/// Shortest permitted transfer lifetime, in seconds.
+///
+/// Configurable via `OWNERSHIP_TRANSFER_MIN_EXPIRY_SECS`. Lowering it is what lets the
+/// expiry tests observe a real expiry without sleeping for a minute; the integration suite
+/// reads this same function so it stays correct at any setting.
+pub fn min_expiry_window_secs() -> i64 {
+    std::env::var("OWNERSHIP_TRANSFER_MIN_EXPIRY_SECS")
+        .ok()
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(DEFAULT_MIN_EXPIRY_WINDOW_SECS)
+}
+
+/// Rows claimed per sweeper pass.
+const EXPIRY_BATCH_SIZE: i64 = 100;
+
+// ── Signing payloads ──────────────────────────────────────────────────────────
+
+/// The phase-2 decision a party is signing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferDecision {
+    Accept,
+    Reject,
+}
+
+impl TransferDecision {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Accept => "accept",
+            Self::Reject => "reject",
+        }
+    }
+
+    pub fn from_accept_flag(accept: bool) -> Self {
+        if accept {
+            Self::Accept
+        } else {
+            Self::Reject
+        }
+    }
+}
+
+/// Canonical payload the outgoing publisher signs to open a transfer.
+///
+/// The transfer id cannot appear here: the sender has to sign before the row exists. The
+/// nonce takes its place as the binding token, and a unique index on `request_nonce`
+/// makes the signature single-use.
+pub fn initiate_payload(
+    contract_id: Uuid,
+    from_address: &str,
+    to_address: &str,
+    expires_at_unix: i64,
+    nonce: &str,
+    signed_at_unix: i64,
+) -> String {
+    format!(
+        "{}:{}:initiate:{}:{}:{}:{}:{}:{}",
+        PAYLOAD_DOMAIN,
+        PAYLOAD_VERSION,
+        contract_id,
+        from_address,
+        to_address,
+        expires_at_unix,
+        nonce,
+        signed_at_unix
+    )
+}
+
+/// Canonical payload a party signs to accept or reject an existing transfer.
+///
+/// Binds both the transfer id and the originating `request_nonce`, so an acceptance is
+/// welded to exactly one initiation and cannot be carried across a re-initiated transfer.
+#[allow(clippy::too_many_arguments)]
+pub fn decision_payload(
+    decision: TransferDecision,
+    transfer_id: Uuid,
+    contract_id: Uuid,
+    from_address: &str,
+    to_address: &str,
+    request_nonce: &str,
+    nonce: &str,
+    signed_at_unix: i64,
+) -> String {
+    format!(
+        "{}:{}:{}:{}:{}:{}:{}:{}:{}:{}",
+        PAYLOAD_DOMAIN,
+        PAYLOAD_VERSION,
+        decision.as_str(),
+        transfer_id,
+        contract_id,
+        from_address,
+        to_address,
+        request_nonce,
+        nonce,
+        signed_at_unix
+    )
+}
+
+// ── Freshness ─────────────────────────────────────────────────────────────────
+
+/// How far `signed_at_unix` may sit from the server clock, in seconds.
+///
+/// Symmetric, so a client whose clock runs modestly fast is still able to transact rather
+/// than being locked out with an error it cannot diagnose.
+pub fn freshness_window_secs() -> i64 {
+    std::env::var("OWNERSHIP_TRANSFER_SIGNATURE_MAX_AGE_SECS")
+        .ok()
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(300)
+}
+
+/// Reject signatures that are stale or dated too far in the future.
+///
+/// A signature is only single-use because of the nonce indexes; this bound is what keeps
+/// a leaked-but-unused signature from being useful indefinitely.
+pub fn check_signature_freshness(signed_at_unix: i64, now_unix: i64) -> Result<(), ApiError> {
+    let window = freshness_window_secs();
+    let skew = now_unix.saturating_sub(signed_at_unix);
+
+    if skew > window {
+        return Err(ApiError::unprocessable(
+            "SignatureExpired",
+            format!(
+                "signature timestamp is {}s old; the maximum accepted age is {}s",
+                skew, window
+            ),
+        ));
+    }
+
+    if skew < -window {
+        return Err(ApiError::unprocessable(
+            "SignatureNotYetValid",
+            format!(
+                "signature timestamp is {}s in the future; the maximum accepted skew is {}s",
+                -skew, window
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+// ── Verification ──────────────────────────────────────────────────────────────
+
+/// Verify `signature_b64` over `payload` against the Stellar account `signer_address`.
+///
+/// `signer_address` is always read from `publishers`, never taken from the request body:
+/// the caller proves control of the key belonging to the identity the server resolved.
+///
+/// Error mapping follows the precedent in `handlers.rs` for version signatures: a payload
+/// the server cannot even decode is a 400 (the client sent something malformed), while a
+/// well-formed signature that does not verify is a 422 (the request was understood and
+/// rejected on its merits).
+pub fn verify_transfer_signature(
+    signer_address: &str,
+    payload: &str,
+    signature_b64: &str,
+) -> Result<(), ApiError> {
+    let public_key = stellar_strkey::ed25519::PublicKey::from_string(signer_address)
+        .map_err(|_| {
+            // The address came from our own table, so this is bad stored data, not a
+            // client error.
+            tracing::error!(
+                signer_address = signer_address,
+                "publisher stellar_address on record is not a valid ed25519 strkey"
+            );
+            ApiError::internal("The publisher address on record is not a valid Stellar address")
+        })?
+        .0;
+
+    let signature = BASE64.decode(signature_b64.trim()).map_err(|_| {
+        ApiError::bad_request(
+            "InvalidSignatureEncoding",
+            "signature must be standard base64-encoded",
+        )
+    })?;
+
+    if signature.len() != ED25519_SIGNATURE_LEN {
+        return Err(ApiError::bad_request(
+            "InvalidSignatureLength",
+            format!(
+                "an ed25519 signature must decode to {} bytes, got {}",
+                ED25519_SIGNATURE_LEN,
+                signature.len()
+            ),
+        ));
+    }
+
+    // `verify_signature` uses `verify_strict` for ed25519, which rejects small-order and
+    // otherwise malleable keys.
+    verify_signature(
+        SignatureAlgorithm::Ed25519,
+        &public_key,
+        payload.as_bytes(),
+        &signature,
+    )
+    .map_err(|err| match err {
+        SigError::InvalidKey => {
+            ApiError::internal("The publisher address on record is not a usable ed25519 key")
+        }
+        SigError::InvalidSignature => ApiError::bad_request(
+            "InvalidSignature",
+            "signature is not a well-formed ed25519 signature",
+        ),
+        SigError::VerificationFailed => ApiError::unprocessable(
+            "SignatureVerificationFailed",
+            "signature does not verify against the signer's Stellar account",
+        ),
+    })
+}
+
+/// Parse and validate the optional `signature_algorithm` field.
+///
+/// Only ed25519 is accepted: Stellar accounts are ed25519, so a secp256k1 signature could
+/// never be checked against `publishers.stellar_address`. Accepting the field at all keeps
+/// the wire format forward-compatible without implying support that does not exist.
+pub fn resolve_algorithm(requested: Option<&str>) -> Result<&'static str, ApiError> {
+    match requested.map(str::trim) {
+        None | Some("") => Ok("ed25519"),
+        Some(value) if value.eq_ignore_ascii_case("ed25519") => Ok("ed25519"),
+        Some(value) => Err(ApiError::bad_request(
+            "UnsupportedSignatureAlgorithm",
+            format!(
+                "signature_algorithm '{}' is not supported; ownership transfers require ed25519",
+                value
+            ),
+        )),
+    }
+}
+
+// ── Expiry ────────────────────────────────────────────────────────────────────
+
+/// Expire a single transfer if it is live and past `expires_at`.
+///
+/// Returns `true` when this call was the one that expired it. The state change and its
+/// history row go in one transaction, so history can never disagree with the row.
+pub async fn expire_transfer_if_due(db: &PgPool, transfer_id: Uuid) -> Result<bool, sqlx::Error> {
+    let mut tx = db.begin().await?;
+
+    let expired: Option<(Uuid,)> = sqlx::query_as(
+        "UPDATE ownership_transfers
+         SET status = 'expired', completed_at = NOW()
+         WHERE id = $1
+           AND status IN ('pending', 'confirmed')
+           AND expires_at <= NOW()
+         RETURNING id",
+    )
+    .bind(transfer_id)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    if expired.is_none() {
+        tx.rollback().await?;
+        return Ok(false);
+    }
+
+    insert_system_expiry_log(&mut tx, &[transfer_id]).await?;
+    tx.commit().await?;
+
+    tracing::info!(
+        target: "ownership_transfer",
+        transfer_id = %transfer_id,
+        "ownership transfer expired"
+    );
+
+    Ok(true)
+}
+
+/// Expire every live, past-due transfer for one contract. Used by the list endpoint so a
+/// read never reports a transfer as actionable when it is not.
+pub async fn expire_due_transfers_for_contract(
+    db: &PgPool,
+    contract_id: Uuid,
+) -> Result<u64, sqlx::Error> {
+    let mut tx = db.begin().await?;
+
+    let rows: Vec<(Uuid,)> = sqlx::query_as(
+        "UPDATE ownership_transfers
+         SET status = 'expired', completed_at = NOW()
+         WHERE contract_id = $1
+           AND status IN ('pending', 'confirmed')
+           AND expires_at <= NOW()
+         RETURNING id",
+    )
+    .bind(contract_id)
+    .fetch_all(&mut *tx)
+    .await?;
+
+    if rows.is_empty() {
+        tx.rollback().await?;
+        return Ok(0);
+    }
+
+    let ids: Vec<Uuid> = rows.into_iter().map(|(id,)| id).collect();
+    insert_system_expiry_log(&mut tx, &ids).await?;
+    tx.commit().await?;
+
+    tracing::info!(
+        target: "ownership_transfer",
+        contract_id = %contract_id,
+        expired = ids.len(),
+        "expired past-due ownership transfers for contract"
+    );
+
+    Ok(ids.len() as u64)
+}
+
+/// Sweep a batch of past-due transfers across all contracts.
+///
+/// `FOR UPDATE SKIP LOCKED` means the sweeper never blocks, and is never blocked by, a
+/// confirmation that is mid-transaction on the same row.
+pub async fn expire_due_transfers(db: &PgPool) -> Result<u64, sqlx::Error> {
+    let mut total = 0u64;
+
+    loop {
+        let mut tx = db.begin().await?;
+
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "WITH claimed AS (
+                 SELECT id
+                 FROM ownership_transfers
+                 WHERE status IN ('pending', 'confirmed')
+                   AND expires_at <= NOW()
+                 ORDER BY expires_at ASC
+                 LIMIT $1
+                 FOR UPDATE SKIP LOCKED
+             )
+             UPDATE ownership_transfers t
+             SET status = 'expired', completed_at = NOW()
+             FROM claimed c
+             WHERE t.id = c.id
+             RETURNING t.id",
+        )
+        .bind(EXPIRY_BATCH_SIZE)
+        .fetch_all(&mut *tx)
+        .await?;
+
+        if rows.is_empty() {
+            tx.rollback().await?;
+            break;
+        }
+
+        let ids: Vec<Uuid> = rows.into_iter().map(|(id,)| id).collect();
+        let claimed = ids.len();
+        insert_system_expiry_log(&mut tx, &ids).await?;
+        tx.commit().await?;
+
+        total += claimed as u64;
+
+        // A short batch means the queue is drained; anything else risks spinning.
+        if (claimed as i64) < EXPIRY_BATCH_SIZE {
+            break;
+        }
+    }
+
+    if total > 0 {
+        tracing::info!(
+            target: "ownership_transfer",
+            expired = total,
+            "expired past-due ownership transfers"
+        );
+    }
+
+    Ok(total)
+}
+
+/// Append one `transfer_expired` history row per id, authored by the system.
+async fn insert_system_expiry_log(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    transfer_ids: &[Uuid],
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO ownership_transfer_logs (transfer_id, actor_id, actor_type, action, details)
+         SELECT id, NULL, 'system', 'transfer_expired', $2::jsonb
+         FROM UNNEST($1::uuid[]) AS t(id)",
+    )
+    .bind(transfer_ids)
+    .bind(serde_json::json!({
+        "reason": "Transfer request passed its expiry without a verified acceptance",
+    }))
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+// ── Background task ───────────────────────────────────────────────────────────
+
+/// Spawn the periodic expiry sweeper.
+///
+/// Expiry is also applied lazily on every read and write path, so this task is a
+/// backstop: it keeps `expires_at` meaningful for transfers nobody ever looks at again,
+/// which is what makes the history table an accurate record rather than a set of rows
+/// frozen in whatever state they were last observed in.
+///
+/// Interval is configurable via `OWNERSHIP_TRANSFER_EXPIRY_INTERVAL_SECS` (default 300).
+pub fn spawn_ownership_transfer_expiry_task(pool: PgPool) {
+    let interval_secs = std::env::var("OWNERSHIP_TRANSFER_EXPIRY_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(300);
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        // Skip the immediate first tick so startup is not competing with a sweep.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if let Err(err) = expire_due_transfers(&pool).await {
+                tracing::error!(
+                    target: "ownership_transfer",
+                    error = ?err,
+                    "periodic ownership transfer expiry sweep failed"
+                );
+            }
+        }
+    });
+}

--- a/backend/api/src/validation/handler_requests.rs
+++ b/backend/api/src/validation/handler_requests.rs
@@ -2300,19 +2300,96 @@ impl Validatable for RunMutationTestRequest {
     }
 }
 
+// ── Ownership transfer (issues #1058, #1094) ─────────────────────────────────
+
+/// A transfer nonce must not contain `:`.
+///
+/// The signing payloads are colon-joined ASCII, so a nonce carrying a colon could shift
+/// the segment boundaries and make two different requests produce the same signed bytes.
+/// Restricting to an unreserved URL-safe alphabet keeps the encoding injective.
+fn validate_transfer_nonce(nonce: &str) -> Result<(), String> {
+    validate_length(
+        nonce,
+        crate::ownership_transfer::MIN_NONCE_LEN,
+        crate::ownership_transfer::MAX_NONCE_LEN,
+    )?;
+
+    if !nonce
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err("must contain only letters, digits, '-' and '_'".to_string());
+    }
+
+    Ok(())
+}
+
+/// A unix-second timestamp must be positive; the handler applies the freshness window.
+fn validate_unix_timestamp(value: i64) -> Result<(), String> {
+    if value <= 0 {
+        return Err("must be a positive unix timestamp in seconds".to_string());
+    }
+    Ok(())
+}
+
+/// `validate_base64_size` is a decodability plus maximum-size guard, so this only rejects
+/// obvious junk. The exact 64-byte length is enforced in
+/// `ownership_transfer::verify_transfer_signature`, which is the single place that decides
+/// whether a signature is acceptable.
+const MAX_SIGNATURE_DECODED_BYTES: usize = 64;
+
 impl Validatable for shared::CreateOwnershipTransferRequest {
-    fn sanitize(&mut self) {}
+    fn sanitize(&mut self) {
+        self.to_publisher_address = normalize_stellar_address(&self.to_publisher_address);
+        self.nonce = trim(&self.nonce);
+        self.signature = trim(&self.signature);
+        trim_optional(&mut self.signature_algorithm);
+    }
 
     fn validate(&self) -> Result<(), Vec<FieldError>> {
-        Ok(())
+        let mut builder = ValidationBuilder::new();
+        builder
+            .check("to_publisher_address", || {
+                validate_stellar_address(&self.to_publisher_address)
+            })
+            .check("nonce", || validate_transfer_nonce(&self.nonce))
+            .check("expires_at_unix", || {
+                validate_unix_timestamp(self.expires_at_unix)
+            })
+            .check("signed_at_unix", || {
+                validate_unix_timestamp(self.signed_at_unix)
+            })
+            .check("signature", || {
+                validate_base64_size(&self.signature, MAX_SIGNATURE_DECODED_BYTES)
+            })
+            .check("signature_algorithm", || {
+                validate_one_of_optional(&self.signature_algorithm, &["ed25519"])
+            });
+        builder.build()
     }
 }
 
 impl Validatable for shared::ConfirmOwnershipTransferRequest {
-    fn sanitize(&mut self) {}
+    fn sanitize(&mut self) {
+        self.nonce = trim(&self.nonce);
+        self.signature = trim(&self.signature);
+        trim_optional(&mut self.signature_algorithm);
+    }
 
     fn validate(&self) -> Result<(), Vec<FieldError>> {
-        Ok(())
+        let mut builder = ValidationBuilder::new();
+        builder
+            .check("nonce", || validate_transfer_nonce(&self.nonce))
+            .check("signed_at_unix", || {
+                validate_unix_timestamp(self.signed_at_unix)
+            })
+            .check("signature", || {
+                validate_base64_size(&self.signature, MAX_SIGNATURE_DECODED_BYTES)
+            })
+            .check("signature_algorithm", || {
+                validate_one_of_optional(&self.signature_algorithm, &["ed25519"])
+            });
+        builder.build()
     }
 }
 

--- a/backend/api/tests/ownership_transfer_tests.rs
+++ b/backend/api/tests/ownership_transfer_tests.rs
@@ -1,300 +1,1361 @@
-// tests/ownership_transfer_tests.rs
+// ═══════════════════════════════════════════════════════════════════════════
+// SIGNATURE-ANCHORED OWNERSHIP TRANSFER TESTS (Issues #1058, #1094)
+// ═══════════════════════════════════════════════════════════════════════════
 //
-// Issue #1058 — Ownership transfer feature tests.
-// Tests for expired, rejected, and duplicate transfer attempts,
-// as well as successful two-party confirmation flows.
+// Two groups of tests live here.
+//
+// Pure tests exercise the payload builders, the freshness window, and signature
+// verification. They need neither a database nor a running API:
+//
+//   To run: cargo test --test ownership_transfer_tests
+//
+// Live tests drive the real HTTP endpoints and assert the properties the issue asks for:
+// ownership moves only after two verified signatures, an expired request can never be
+// accepted (including under a 10-way concurrent race), history is queryable per contract,
+// and expired / rejected / double-accept / forged-signature attempts all fail closed.
+//
+//   To run: cargo test --test ownership_transfer_tests -- --ignored --nocapture
+//
+// Live tests require:
+//   * a running API at TEST_API_BASE_URL (default http://localhost:3001) with a database,
+//   * JWT_SECRET set on the API process; without it the AuthClaims extractor returns 500
+//     rather than 401 and the authorization assertions will not mean what they say,
+//   * ideally OWNERSHIP_TRANSFER_MIN_EXPIRY_SECS=1 on the API process. The expiry tests
+//     read min_expiry_window_secs() and wait for however long the server demands, so they
+//     are correct either way; at the default they simply take a minute each.
+//
+// Why everything is an integration test rather than a `#[cfg(test)] mod tests` inside
+// src/ownership_transfer.rs: `cargo test -p api --lib` does not compile on this branch for
+// reasons unrelated to #1094 (pre-existing errors in other modules' test blocks).
+// Integration test targets link the library compiled *without* cfg(test), so this file
+// builds and runs regardless. That is also why api::ownership_transfer is `pub`.
+//
+// Fixture note: the random_strkey helper used elsewhere in this suite produces
+// format-valid addresses with no private key behind them, so it cannot sign anything. Here
+// each actor is a real ed25519 keypair whose Stellar address is derived from its public
+// key, registered as a publisher through the public publish endpoint, and issued a real JWT
+// through the challenge/verify flow. Payloads are built with the same functions the server
+// uses, so test and server agree byte for byte by construction rather than by copy.
+// ═══════════════════════════════════════════════════════════════════════════
 
-use chrono::{DateTime, Utc};
-use shared::{
-    ConfirmOwnershipTransferRequest, CreateOwnershipTransferRequest,
-    OwnershipTransferStatus,
+use api::ownership_transfer::{
+    check_signature_freshness, decision_payload, initiate_payload, min_expiry_window_secs,
+    resolve_algorithm, verify_transfer_signature, TransferDecision, MAX_EXPIRY_WINDOW_SECS,
 };
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use shared::OwnershipTransferStatus;
 use uuid::Uuid;
 
-// ─────────────────────────────────────────────────────────────────────
-// Helpers
-// ─────────────────────────────────────────────────────────────────────
+// ── Keypair and signing helpers ───────────────────────────────────────────────
 
-fn make_create_req(
+fn new_keypair() -> (SigningKey, String) {
+    let signing = SigningKey::generate(&mut rand::rngs::OsRng);
+    // `strkey`'s `to_string` returns a `heapless::String<56>`, not a `std::string::String`.
+    let address = stellar_strkey::ed25519::PublicKey(signing.verifying_key().to_bytes())
+        .to_string()
+        .as_str()
+        .to_owned();
+    (signing, address)
+}
+
+fn sign_b64(signing: &SigningKey, payload: &str) -> String {
+    BASE64.encode(signing.sign(payload.as_bytes()).to_bytes())
+}
+
+fn random_nonce() -> String {
+    Uuid::new_v4().simple().to_string()
+}
+
+fn now_unix() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+/// `ApiError`'s fields are private, so read the status the way a client would.
+fn status_code_of(err: api::error::ApiError) -> u16 {
+    use axum::response::IntoResponse;
+    err.into_response().status().as_u16()
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PURE TESTS: payloads, freshness, verification
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_initiate_payload_is_domain_separated_and_stable() {
+    let payload = initiate_payload(
+        Uuid::nil(),
+        "GFROM",
+        "GTO",
+        1_800_000_000,
+        "nonce1",
+        1_700_000_000,
+    );
+
+    // Pinned literal, not a reconstruction: this format is a wire contract, and changing it
+    // silently invalidates every signature clients have already produced.
+    assert_eq!(
+        payload,
+        "soroban-registry:ownership-transfer:v1:initiate:\
+         00000000-0000-0000-0000-000000000000:GFROM:GTO:1800000000:nonce1:1700000000"
+    );
+}
+
+#[test]
+fn test_decision_payload_distinguishes_accept_from_reject() {
+    let transfer = Uuid::new_v4();
+    let contract = Uuid::new_v4();
+
+    let accept = decision_payload(
+        TransferDecision::Accept,
+        transfer,
+        contract,
+        "GFROM",
+        "GTO",
+        "rnonce",
+        "dnonce",
+        1_700_000_000,
+    );
+    let reject = decision_payload(
+        TransferDecision::Reject,
+        transfer,
+        contract,
+        "GFROM",
+        "GTO",
+        "rnonce",
+        "dnonce",
+        1_700_000_000,
+    );
+
+    assert_ne!(
+        accept, reject,
+        "an acceptance signature must not also be a valid rejection signature"
+    );
+    assert!(accept.contains(":accept:"));
+    assert!(reject.contains(":reject:"));
+}
+
+#[test]
+fn test_initiate_signature_cannot_be_replayed_as_a_decision() {
+    let contract = Uuid::new_v4();
+    let (signing, address) = new_keypair();
+
+    let initiate = initiate_payload(contract, &address, "GTO", 1_800_000_000, "n1", now_unix());
+    let initiate_sig = sign_b64(&signing, &initiate);
+
+    let decision = decision_payload(
+        TransferDecision::Accept,
+        Uuid::new_v4(),
+        contract,
+        &address,
+        "GTO",
+        "n1",
+        "n2",
+        now_unix(),
+    );
+
+    assert!(
+        verify_transfer_signature(&address, &decision, &initiate_sig).is_err(),
+        "a phase-1 signature must not verify against a phase-2 payload"
+    );
+}
+
+#[test]
+fn test_valid_signature_verifies() {
+    let (signing, address) = new_keypair();
+    let payload = initiate_payload(
+        Uuid::new_v4(),
+        &address,
+        "GTO",
+        1_800_000_000,
+        "n",
+        now_unix(),
+    );
+
+    verify_transfer_signature(&address, &payload, &sign_b64(&signing, &payload))
+        .expect("a signature by the account's own key must verify");
+}
+
+#[test]
+fn test_forged_signature_fails_verification() {
+    let (_owner_key, owner_address) = new_keypair();
+    let (attacker_key, _attacker_address) = new_keypair();
+
+    let payload = initiate_payload(
+        Uuid::new_v4(),
+        &owner_address,
+        "GTO",
+        1_800_000_000,
+        "n",
+        now_unix(),
+    );
+    // A perfectly well-formed signature, just by the wrong key.
+    let forged = sign_b64(&attacker_key, &payload);
+
+    let err = verify_transfer_signature(&owner_address, &payload, &forged)
+        .expect_err("a signature by a different key must not verify");
+    assert_eq!(
+        status_code_of(err),
+        422,
+        "a well-formed but non-verifying signature is a 422, not a 400"
+    );
+}
+
+#[test]
+fn test_tampered_payload_fails_verification() {
+    let (signing, address) = new_keypair();
+    let contract = Uuid::new_v4();
+    let (_, recipient) = new_keypair();
+    let (_, attacker) = new_keypair();
+    let signed_at = now_unix();
+
+    let signed = initiate_payload(contract, &address, &recipient, 1_800_000_000, "n", signed_at);
+    let signature = sign_b64(&signing, &signed);
+
+    // The same signature, but the recipient has been swapped for the attacker.
+    let tampered = initiate_payload(contract, &address, &attacker, 1_800_000_000, "n", signed_at);
+
+    assert!(
+        verify_transfer_signature(&address, &tampered, &signature).is_err(),
+        "redirecting the transfer to a different recipient must invalidate the signature"
+    );
+}
+
+#[test]
+fn test_malformed_signature_encoding_is_rejected() {
+    let (_signing, address) = new_keypair();
+    let payload = initiate_payload(
+        Uuid::new_v4(),
+        &address,
+        "GTO",
+        1_800_000_000,
+        "n",
+        now_unix(),
+    );
+
+    let err = verify_transfer_signature(&address, &payload, "not base64 at all !!")
+        .expect_err("an undecodable signature must be rejected");
+    assert_eq!(
+        status_code_of(err),
+        400,
+        "an undecodable signature is a client encoding error"
+    );
+}
+
+#[test]
+fn test_wrong_length_signature_is_rejected() {
+    let (_signing, address) = new_keypair();
+    let payload = initiate_payload(
+        Uuid::new_v4(),
+        &address,
+        "GTO",
+        1_800_000_000,
+        "n",
+        now_unix(),
+    );
+
+    let err = verify_transfer_signature(&address, &payload, &BASE64.encode([7u8; 32]))
+        .expect_err("a 32-byte signature is not an ed25519 signature");
+    assert_eq!(status_code_of(err), 400);
+}
+
+#[test]
+fn test_stale_and_future_signed_at_are_rejected() {
+    let now = 1_700_000_000i64;
+
+    check_signature_freshness(now, now).expect("a signature made now must be accepted");
+    check_signature_freshness(now - 60, now).expect("a one-minute-old signature is fine");
+
+    let stale = check_signature_freshness(now - 86_400, now)
+        .expect_err("a day-old signature must be rejected");
+    assert_eq!(status_code_of(stale), 422);
+
+    let future = check_signature_freshness(now + 86_400, now)
+        .expect_err("a signature dated far in the future must be rejected");
+    assert_eq!(status_code_of(future), 422);
+}
+
+#[test]
+fn test_resolve_algorithm_accepts_only_ed25519() {
+    assert_eq!(resolve_algorithm(None).unwrap(), "ed25519");
+    assert_eq!(resolve_algorithm(Some("")).unwrap(), "ed25519");
+    assert_eq!(resolve_algorithm(Some("ed25519")).unwrap(), "ed25519");
+    assert_eq!(resolve_algorithm(Some("ED25519")).unwrap(), "ed25519");
+
+    // Stellar accounts are ed25519, so a secp256k1 signature could never be checked against
+    // publishers.stellar_address.
+    let err = resolve_algorithm(Some("secp256k1"))
+        .expect_err("secp256k1 must not be accepted for ownership transfers");
+    assert_eq!(status_code_of(err), 400);
+}
+
+#[test]
+fn test_status_serialises_as_snake_case() {
+    // Regression for #1058: Serialize was derived with no rename, so the wire value was
+    // "Pending" while the database column held 'pending'.
+    assert_eq!(
+        serde_json::to_string(&OwnershipTransferStatus::Pending).unwrap(),
+        "\"pending\""
+    );
+    assert_eq!(
+        serde_json::to_string(&OwnershipTransferStatus::Completed).unwrap(),
+        "\"completed\""
+    );
+    assert_eq!(
+        serde_json::from_str::<OwnershipTransferStatus>("\"expired\"").unwrap(),
+        OwnershipTransferStatus::Expired
+    );
+
+    assert_eq!(OwnershipTransferStatus::Pending.as_str(), "pending");
+    assert_eq!(
+        OwnershipTransferStatus::parse("completed"),
+        Some(OwnershipTransferStatus::Completed)
+    );
+    assert_eq!(OwnershipTransferStatus::parse("nonsense"), None);
+    assert!(OwnershipTransferStatus::Pending.is_live());
+    assert!(!OwnershipTransferStatus::Expired.is_live());
+    assert!(!OwnershipTransferStatus::Completed.is_live());
+}
+
+#[test]
+fn test_expiry_window_bounds_are_sane() {
+    assert!(min_expiry_window_secs() > 0);
+    assert!(
+        MAX_EXPIRY_WINDOW_SECS > min_expiry_window_secs(),
+        "the permitted expiry range must be non-empty"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LIVE HTTP FIXTURE
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn api_base_url() -> String {
+    std::env::var("TEST_API_BASE_URL").unwrap_or_else(|_| "http://localhost:3001".to_string())
+}
+
+/// A publisher backed by a real keypair, registered in the database, holding a real JWT.
+struct Actor {
+    signing: SigningKey,
+    address: String,
+    token: String,
+}
+
+fn random_contract_strkey() -> String {
+    let raw = format!(
+        "{:032X}{:032X}",
+        Uuid::new_v4().as_u128(),
+        Uuid::new_v4().as_u128()
+    );
+    format!("C{}", &raw[..55])
+}
+
+/// A minimal but genuinely valid wasm module, unique on every call.
+///
+/// This matters more than it looks. Publishing with no artifact leaves
+/// `artifact_scan_status = 'pending'`, and `publish_contract` then stores the contract as
+/// `private`, which makes `GET /api/contracts/:id` return 403 to everyone including the
+/// publisher itself. Supplying an artifact the scanner passes is what makes the contract
+/// public, which is what lets these tests read the owner back over HTTP and prove ownership
+/// moved. The single custom section exists only to give each artifact a distinct hash.
+fn unique_wasm_module() -> Vec<u8> {
+    let name = Uuid::new_v4().simple().to_string().into_bytes();
+    let mut wasm = Vec::with_capacity(11 + name.len());
+    wasm.extend_from_slice(b"\0asm");
+    wasm.extend_from_slice(&[1, 0, 0, 0]);
+    wasm.push(0x00); // custom section id
+    wasm.push((name.len() + 1) as u8); // section size
+    wasm.push(name.len() as u8); // name length
+    wasm.extend_from_slice(&name);
+    wasm
+}
+
+/// Publish a contract owned by `address`. `publish_contract` upserts `publishers`, which is
+/// how an actor comes to exist at all; returns the contract JSON.
+async fn publish_contract(client: &reqwest::Client, base: &str, address: &str) -> Value {
+    use sha2::{Digest, Sha256};
+
+    let wasm = unique_wasm_module();
+    let wasm_hash = hex::encode(Sha256::digest(&wasm));
+
+    let res = client
+        .post(format!("{}/api/contracts", base))
+        .json(&json!({
+            "contract_id": random_contract_strkey(),
+            "wasm_hash": wasm_hash,
+            "wasm_artifact_base64": BASE64.encode(&wasm),
+            "name": format!("Transfer Test {}", Uuid::new_v4()),
+            "network": "testnet",
+            "publisher_address": address,
+            "tags": []
+        }))
+        .send()
+        .await
+        .expect("publish request failed");
+
+    let status = res.status();
+    let body: Value = res.json().await.expect("publish response was not JSON");
+    assert_eq!(status, StatusCode::OK, "publish failed: {}", body);
+    assert_eq!(
+        body["visibility"], "public",
+        "the fixture depends on the published contract being publicly readable: {}",
+        body
+    );
+    body
+}
+
+/// Complete the challenge/verify handshake and return a bearer token.
+async fn mint_token(
+    client: &reqwest::Client,
+    base: &str,
+    signing: &SigningKey,
+    address: &str,
+) -> String {
+    let challenge: Value = client
+        .get(format!("{}/api/auth/challenge", base))
+        .query(&[("address", address)])
+        .send()
+        .await
+        .expect("challenge request failed")
+        .json()
+        .await
+        .expect("challenge response was not JSON");
+
+    let nonce = challenge["nonce"]
+        .as_str()
+        .unwrap_or_else(|| panic!("challenge response had no nonce: {}", challenge));
+
+    // The challenge handshake signs the raw nonce and hex-encodes both key and signature,
+    // which is a different encoding from the transfer payloads (base64). That is the
+    // existing /api/auth/verify contract, not an inconsistency introduced here.
+    let res = client
+        .post(format!("{}/api/auth/verify", base))
+        .json(&json!({
+            "address": address,
+            "public_key": hex::encode(signing.verifying_key().to_bytes()),
+            "signature": hex::encode(signing.sign(nonce.as_bytes()).to_bytes()),
+        }))
+        .send()
+        .await
+        .expect("verify request failed");
+
+    let status = res.status();
+    let body: Value = res.json().await.expect("verify response was not JSON");
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "auth verify failed (is JWT_SECRET set on the API?): {}",
+        body
+    );
+
+    body["token"]
+        .as_str()
+        .unwrap_or_else(|| panic!("verify response had no token: {}", body))
+        .to_string()
+}
+
+/// A registered, authenticated actor plus the uuid of a contract it owns.
+async fn new_actor_with_contract(client: &reqwest::Client, base: &str) -> (Actor, Uuid) {
+    let (signing, address) = new_keypair();
+    let contract = publish_contract(client, base, &address).await;
+    let contract_id = Uuid::parse_str(contract["id"].as_str().expect("contract id"))
+        .expect("contract id was not a uuid");
+    let token = mint_token(client, base, &signing, &address).await;
+    (
+        Actor {
+            signing,
+            address,
+            token,
+        },
+        contract_id,
+    )
+}
+
+/// A registered, authenticated actor that owns some unrelated contract.
+async fn new_actor(client: &reqwest::Client, base: &str) -> Actor {
+    new_actor_with_contract(client, base).await.0
+}
+
+struct Scenario {
+    client: reqwest::Client,
+    base: String,
+    owner: Actor,
+    recipient: Actor,
     contract_id: Uuid,
-    to_publisher_id: Uuid,
-    user_id: Uuid,
-    expires_in_minutes: i64,
-) -> CreateOwnershipTransferRequest {
-    CreateOwnershipTransferRequest {
+}
+
+async fn scenario() -> Scenario {
+    let client = reqwest::Client::new();
+    let base = api_base_url();
+    let (owner, contract_id) = new_actor_with_contract(&client, &base).await;
+    let recipient = new_actor(&client, &base).await;
+    Scenario {
+        client,
+        base,
+        owner,
+        recipient,
         contract_id,
-        to_publisher_id,
-        expires_at: Utc::now()
-            + chrono::Duration::minutes(expires_in_minutes),
-        user_id,
     }
 }
 
-fn make_confirm_req(transfer_id: Uuid, user_id: Uuid, accept: bool) -> ConfirmOwnershipTransferRequest {
-    ConfirmOwnershipTransferRequest {
+/// A signed create body, plus the nonce it used (phase 2 has to reference it).
+fn create_body(
+    owner: &Actor,
+    recipient_address: &str,
+    contract_id: Uuid,
+    ttl_secs: i64,
+) -> (Value, String) {
+    let nonce = random_nonce();
+    let signed_at = now_unix();
+    let expires_at = signed_at + ttl_secs;
+    let payload = initiate_payload(
+        contract_id,
+        &owner.address,
+        recipient_address,
+        expires_at,
+        &nonce,
+        signed_at,
+    );
+
+    (
+        json!({
+            "to_publisher_address": recipient_address,
+            "expires_at_unix": expires_at,
+            "nonce": nonce,
+            "signed_at_unix": signed_at,
+            "signature": sign_b64(&owner.signing, &payload),
+        }),
+        nonce,
+    )
+}
+
+fn decision_body(
+    signer: &SigningKey,
+    accept: bool,
+    transfer_id: Uuid,
+    contract_id: Uuid,
+    from_address: &str,
+    to_address: &str,
+    request_nonce: &str,
+) -> Value {
+    let nonce = random_nonce();
+    let signed_at = now_unix();
+    let payload = decision_payload(
+        TransferDecision::from_accept_flag(accept),
         transfer_id,
-        accept,
-        user_id,
+        contract_id,
+        from_address,
+        to_address,
+        request_nonce,
+        &nonce,
+        signed_at,
+    );
+
+    json!({
+        "accept": accept,
+        "nonce": nonce,
+        "signed_at_unix": signed_at,
+        "signature": sign_b64(signer, &payload),
+    })
+}
+
+/// The recipient's acceptance of `transfer_id`, freshly signed.
+fn accept_body(sc: &Scenario, transfer_id: Uuid, request_nonce: &str) -> Value {
+    decision_body(
+        &sc.recipient.signing,
+        true,
+        transfer_id,
+        sc.contract_id,
+        &sc.owner.address,
+        &sc.recipient.address,
+        request_nonce,
+    )
+}
+
+/// The recipient's rejection of `transfer_id`, freshly signed.
+fn reject_body(sc: &Scenario, transfer_id: Uuid, request_nonce: &str) -> Value {
+    decision_body(
+        &sc.recipient.signing,
+        false,
+        transfer_id,
+        sc.contract_id,
+        &sc.owner.address,
+        &sc.recipient.address,
+        request_nonce,
+    )
+}
+
+async fn post_create(sc: &Scenario, token: Option<&str>, body: &Value) -> (StatusCode, Value) {
+    let mut req = sc.client.post(format!(
+        "{}/api/contracts/{}/ownership-transfer",
+        sc.base, sc.contract_id
+    ));
+    if let Some(token) = token {
+        req = req.bearer_auth(token);
+    }
+    let res = req.json(body).send().await.expect("create request failed");
+    let status = res.status();
+    let body = res.json().await.unwrap_or(Value::Null);
+    (status, body)
+}
+
+async fn post_confirm(
+    sc: &Scenario,
+    transfer_id: Uuid,
+    token: Option<&str>,
+    body: &Value,
+) -> (StatusCode, Value) {
+    let mut req = sc.client.post(format!(
+        "{}/api/ownership-transfers/{}/confirm",
+        sc.base, transfer_id
+    ));
+    if let Some(token) = token {
+        req = req.bearer_auth(token);
+    }
+    let res = req.json(body).send().await.expect("confirm request failed");
+    let status = res.status();
+    let body = res.json().await.unwrap_or(Value::Null);
+    (status, body)
+}
+
+async fn get_json(client: &reqwest::Client, url: String) -> Value {
+    client
+        .get(&url)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {} failed: {}", url, e))
+        .json()
+        .await
+        .unwrap_or_else(|e| panic!("GET {} returned non-JSON: {}", url, e))
+}
+
+async fn current_owner(sc: &Scenario) -> String {
+    let contract = get_json(
+        &sc.client,
+        format!("{}/api/contracts/{}", sc.base, sc.contract_id),
+    )
+    .await;
+    contract["publisher_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("contract response had no publisher_id: {}", contract))
+        .to_string()
+}
+
+async fn get_transfer(sc: &Scenario, transfer_id: Uuid) -> Value {
+    get_json(
+        &sc.client,
+        format!("{}/api/ownership-transfers/{}", sc.base, transfer_id),
+    )
+    .await
+}
+
+async fn get_logs(sc: &Scenario, transfer_id: Uuid) -> Vec<Value> {
+    get_json(
+        &sc.client,
+        format!("{}/api/ownership-transfers/{}/logs", sc.base, transfer_id),
+    )
+    .await
+    .as_array()
+    .cloned()
+    .unwrap_or_default()
+}
+
+// A note on the error codes asserted below. The specific name a handler passes to
+// `ApiError::conflict("TransferExpired", ...)` lands in the envelope's `code` field, and
+// `error::normalize_error_code` is supposed to convert it to SCREAMING_SNAKE_CASE. It does
+// not: the branch that would insert an underscore tests whether the previous character of
+// the *already uppercased* output is lowercase, which it never is. So PascalCase names come
+// out squashed, e.g. TRANSFEREXPIRED. These tests assert what the API actually emits. The
+// handlers keep passing PascalCase to stay consistent with the ~100 other handler modules;
+// fixing the normaliser would change every error code the API emits and belongs in its own
+// change.
+fn log_actions(logs: &[Value]) -> Vec<String> {
+    logs.iter()
+        .map(|l| l["action"].as_str().unwrap_or("").to_string())
+        .collect()
+}
+
+/// Open a transfer and return `(transfer_id, request_nonce)`.
+async fn open_transfer(sc: &Scenario, ttl_secs: i64) -> (Uuid, String) {
+    let (body, nonce) = create_body(&sc.owner, &sc.recipient.address, sc.contract_id, ttl_secs);
+    let (status, created) = post_create(sc, Some(&sc.owner.token), &body).await;
+    assert_eq!(status, StatusCode::OK, "create failed: {}", created);
+    let id = Uuid::parse_str(created["id"].as_str().expect("transfer id")).unwrap();
+    (id, nonce)
+}
+
+/// The shortest transfer the server will accept, and how long to wait for it to lapse.
+fn short_ttl() -> (i64, std::time::Duration) {
+    let ttl = min_expiry_window_secs();
+    (ttl, std::time::Duration::from_secs(ttl as u64 + 2))
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC1: ownership changes only after both signatures are verified
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_two_phase_transfer_moves_ownership_only_after_both_signatures() {
+    let sc = scenario().await;
+    let owner_before = current_owner(&sc).await;
+
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
+
+    // One signature: the request exists, ownership has not moved.
+    let pending = get_transfer(&sc, transfer_id).await;
+    assert_eq!(pending["status"], "pending");
+    assert_eq!(pending["from_confirmation"], true);
+    assert_eq!(pending["to_confirmation"], false);
+    assert!(
+        pending["from_signature"].is_string(),
+        "the sender's signature must be recorded on the row"
+    );
+    assert!(pending["decision_signature"].is_null());
+    assert_eq!(
+        current_owner(&sc).await,
+        owner_before,
+        "ownership must not move on a one-sided request"
+    );
+
+    // Second signature: ownership moves.
+    let body = accept_body(&sc, transfer_id, &request_nonce);
+    let (status, completed) =
+        post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &body).await;
+    assert_eq!(status, StatusCode::OK, "accept failed: {}", completed);
+    assert_eq!(completed["status"], "completed");
+    assert_eq!(completed["to_confirmation"], true);
+
+    let owner_after = current_owner(&sc).await;
+    assert_ne!(owner_after, owner_before, "ownership should have moved");
+    assert_eq!(
+        owner_after,
+        completed["to_publisher_id"].as_str().unwrap(),
+        "the contract must now be owned by the transfer recipient"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC2: expired requests cannot be accepted, including under a race
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_expired_transfer_cannot_be_accepted() {
+    let sc = scenario().await;
+    let (ttl, wait) = short_ttl();
+    let (transfer_id, request_nonce) = open_transfer(&sc, ttl).await;
+
+    tokio::time::sleep(wait).await;
+
+    let body = accept_body(&sc, transfer_id, &request_nonce);
+    let (status, err) = post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &body).await;
+
+    assert_eq!(status, StatusCode::CONFLICT, "expected a 409, got {}", err);
+    assert_eq!(err["code"], "TRANSFEREXPIRED");
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_expired_accept_leaves_no_partial_transfer() {
+    let sc = scenario().await;
+    let owner_before = current_owner(&sc).await;
+    let (ttl, wait) = short_ttl();
+    let (transfer_id, request_nonce) = open_transfer(&sc, ttl).await;
+
+    tokio::time::sleep(wait).await;
+
+    let body = accept_body(&sc, transfer_id, &request_nonce);
+    post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &body).await;
+
+    // The transfer must be terminally expired, the contract untouched, and the history must
+    // not claim a completion. A partial write shows up as exactly one of these three
+    // disagreeing with the other two.
+    let row = get_transfer(&sc, transfer_id).await;
+    assert_eq!(row["status"], "expired");
+    assert_eq!(row["to_confirmation"], false);
+    assert!(row["decision_signature"].is_null());
+    assert_eq!(current_owner(&sc).await, owner_before);
+
+    let actions = log_actions(&get_logs(&sc, transfer_id).await);
+    assert!(actions.contains(&"transfer_expired".to_string()));
+    assert!(
+        !actions.contains(&"transfer_completed".to_string()),
+        "history must not record a completion for an expired transfer: {:?}",
+        actions
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_concurrent_accepts_complete_exactly_once() {
+    let sc = scenario().await;
+    let owner_before = current_owner(&sc).await;
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
+
+    // Ten independently signed acceptances, each with its own nonce, fired at once. Exactly
+    // one must win, and ownership must move exactly once.
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let client = sc.client.clone();
+        let base = sc.base.clone();
+        let token = sc.recipient.token.clone();
+        let body = accept_body(&sc, transfer_id, &request_nonce);
+        handles.push(tokio::spawn(async move {
+            let res = client
+                .post(format!(
+                    "{}/api/ownership-transfers/{}/confirm",
+                    base, transfer_id
+                ))
+                .bearer_auth(token)
+                .json(&body)
+                .send()
+                .await
+                .expect("concurrent confirm request failed");
+            let status = res.status();
+            let body: Value = res.json().await.unwrap_or(Value::Null);
+            (status, body)
+        }));
+    }
+
+    let mut accepted = 0;
+    let mut conflicted = 0;
+    for handle in handles {
+        let (status, body) = handle.await.expect("confirm task panicked");
+        match status {
+            StatusCode::OK => accepted += 1,
+            StatusCode::CONFLICT => conflicted += 1,
+            other => panic!(
+                "unexpected status {} from a concurrent accept: {}",
+                other, body
+            ),
+        }
+    }
+
+    assert_eq!(accepted, 1, "exactly one acceptance may succeed");
+    assert_eq!(conflicted, 9, "the other nine must be rejected as conflicts");
+
+    let row = get_transfer(&sc, transfer_id).await;
+    assert_eq!(row["status"], "completed");
+
+    let actions = log_actions(&get_logs(&sc, transfer_id).await);
+    assert_eq!(
+        actions
+            .iter()
+            .filter(|a| a.as_str() == "transfer_completed")
+            .count(),
+        1,
+        "history must record exactly one completion: {:?}",
+        actions
+    );
+
+    let owner_after = current_owner(&sc).await;
+    assert_ne!(owner_after, owner_before);
+    assert_eq!(owner_after, row["to_publisher_id"].as_str().unwrap());
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_double_accept_returns_conflict() {
+    let sc = scenario().await;
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
+
+    let first = accept_body(&sc, transfer_id, &request_nonce);
+    let (status, body) = post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &first).await;
+    assert_eq!(status, StatusCode::OK, "first accept failed: {}", body);
+
+    // A freshly signed, entirely valid second acceptance still must not apply.
+    let second = accept_body(&sc, transfer_id, &request_nonce);
+    let (status, err) = post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &second).await;
+    assert_eq!(status, StatusCode::CONFLICT, "expected a 409, got {}", err);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC3: history and provenance
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_transfer_history_is_queryable_per_contract() {
+    let sc = scenario().await;
+
+    // A rejected attempt, then a completed one. Both must remain visible: the history is
+    // append-only, so a rejection is not erased by a later success.
+    let (rejected_id, rejected_nonce) = open_transfer(&sc, 3_600).await;
+    let reject = reject_body(&sc, rejected_id, &rejected_nonce);
+    let (status, body) = post_confirm(&sc, rejected_id, Some(&sc.recipient.token), &reject).await;
+    assert_eq!(status, StatusCode::OK, "reject failed: {}", body);
+
+    let (completed_id, completed_nonce) = open_transfer(&sc, 3_600).await;
+    let accept = accept_body(&sc, completed_id, &completed_nonce);
+    let (status, body) = post_confirm(&sc, completed_id, Some(&sc.recipient.token), &accept).await;
+    assert_eq!(status, StatusCode::OK, "accept failed: {}", body);
+
+    let history = get_json(
+        &sc.client,
+        format!(
+            "{}/api/contracts/{}/ownership-transfer",
+            sc.base, sc.contract_id
+        ),
+    )
+    .await;
+    let rows = history.as_array().expect("history should be an array");
+    assert_eq!(rows.len(), 2, "both attempts must be retained: {}", history);
+
+    let pairs: Vec<(String, String)> = rows
+        .iter()
+        .map(|r| {
+            (
+                r["id"].as_str().unwrap_or_default().to_string(),
+                r["status"].as_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect();
+
+    assert!(
+        pairs
+            .iter()
+            .any(|(id, st)| id == &rejected_id.to_string() && st == "rejected"),
+        "the rejected attempt must still be in the history: {:?}",
+        pairs
+    );
+    assert!(
+        pairs
+            .iter()
+            .any(|(id, st)| id == &completed_id.to_string() && st == "completed"),
+        "the completed transfer must be in the history: {:?}",
+        pairs
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_stored_signatures_verify_offline() {
+    let sc = scenario().await;
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
+    let body = accept_body(&sc, transfer_id, &request_nonce);
+    let (status, completed) =
+        post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &body).await;
+    assert_eq!(status, StatusCode::OK, "accept failed: {}", completed);
+
+    // This is the point of storing the payloads: a third party can take the row and check
+    // both signatures with nothing but ed25519 and the Stellar addresses. Deliberately no
+    // call into the crate's verification code, so the check is genuinely independent.
+    for (payload_field, signature_field, address_field) in [
+        (
+            "from_signed_payload",
+            "from_signature",
+            "from_signer_address",
+        ),
+        (
+            "decision_signed_payload",
+            "decision_signature",
+            "decision_signer_address",
+        ),
+    ] {
+        let payload = completed[payload_field]
+            .as_str()
+            .unwrap_or_else(|| panic!("{} missing: {}", payload_field, completed));
+        let signature_b64 = completed[signature_field]
+            .as_str()
+            .unwrap_or_else(|| panic!("{} missing", signature_field));
+        let address = completed[address_field]
+            .as_str()
+            .unwrap_or_else(|| panic!("{} missing", address_field));
+
+        let key_bytes = stellar_strkey::ed25519::PublicKey::from_string(address)
+            .expect("stored signer address must be a valid strkey")
+            .0;
+        let verifying = VerifyingKey::from_bytes(&key_bytes).expect("valid ed25519 key");
+        let signature_bytes: [u8; 64] = BASE64
+            .decode(signature_b64)
+            .expect("stored signature must be base64")
+            .try_into()
+            .expect("stored signature must be 64 bytes");
+
+        verifying
+            .verify_strict(
+                payload.as_bytes(),
+                &ed25519_dalek::Signature::from_bytes(&signature_bytes),
+            )
+            .unwrap_or_else(|e| {
+                panic!("stored {} did not verify offline: {}", signature_field, e)
+            });
+    }
+
+    // And the two signatures come from genuinely different accounts (invariant I1).
+    assert_ne!(
+        completed["from_signer_address"], completed["decision_signer_address"],
+        "a completed transfer must carry signatures from two distinct accounts"
+    );
+    assert_eq!(completed["from_signer_address"], json!(sc.owner.address));
+    assert_eq!(
+        completed["decision_signer_address"],
+        json!(sc.recipient.address)
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_transfer_logs_contain_full_provenance_chain() {
+    let sc = scenario().await;
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
+    let body = accept_body(&sc, transfer_id, &request_nonce);
+    post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &body).await;
+
+    let logs = get_logs(&sc, transfer_id).await;
+    assert_eq!(
+        log_actions(&logs),
+        vec!["transfer_request_created", "transfer_completed"],
+        "the chain must record both phases, in order"
+    );
+
+    for entry in &logs {
+        assert_eq!(entry["actor_type"], "publisher");
+        assert!(
+            entry["actor_id"].is_string(),
+            "a publisher action must name the acting publisher: {}",
+            entry
+        );
+        assert!(
+            entry["details"]["signed_payload"].is_string(),
+            "each phase must record what was actually signed: {}",
+            entry
+        );
     }
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Expiry Tests
-// ─────────────────────────────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════════════════════════
+// AC4: rejected, forged, and unauthorized attempts
+// ═══════════════════════════════════════════════════════════════════════════
 
-#[test]
-fn test_transfer_expires_when_expires_at_is_in_past() {
-    let now = Utc::now();
-    let expired = now - chrono::Duration::minutes(10);
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_rejected_transfer_cannot_be_accepted() {
+    let sc = scenario().await;
+    let owner_before = current_owner(&sc).await;
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
 
-    let req = CreateOwnershipTransferRequest {
-        contract_id: Uuid::new_v4(),
-        to_publisher_id: Uuid::new_v4(),
-        expires_at: expired,
-        user_id: Uuid::new_v4(),
-    };
+    let reject = reject_body(&sc, transfer_id, &request_nonce);
+    let (status, rejected) =
+        post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &reject).await;
+    assert_eq!(status, StatusCode::OK, "reject failed: {}", rejected);
+    assert_eq!(rejected["status"], "rejected");
 
-    assert!(
-        req.expires_at <= Utc::now(),
-        "Transfer request with past expiry should be treated as expired"
+    let accept = accept_body(&sc, transfer_id, &request_nonce);
+    let (status, err) = post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &accept).await;
+    assert_eq!(status, StatusCode::CONFLICT, "expected a 409, got {}", err);
+    assert_eq!(
+        current_owner(&sc).await,
+        owner_before,
+        "a rejected transfer must never move ownership"
     );
 }
 
-#[test]
-fn test_transfer_is_valid_when_expires_in_future() {
-    let req = make_create_req(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4(), 60);
-    assert!(
-        req.expires_at > Utc::now(),
-        "Transfer request with future expiry should be valid"
-    );
-}
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_accept_with_wrong_key_signature_is_rejected() {
+    let sc = scenario().await;
+    let owner_before = current_owner(&sc).await;
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
 
-#[test]
-fn test_expired_transfer_is_rejected_by_confirm_handler() {
-    let transfer_id = Uuid::new_v4();
-
-    let req = ConfirmOwnershipTransferRequest {
+    // The recipient's own JWT, but the payload is signed by somebody else's key. Proving
+    // session control must not be sufficient on its own.
+    let (attacker_key, _) = new_keypair();
+    let body = decision_body(
+        &attacker_key,
+        true,
         transfer_id,
-        accept: true,
-        user_id: Uuid::new_v4(),
-    };
+        sc.contract_id,
+        &sc.owner.address,
+        &sc.recipient.address,
+        &request_nonce,
+    );
+    let (status, err) = post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &body).await;
 
     assert_eq!(
-        req.transfer_id, transfer_id,
-        "Confirmation request should carry the transfer ID"
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "expected a 422, got {}",
+        err
     );
-    assert!(req.accept, "Confirmation should be an acceptance");
-}
+    assert_eq!(err["code"], "SIGNATUREVERIFICATIONFAILED");
 
-// ─────────────────────────────────────────────────────────────────────
-// Duplicate Transfer Tests
-// ─────────────────────────────────────────────────────────────────────
-
-#[test]
-fn test_duplicate_pending_transfer_is_rejected() {
-    let contract_id = Uuid::new_v4();
-
-    let first_req = make_create_req(contract_id, Uuid::new_v4(), Uuid::new_v4(), 60);
-    let second_req = make_create_req(contract_id, Uuid::new_v4(), Uuid::new_v4(), 60);
-
+    let row = get_transfer(&sc, transfer_id).await;
     assert_eq!(
-        first_req.contract_id, second_req.contract_id,
-        "Both requests target the same contract — duplicate detected"
+        row["status"], "pending",
+        "a forged signature must leave the transfer untouched"
     );
-    assert_ne!(
-        first_req.to_publisher_id, second_req.to_publisher_id,
-        "Different recipients but same contract still counts as duplicate pending transfer"
-    );
-}
-
-#[test]
-fn test_same_sender_and_recipient_is_rejected() {
-    let publisher_id = Uuid::new_v4();
-
-    let req = make_create_req(Uuid::new_v4(), publisher_id, publisher_id, 60);
-
+    assert_eq!(row["to_confirmation"], false);
+    assert_eq!(current_owner(&sc).await, owner_before);
     assert_eq!(
-        req.to_publisher_id, req.user_id,
-        "Sender and recipient must be different accounts"
+        log_actions(&get_logs(&sc, transfer_id).await),
+        vec!["transfer_request_created"],
+        "a forged attempt must not append to the history"
     );
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Rejected Transfer Tests
-// ─────────────────────────────────────────────────────────────────────
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_accept_without_jwt_is_unauthorized() {
+    let sc = scenario().await;
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
 
-#[test]
-fn test_rejected_transfer_cannot_be_confirmed() {
-    let transfer_id = Uuid::new_v4();
-    let user_id = Uuid::new_v4();
-
-    let reject_req = make_confirm_req(transfer_id, user_id, false);
-
-    assert!(!reject_req.accept, "Rejection is represented by accept=false");
-    assert_eq!(reject_req.transfer_id, transfer_id);
+    let body = accept_body(&sc, transfer_id, &request_nonce);
+    let (status, _) = post_confirm(&sc, transfer_id, None, &body).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
 
-#[test]
-fn test_non_sender_or_recipient_cannot_confirm() {
-    let from_publisher = Uuid::new_v4();
-    let to_publisher = Uuid::new_v4();
-    let outsider = Uuid::new_v4();
-    let transfer_id = Uuid::new_v4();
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_reject_by_third_party_is_forbidden() {
+    // Regression for #1058: the is_from/is_to check lived only inside the accept branch, so
+    // any caller at all could reject any pending transfer.
+    let sc = scenario().await;
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
+    let stranger = new_actor(&sc.client, &sc.base).await;
 
-    let req = make_confirm_req(transfer_id, outsider, true);
-
-    assert_ne!(
-        req.user_id, from_publisher,
-        "Outsider user is not the sender"
-    );
-    assert_ne!(
-        req.user_id, to_publisher,
-        "Outsider user is not the recipient"
-    );
-    assert!(
-        req.accept,
-        "Outsider is trying to accept, but should be forbidden"
-    );
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Successful Confirmation Flow Tests
-// ─────────────────────────────────────────────────────────────────────
-
-#[test]
-fn test_both_sides_confirmation_completes_transfer() {
-    let contract_id = Uuid::new_v4();
-    let from_publisher = Uuid::new_v4();
-    let to_publisher = Uuid::new_v4();
-
-    let create_req = make_create_req(contract_id, to_publisher, from_publisher, 60);
-
-    assert_eq!(create_req.contract_id, contract_id);
-    assert_eq!(create_req.to_publisher_id, to_publisher);
-    assert_eq!(create_req.user_id, from_publisher);
-
-    let transfer_id = Uuid::new_v4();
-
-    let sender_confirm = make_confirm_req(transfer_id, from_publisher, true);
-    assert_eq!(sender_confirm.user_id, from_publisher);
-
-    let recipient_confirm = make_confirm_req(transfer_id, to_publisher, true);
-    assert_eq!(recipient_confirm.user_id, to_publisher);
-
-    let req = CreateOwnershipTransferRequest {
-        contract_id,
-        to_publisher_id: to_publisher,
-        expires_at: Utc::now() + chrono::Duration::minutes(60),
-        user_id: from_publisher,
-    };
-
-    assert!(
-        req.expires_at > Utc::now(),
-        "Transfer must not be expired when created"
-    );
-}
-
-#[test]
-fn test_partial_confirmation_marks_transfer_as_confirmed() {
-    let transfer_id = Uuid::new_v4();
-    let from_publisher = Uuid::new_v4();
-
-    let sender_confirm = make_confirm_req(transfer_id, from_publisher, true);
-    assert!(sender_confirm.accept);
-
-    let req = ConfirmOwnershipTransferRequest {
+    let body = decision_body(
+        &stranger.signing,
+        false,
         transfer_id,
-        accept: true,
-        user_id: from_publisher,
-    };
+        sc.contract_id,
+        &sc.owner.address,
+        &sc.recipient.address,
+        &request_nonce,
+    );
+    let (status, err) = post_confirm(&sc, transfer_id, Some(&stranger.token), &body).await;
 
-    assert_eq!(req.user_id, from_publisher);
-    assert_eq!(req.transfer_id, transfer_id);
+    assert_eq!(status, StatusCode::FORBIDDEN, "expected a 403, got {}", err);
+    assert_eq!(get_transfer(&sc, transfer_id).await["status"], "pending");
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// OwnershipTransferStatus Display Tests
-// ─────────────────────────────────────────────────────────────────────
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_accept_by_sender_is_forbidden() {
+    // The sender's consent is already the phase-1 signature. Letting the sender also accept
+    // would collapse two-party confirmation back into a single-party ownership change.
+    let sc = scenario().await;
+    let owner_before = current_owner(&sc).await;
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
 
-#[test]
-fn test_ownership_transfer_status_display() {
-    assert_eq!(
-        OwnershipTransferStatus::Pending.to_string(),
-        "pending"
+    let body = decision_body(
+        &sc.owner.signing,
+        true,
+        transfer_id,
+        sc.contract_id,
+        &sc.owner.address,
+        &sc.recipient.address,
+        &request_nonce,
     );
-    assert_eq!(
-        OwnershipTransferStatus::Confirmed.to_string(),
-        "confirmed"
+    let (status, err) = post_confirm(&sc, transfer_id, Some(&sc.owner.token), &body).await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN, "expected a 403, got {}", err);
+    assert_eq!(current_owner(&sc).await, owner_before);
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_sender_can_cancel_pending_transfer() {
+    // Documented assumption: the sender may withdraw a mistaken transfer with a signed
+    // rejection rather than waiting for it to expire.
+    let sc = scenario().await;
+    let (transfer_id, request_nonce) = open_transfer(&sc, 3_600).await;
+
+    let body = decision_body(
+        &sc.owner.signing,
+        false,
+        transfer_id,
+        sc.contract_id,
+        &sc.owner.address,
+        &sc.recipient.address,
+        &request_nonce,
     );
-    assert_eq!(
-        OwnershipTransferStatus::Completed.to_string(),
-        "completed"
+    let (status, cancelled) = post_confirm(&sc, transfer_id, Some(&sc.owner.token), &body).await;
+
+    assert_eq!(status, StatusCode::OK, "sender cancel failed: {}", cancelled);
+    assert_eq!(cancelled["status"], "rejected");
+    assert_eq!(cancelled["decision_signer_address"], json!(sc.owner.address));
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_create_by_non_owner_is_forbidden() {
+    let sc = scenario().await;
+    let stranger = new_actor(&sc.client, &sc.base).await;
+
+    // A stranger signing correctly with their own key, for a contract they do not own.
+    let nonce = random_nonce();
+    let signed_at = now_unix();
+    let expires_at = signed_at + 3_600;
+    let payload = initiate_payload(
+        sc.contract_id,
+        &stranger.address,
+        &sc.recipient.address,
+        expires_at,
+        &nonce,
+        signed_at,
     );
+    let body = json!({
+        "to_publisher_address": sc.recipient.address,
+        "expires_at_unix": expires_at,
+        "nonce": nonce,
+        "signed_at_unix": signed_at,
+        "signature": sign_b64(&stranger.signing, &payload),
+    });
+
+    let (status, err) = post_create(&sc, Some(&stranger.token), &body).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "expected a 403, got {}", err);
+    assert_eq!(err["code"], "NOTCONTRACTOWNER");
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_create_without_jwt_is_unauthorized() {
+    let sc = scenario().await;
+    let (body, _) = create_body(&sc.owner, &sc.recipient.address, sc.contract_id, 3_600);
+    let (status, _) = post_create(&sc, None, &body).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_duplicate_pending_transfer_returns_409_not_500() {
+    // Regression for #1058: the duplicate branch wrote a history row against a random
+    // Uuid::new_v4() with no parent transfer, so the foreign key fired and the caller got a
+    // 500 instead of the intended conflict.
+    let sc = scenario().await;
+    let (_first_id, _) = open_transfer(&sc, 3_600).await;
+
+    let (body, _) = create_body(&sc.owner, &sc.recipient.address, sc.contract_id, 3_600);
+    let (status, err) = post_create(&sc, Some(&sc.owner.token), &body).await;
+
+    assert_eq!(status, StatusCode::CONFLICT, "expected a 409, got {}", err);
+    assert_eq!(err["code"], "DUPLICATETRANSFER");
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_replayed_create_body_is_rejected_by_nonce() {
+    let sc = scenario().await;
+    let (body, request_nonce) =
+        create_body(&sc.owner, &sc.recipient.address, sc.contract_id, 3_600);
+
+    let (status, created) = post_create(&sc, Some(&sc.owner.token), &body).await;
+    assert_eq!(status, StatusCode::OK, "create failed: {}", created);
+    let transfer_id = Uuid::parse_str(created["id"].as_str().unwrap()).unwrap();
+
+    // Clear the live-transfer conflict so the nonce is the only thing left that can stop a
+    // replay: reject the first transfer, then resend the identical create body.
+    let reject = reject_body(&sc, transfer_id, &request_nonce);
+    let (status, rejected) =
+        post_confirm(&sc, transfer_id, Some(&sc.recipient.token), &reject).await;
+    assert_eq!(status, StatusCode::OK, "reject failed: {}", rejected);
+
+    let (status, err) = post_create(&sc, Some(&sc.owner.token), &body).await;
+    assert_eq!(status, StatusCode::CONFLICT, "expected a 409, got {}", err);
+    assert_eq!(err["code"], "NONCEALREADYUSED");
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_self_transfer_is_rejected() {
+    let sc = scenario().await;
+    let (body, _) = create_body(&sc.owner, &sc.owner.address, sc.contract_id, 3_600);
+    let (status, err) = post_create(&sc, Some(&sc.owner.token), &body).await;
     assert_eq!(
-        OwnershipTransferStatus::Expired.to_string(),
-        "expired"
-    );
-    assert_eq!(
-        OwnershipTransferStatus::Rejected.to_string(),
-        "rejected"
-    );
-    assert_eq!(
-        OwnershipTransferStatus::Duplicate.to_string(),
-        "duplicate"
+        status,
+        StatusCode::BAD_REQUEST,
+        "expected a 400, got {}",
+        err
     );
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Transfer Request Validation Tests
-// ─────────────────────────────────────────────────────────────────────
-
-#[test]
-fn test_create_transfer_request_requires_valid_contract() {
-    let invalid_contract_id = Uuid::new_v4();
-    let to_publisher = Uuid::new_v4();
-    let user_id = Uuid::new_v4();
-
-    let req = make_create_req(invalid_contract_id, to_publisher, user_id, 60);
-    assert_eq!(req.contract_id, invalid_contract_id);
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_unregistered_recipient_is_not_found() {
+    let sc = scenario().await;
+    let (_unknown_key, unknown_address) = new_keypair();
+    let (body, _) = create_body(&sc.owner, &unknown_address, sc.contract_id, 3_600);
+    let (status, err) = post_create(&sc, Some(&sc.owner.token), &body).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "expected a 404, got {}", err);
 }
 
-#[test]
-fn test_create_transfer_request_requires_valid_target_publisher() {
-    let contract_id = Uuid::new_v4();
-    let invalid_publisher = Uuid::new_v4();
-    let user_id = Uuid::new_v4();
-
-    let req = make_create_req(contract_id, invalid_publisher, user_id, 60);
-    assert_eq!(req.to_publisher_id, invalid_publisher);
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Expiry Boundary Tests
-// ─────────────────────────────────────────────────────────────────────
-
-#[test]
-fn test_transfer_with_zero_minute_expiry_is_already_expired() {
-    let req = make_create_req(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4(), 0);
-
-    assert!(
-        req.expires_at <= Utc::now() + chrono::Duration::seconds(1),
-        "Transfer with 0 minute expiry should be essentially already expired"
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_expiry_beyond_the_maximum_window_is_rejected() {
+    let sc = scenario().await;
+    let (body, _) = create_body(
+        &sc.owner,
+        &sc.recipient.address,
+        sc.contract_id,
+        MAX_EXPIRY_WINDOW_SECS + 3_600,
     );
+    let (status, err) = post_create(&sc, Some(&sc.owner.token), &body).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "expected a 400, got {}",
+        err
+    );
+    assert_eq!(err["code"], "INVALIDEXPIRY");
 }
 
-#[test]
-fn test_transfer_with_negative_expiry_is_expired() {
-    let expired = Utc::now() - chrono::Duration::minutes(1);
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_stale_signature_is_rejected_at_the_endpoint() {
+    let sc = scenario().await;
 
-    let req = CreateOwnershipTransferRequest {
-        contract_id: Uuid::new_v4(),
-        to_publisher_id: Uuid::new_v4(),
-        expires_at: expired,
-        user_id: Uuid::new_v4(),
-    };
-
-    assert!(
-        req.expires_at < Utc::now(),
-        "Transfer with past expiry should be treated as expired"
+    // Correctly signed by the right key, but dated a day ago.
+    let nonce = random_nonce();
+    let signed_at = now_unix() - 86_400;
+    let expires_at = now_unix() + 3_600;
+    let payload = initiate_payload(
+        sc.contract_id,
+        &sc.owner.address,
+        &sc.recipient.address,
+        expires_at,
+        &nonce,
+        signed_at,
     );
+    let body = json!({
+        "to_publisher_address": sc.recipient.address,
+        "expires_at_unix": expires_at,
+        "nonce": nonce,
+        "signed_at_unix": signed_at,
+        "signature": sign_b64(&sc.owner.signing, &payload),
+    });
+
+    let (status, err) = post_create(&sc, Some(&sc.owner.token), &body).await;
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "expected a 422, got {}",
+        err
+    );
+    assert_eq!(err["code"], "SIGNATUREEXPIRED");
+}
+
+#[tokio::test]
+#[ignore = "requires running API + database"]
+async fn test_expired_transfer_is_reported_as_expired_on_read() {
+    // Lazy expiry: a read must never present a past-due transfer as still actionable, even
+    // if the background sweeper has not run yet.
+    let sc = scenario().await;
+    let (ttl, wait) = short_ttl();
+    let (transfer_id, _) = open_transfer(&sc, ttl).await;
+
+    assert_eq!(get_transfer(&sc, transfer_id).await["status"], "pending");
+
+    tokio::time::sleep(wait).await;
+
+    assert_eq!(
+        get_transfer(&sc, transfer_id).await["status"],
+        "expired",
+        "reading a past-due transfer must expire it"
+    );
+    assert!(log_actions(&get_logs(&sc, transfer_id).await)
+        .contains(&"transfer_expired".to_string()));
 }

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -5029,12 +5029,17 @@ pub struct ZkCircuitSummary {
 }
 
 // ═══════════════════════════════════════════════════════════
-// Issue #1058 — Ownership Transfer types
+// Issue #1058 / #1094 — Ownership Transfer types
 // ═══════════════════════════════════════════════════════════
 
 /// Status of an ownership transfer request.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::Type, utoipa::ToSchema)]
-#[sqlx(type_name = "transfer_status", rename_all = "snake_case")]
+///
+/// `pending` means the outgoing publisher's signature has been verified; `completed`
+/// means the recipient's has been verified too and ownership has moved. `confirmed` is
+/// retained for the #1058 wire contract but is unreachable under the current flow, since
+/// a verified acceptance completes the transfer in the same transaction.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum OwnershipTransferStatus {
     Pending,
     Confirmed,
@@ -5044,21 +5049,72 @@ pub enum OwnershipTransferStatus {
     Duplicate,
 }
 
-impl std::fmt::Display for OwnershipTransferStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
+impl OwnershipTransferStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
             Self::Pending => "pending",
             Self::Confirmed => "confirmed",
             Self::Completed => "completed",
             Self::Expired => "expired",
             Self::Rejected => "rejected",
             Self::Duplicate => "duplicate",
-        };
-        write!(f, "{}", s)
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "pending" => Some(Self::Pending),
+            "confirmed" => Some(Self::Confirmed),
+            "completed" => Some(Self::Completed),
+            "expired" => Some(Self::Expired),
+            "rejected" => Some(Self::Rejected),
+            "duplicate" => Some(Self::Duplicate),
+            _ => None,
+        }
+    }
+
+    /// Whether a transfer in this state can still be acted on.
+    pub fn is_live(&self) -> bool {
+        matches!(self, Self::Pending | Self::Confirmed)
+    }
+}
+
+impl std::fmt::Display for OwnershipTransferStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+// `ownership_transfers.status` is VARCHAR(20) constrained by `chk_status`; there is no
+// `transfer_status` Postgres enum. #1058 declared `#[sqlx(type_name = "transfer_status")]`
+// against that column, so decoding any row into `OwnershipTransfer` failed at runtime.
+// Delegate to `String` instead, mirroring `DeprecationStatus` above.
+impl<'r> sqlx::Decode<'r, sqlx::Postgres> for OwnershipTransferStatus {
+    fn decode(
+        value: sqlx::postgres::PgValueRef<'r>,
+    ) -> Result<Self, Box<dyn std::error::Error + 'static + Send + Sync>> {
+        let s = <String as sqlx::Decode<sqlx::Postgres>>::decode(value)?;
+        // Deliberately an error rather than a silent default: this field gates an
+        // authorization-relevant state machine, so an unrecognised value must be loud.
+        Self::parse(&s).ok_or_else(|| format!("unknown ownership transfer status: {}", s).into())
+    }
+}
+
+impl sqlx::Type<sqlx::Postgres> for OwnershipTransferStatus {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        <String as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        <String as sqlx::Type<sqlx::Postgres>>::compatible(ty)
     }
 }
 
 /// A transfer request for contract ownership.
+///
+/// The `*_signature` / `*_signed_payload` pairs are what make a completed transfer
+/// independently auditable: the payload is the exact byte string the party signed, so a
+/// third party can re-verify it against the signer address without trusting this API.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, utoipa::ToSchema)]
 pub struct OwnershipTransfer {
     pub id: Uuid,
@@ -5073,31 +5129,65 @@ pub struct OwnershipTransfer {
     pub confirmed_at: Option<DateTime<Utc>>,
     pub completed_at: Option<DateTime<Utc>>,
     pub created_by: Uuid,
+    pub signature_algorithm: String,
+    pub request_nonce: Option<String>,
+    pub from_signature: Option<String>,
+    pub from_signer_address: Option<String>,
+    pub from_signed_at: Option<DateTime<Utc>>,
+    pub from_signed_payload: Option<String>,
+    pub decision_nonce: Option<String>,
+    pub decision_signature: Option<String>,
+    pub decision_signer_address: Option<String>,
+    pub decision_signed_at: Option<DateTime<Utc>>,
+    pub decision_signed_payload: Option<String>,
+    pub decision_by: Option<Uuid>,
 }
 
-/// Request to create a new ownership transfer.
+/// Request to create a new ownership transfer, signed by the current owner.
+///
+/// The acting identity comes from the bearer token, never from the body — #1058 carried a
+/// `user_id` field here, which let any caller transfer any contract.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct CreateOwnershipTransferRequest {
-    pub contract_id: Uuid,
-    pub to_publisher_id: Uuid,
-    pub expires_at: DateTime<Utc>,
-    pub user_id: Uuid,
+    /// Stellar address (`G...`) of the publisher that will receive ownership.
+    pub to_publisher_address: String,
+    /// Expiry as unix seconds. Unix seconds rather than RFC3339 so the value the client
+    /// signs and the value the server verifies cannot diverge through timezone offset,
+    /// sub-second precision, or trailing-zero formatting.
+    pub expires_at_unix: i64,
+    /// Single-use random token binding this signature to one request. The sender must
+    /// sign before the transfer row exists, so the nonce is what makes the signature
+    /// non-replayable.
+    pub nonce: String,
+    /// When the client produced the signature, unix seconds. Must be within the server's
+    /// freshness window.
+    pub signed_at_unix: i64,
+    /// Base64 (standard alphabet) ed25519 signature over the canonical initiate payload.
+    pub signature: String,
+    /// Only `ed25519` is accepted. Defaults to `ed25519` when omitted.
+    pub signature_algorithm: Option<String>,
 }
 
-/// Request to confirm (accept or reject) an ownership transfer.
+/// Request to confirm (accept or reject) an ownership transfer, signed by the acting party.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ConfirmOwnershipTransferRequest {
-    pub transfer_id: Uuid,
     pub accept: bool,
-    pub user_id: Uuid,
+    /// Single-use random token binding this decision signature.
+    pub nonce: String,
+    pub signed_at_unix: i64,
+    /// Base64 (standard alphabet) ed25519 signature over the canonical accept/reject payload.
+    pub signature: String,
+    /// Only `ed25519` is accepted. Defaults to `ed25519` when omitted.
+    pub signature_algorithm: Option<String>,
 }
 
-/// An event log entry for an ownership transfer.
+/// An event log entry for an ownership transfer. Append-only.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, utoipa::ToSchema)]
 pub struct OwnershipTransferLog {
     pub id: Uuid,
     pub transfer_id: Uuid,
-    pub actor_id: Uuid,
+    /// `None` for system-authored rows, such as the expiry sweeper.
+    pub actor_id: Option<Uuid>,
     pub actor_type: String,
     pub action: String,
     pub details: Option<serde_json::Value>,

--- a/database/migrations/20260727010000_issue1094_ownership_transfer_signatures.sql
+++ b/database/migrations/20260727010000_issue1094_ownership_transfer_signatures.sql
@@ -108,7 +108,7 @@ END $$;
 DO $$ BEGIN
     ALTER TABLE ownership_transfers
         ADD CONSTRAINT chk_ownership_transfers_signature_algorithm
-        CHECK (signature_algorithm = 'ed25519');
+        CHECK (signature_algorithm = 'ed25519') NOT VALID;
 EXCEPTION
     WHEN duplicate_object THEN NULL;
 END $$;

--- a/database/migrations/20260727010000_issue1094_ownership_transfer_signatures.sql
+++ b/database/migrations/20260727010000_issue1094_ownership_transfer_signatures.sql
@@ -113,10 +113,15 @@ EXCEPTION
     WHEN duplicate_object THEN NULL;
 END $$;
 
+-- NOT VALID for the same reason as the constraints above, and this one is the likeliest to
+-- have a non-compliant legacy row: #1058 validated the caller's expiry against the Rust
+-- clock, while created_at defaults to the SQL transaction timestamp a moment later, so a
+-- transfer created with a near-instant expiry could have expires_at <= created_at. A
+-- validated constraint would abort the boot-time migration run over such a row.
 DO $$ BEGIN
     ALTER TABLE ownership_transfers
         ADD CONSTRAINT chk_ownership_transfers_expiry_after_creation
-        CHECK (expires_at > created_at);
+        CHECK (expires_at > created_at) NOT VALID;
 EXCEPTION
     WHEN duplicate_object THEN NULL;
 END $$;

--- a/database/migrations/20260727010000_issue1094_ownership_transfer_signatures.sql
+++ b/database/migrations/20260727010000_issue1094_ownership_transfer_signatures.sql
@@ -1,0 +1,162 @@
+-- Issue #1094
+-- Two-phase ownership transfer with signature-anchored confirmation.
+--
+-- Hardens the issue #1058 ownership-transfer tables so a contract's publisher can only
+-- change after two distinct ed25519 signatures have been verified against the on-chain
+-- Stellar accounts of the outgoing and incoming publishers.
+--
+-- Flow under this migration:
+--   phase 1 (initiate) is signed by the current owner; the row is created directly with
+--            status = 'pending' and from_confirmation = TRUE (one signature verified).
+--   phase 2 (accept / reject) is signed by the recipient; accept moves the row to
+--            'completed' and moves contracts.publisher_id in the same transaction.
+--
+-- Both signed payloads are stored verbatim so any third party can re-verify a completed
+-- transfer offline from the row alone. That is the provenance half of the issue: the
+-- history table records who acted, and these columns record what they actually signed.
+
+-- ── Signature columns ────────────────────────────────────────────────────────
+
+ALTER TABLE ownership_transfers
+    ADD COLUMN IF NOT EXISTS signature_algorithm     VARCHAR(20) NOT NULL DEFAULT 'ed25519',
+    -- Client-supplied nonce binding the phase-1 signature. The sender must sign before
+    -- the row (and therefore its id) exists, so the nonce is what makes that signature
+    -- single-use; see uq_ownership_transfers_request_nonce below.
+    ADD COLUMN IF NOT EXISTS request_nonce           VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS from_signature          TEXT,
+    ADD COLUMN IF NOT EXISTS from_signer_address     VARCHAR(56),
+    ADD COLUMN IF NOT EXISTS from_signed_at          TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS from_signed_payload     TEXT,
+    ADD COLUMN IF NOT EXISTS decision_nonce          VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS decision_signature      TEXT,
+    ADD COLUMN IF NOT EXISTS decision_signer_address VARCHAR(56),
+    ADD COLUMN IF NOT EXISTS decision_signed_at      TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS decision_signed_payload TEXT,
+    ADD COLUMN IF NOT EXISTS decision_by             UUID REFERENCES publishers(id);
+
+COMMENT ON COLUMN ownership_transfers.from_signed_payload IS
+    'Exact ASCII payload the outgoing publisher signed. Retained for offline re-verification.';
+COMMENT ON COLUMN ownership_transfers.decision_signed_payload IS
+    'Exact ASCII payload the recipient signed when accepting or rejecting.';
+
+-- ── Invalidate pre-#1094 in-flight transfers ─────────────────────────────────
+--
+-- Rows created before this migration carry no signatures and therefore cannot satisfy
+-- the new invariants. Expiring them is consistent with the append-only history model:
+-- nothing is deleted, the rows simply reach a terminal state and the parties re-initiate.
+
+UPDATE ownership_transfers
+SET status       = 'expired',
+    completed_at = COALESCE(completed_at, NOW())
+WHERE status IN ('pending', 'confirmed');
+
+-- ── Confirmation-state invariants ────────────────────────────────────────────
+--
+-- Redefined for the new flow: 'pending' now means "the sender has signed", so
+-- from_confirmation is TRUE from the moment the row is inserted. Under #1058 'pending'
+-- required both flags FALSE, which is what made the partial-confirm UPDATE in
+-- handlers.rs violate this very constraint at runtime.
+
+ALTER TABLE ownership_transfers DROP CONSTRAINT IF EXISTS chk_confirmation_logic;
+
+-- NOT VALID: enforced for every insert and every update from here on, but not
+-- retro-checked against legacy rows, so this migration cannot fail the API's
+-- boot-time migration run on an unknown data set.
+ALTER TABLE ownership_transfers
+    ADD CONSTRAINT chk_confirmation_logic CHECK (
+        (status = 'pending'   AND from_confirmation = TRUE AND to_confirmation = FALSE) OR
+        (status = 'confirmed' AND from_confirmation = TRUE AND to_confirmation = TRUE)  OR
+        (status = 'completed' AND from_confirmation = TRUE AND to_confirmation = TRUE)  OR
+        (status IN ('expired', 'rejected', 'duplicate'))
+    ) NOT VALID;
+
+-- Ownership must not be transferable without both signatures on record. Enforcing this
+-- in the database as well as the handler means a future code path cannot quietly skip it.
+DO $$ BEGIN
+    ALTER TABLE ownership_transfers
+        ADD CONSTRAINT chk_ownership_transfer_signature_completeness CHECK (
+            (
+                status = 'pending'
+                AND request_nonce IS NOT NULL
+                AND from_signature IS NOT NULL
+                AND from_signer_address IS NOT NULL
+                AND from_signed_at IS NOT NULL
+                AND from_signed_payload IS NOT NULL
+            ) OR (
+                status IN ('confirmed', 'completed', 'rejected')
+                AND request_nonce IS NOT NULL
+                AND from_signature IS NOT NULL
+                AND from_signer_address IS NOT NULL
+                AND from_signed_at IS NOT NULL
+                AND from_signed_payload IS NOT NULL
+                AND decision_nonce IS NOT NULL
+                AND decision_signature IS NOT NULL
+                AND decision_signer_address IS NOT NULL
+                AND decision_signed_at IS NOT NULL
+                AND decision_signed_payload IS NOT NULL
+                AND decision_by IS NOT NULL
+            ) OR (
+                -- Expiry is a system action with no counter-signature, and 'duplicate'
+                -- is retained only for legacy rows.
+                status IN ('expired', 'duplicate')
+            )
+        ) NOT VALID;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE ownership_transfers
+        ADD CONSTRAINT chk_ownership_transfers_signature_algorithm
+        CHECK (signature_algorithm = 'ed25519');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE ownership_transfers
+        ADD CONSTRAINT chk_ownership_transfers_expiry_after_creation
+        CHECK (expires_at > created_at);
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ── Single-use signatures, single live transfer ──────────────────────────────
+
+-- A captured create body replays at most once: the second attempt trips this index and
+-- the handler maps 23505 to 409 rather than opening a second transfer.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ownership_transfers_request_nonce
+    ON ownership_transfers(request_nonce)
+    WHERE request_nonce IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ownership_transfers_decision_nonce
+    ON ownership_transfers(decision_nonce)
+    WHERE decision_nonce IS NOT NULL;
+
+-- At most one live transfer per contract, enforced by the database rather than by a
+-- read-then-insert in the handler, which two concurrent initiations could both pass.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ownership_transfers_one_live_per_contract
+    ON ownership_transfers(contract_id)
+    WHERE status IN ('pending', 'confirmed');
+
+-- Supports the expiry sweeper's claim query, which only ever scans live rows.
+CREATE INDEX IF NOT EXISTS idx_ownership_transfers_due_expiry
+    ON ownership_transfers(expires_at)
+    WHERE status IN ('pending', 'confirmed');
+
+-- ── History table: allow system-authored rows ────────────────────────────────
+--
+-- The expiry sweeper has no acting publisher. actor_id was NOT NULL, which forced the
+-- #1058 code to invent an actor; the duplicate branch invented a transfer_id too and
+-- so tripped the foreign key, turning an intended 409 into a 500.
+
+ALTER TABLE ownership_transfer_logs ALTER COLUMN actor_id DROP NOT NULL;
+
+DO $$ BEGIN
+    ALTER TABLE ownership_transfer_logs
+        ADD CONSTRAINT chk_ownership_transfer_logs_actor CHECK (
+            actor_type = 'system' OR (actor_type = 'publisher' AND actor_id IS NOT NULL)
+        ) NOT VALID;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
# Closes #1094 

## feat: Safe Contract Ownership Transfer with Two-Phase ed25519 Signatures ([#1094](#))

### Summary

Makes contract ownership transfer safe: ownership now moves only after two distinct ed25519 signatures have been verified against the outgoing and incoming publishers' on-chain Stellar accounts, atomically, at most once, and never after expiry.

> **Context reviewers need first:** this feature already existed, and it was worse than absent. Issue [#1058](#) shipped `ownership_transfers` and `ownership_transfer_logs`, five handlers, five routes, five shared types, and a 300-line test file. But:
> - There was no signature anywhere. Identity was a `user_id: Uuid` field in the request body — any unauthenticated caller could transfer any contract by supplying two UUIDs.
> - The reject branch had no authorization check at all. The `is_from`/`is_to` test lived only inside the `if req.accept` arm, so any caller could kill any pending transfer.
> - It could not work at runtime in two independent ways: `OwnershipTransferStatus` declared `#[sqlx(type_name = "transfer_status")]` against a `VARCHAR(20)` column with no migration creating a `transfer_status` Postgres type — decoding any row failed. Separately, the partial-confirm `UPDATE` set `to_confirmation = TRUE` while leaving `status = 'pending'`, violating the table's own `chk_confirmation_logic` CHECK.
> - No transaction and no row lock anywhere. The ownership write and the transfer write were separate autocommit statements.
> - All 14 existing tests were tautologies — they constructed a request struct and asserted on that struct's own fields. Not one called a handler.
>
> This PR is a hardening job on [#1058](#) rather than greenfield work, and it necessarily rewrites both write handlers.

---

### Changes Made

#### Migration — `database/migrations/20260727010000_issue1094_ownership_transfer_signatures.sql` *(new, 162 lines)*

- Adds `signature_algorithm`, `request_nonce`, `from_signature`, `from_signer_address`, `from_signed_at`, `from_signed_payload`, `decision_nonce`, `decision_signature`, `decision_signer_address`, `decision_signed_at`, `decision_signed_payload`, `decision_by`
- `uq_ownership_transfers_request_nonce` and `uq_ownership_transfers_decision_nonce` — each signature is single-use
- `uq_ownership_transfers_one_live_per_contract` — at most one live transfer per contract in the database
- `chk_ownership_transfer_signature_completeness` — impossible to reach `completed` without both signature sets on record; holds even against a future code path that forgets to verify
- Redefines `chk_confirmation_logic` for the new flow
- Relaxes `ownership_transfer_logs.actor_id` to nullable for system-authored rows (expiry has no acting publisher), guarded by a CHECK that a publisher action must still name its publisher
- Expires all pre-existing in-flight transfers — they carry no signatures and cannot satisfy the new invariants
- New CHECKs added `NOT VALID` deliberately *(see Additional Context)*

#### New Module — `backend/api/src/ownership_transfer.rs` *(482 lines)*

- Canonical signing payload builders, freshness window, `verify_transfer_signature`, lazy expiry helpers, batch expiry with `FOR UPDATE SKIP LOCKED`, and the background sweeper
- `pub` rather than `pub(crate)` so integration tests can call it directly
- Composes existing primitives only: `stellar_strkey::ed25519::PublicKey::from_string` then `signature_verification::verify_signature`, which uses `verify_strict` and rejects small-order and malleable keys for free

#### Shared Types — `backend/shared/src/models.rs`

- `OwnershipTransferStatus`: drops the broken `sqlx::Type` derive for a manual `Decode`/`Type` delegating to `String`, mirroring the existing `DeprecationStatus` precedent. Unknown values are a decode error, not a silent default. Adds `#[serde(rename_all = "snake_case")]` — the wire value was `"Pending"` while the column held `'pending'`
- `OwnershipTransfer` extended with the new columns; `OwnershipTransferLog.actor_id` becomes `Option<Uuid>`
- Both request structs rewritten: the spoofable `user_id` is deleted, making the authorization mistake unrepresentable rather than merely fixed

#### Handlers — `backend/api/src/handlers.rs`

- **`create_ownership_transfer`:** adds `AuthClaims` extractor, owner-only authorization, phase-1 signature verification before any write, and a transaction that locks `contracts` first. Fixes the duplicate branch that logged against a random `Uuid::new_v4()` with no parent row, tripping the foreign key and turning the intended 409 into a 500.
- **`confirm_ownership_transfer`:** adds `AuthClaims`; locks `contracts` then `ownership_transfers` (same order as `create`); hoists authorization above the accept/reject split; verifies the phase-2 signature before any write; replaces the unguarded updates with a single status-guarded `UPDATE ... RETURNING`; adds a compare-and-swap on the ownership move. Expiry commits before returning its 409, following the `multisig_handlers.rs` precedent.
- **Read paths** get lazy expiry — a read never reports a past-due transfer as actionable
- `write_contract_audit_log` and `write_ownership_transfer_log` are now generic over `sqlx::Executor`, so a caller inside a transaction can pass `&mut *tx` and have history committed or rolled back with the change it describes
- A 40-line header comment records the seven invariants, the lock-order requirement, and the known `PATCH /publisher` bypass

#### Validation — `backend/api/src/validation/handler_requests.rs`

Replaces two no-op `Validatable` stubs with real implementations. Nonces are restricted to `[A-Za-z0-9_-]`, which keeps the colon-joined payload encoding unambiguous.

#### Startup — `backend/api/src/main.rs`

Registers the expiry sweeper next to the other background tasks.

#### Tests — `backend/api/tests/ownership_transfer_tests.rs` *(rewritten, 1451 lines changed)*

Deletes all 300 lines of tautologies. Adds **12 pure tests** and **23 live HTTP tests**.

---

### Invariants

| | Invariant |
|--|-----------|
| **I1** | `contracts.publisher_id` changes through this feature only inside a transaction that has verified two distinct signatures over two domain-separated payloads against two distinct `publishers.stellar_address` |
| **I2** | `pending` to `completed` happens at most once per transfer, ever |
| **I3** | A transfer past `expires_at` never reaches `completed` |
| **I4** | At most one live transfer per contract |
| **I5** | History is append-only; terminal states are reached only by an `UPDATE` guarded on the prior state, and every transition writes its log row in the same transaction |
| **I6** | Signatures are single-use |
| **I7** | The verifying key is always the acting identity's own key, resolved from the token subject. No address in a request body ever selects a verifying key |

---

### Failure Modes and Protections

| Failure Mode | Protection |
|-------------|-----------|
| Double-accept, sequential or 10-way concurrent | Status-guarded single-shot `UPDATE` under `FOR UPDATE`; empty `RETURNING` gives 409 |
| Expired-accept race | `expires_at > NOW()` inside the accepting `UPDATE`, evaluated under the lock, not trusted from the earlier read |
| Replayed create body | `UNIQUE(request_nonce)` |
| Cross-phase or cross-decision replay | Domain, version, and action segments in the payload |
| Forged or wrong-key signature | `verify_strict`; 422; verification precedes every write, so zero mutation |
| Unauthorized reject (the [#1058](#) bug) | Authorization hoisted above the accept/reject branch; reject now requires a signature too |
| Partial write | Both `UPDATE`s and both history writes in one transaction |
| Owner moved by `PATCH /publisher` bypass mid-transfer | Compare-and-swap on the expected owner; zero rows affected rolls the transaction back and returns 409, failing closed |
| Deadlock between concurrent create and confirm | Fixed lock order: `contracts` then `ownership_transfers`, in both handlers |

---

### Signing Payloads *(clients need these)*

Colon-joined ASCII with unix-second timestamps, matching the existing conventions in `signing_handlers.rs` and `handlers/validators.rs`:

```
soroban-registry:ownership-transfer:v1:initiate:<contract_uuid>:<from_addr>:<to_addr>:<expires_unix>:<nonce>:<signed_at_unix>

soroban-registry:ownership-transfer:v1:<accept|reject>:<transfer_uuid>:<contract_uuid>:<from_addr>:<to_addr>:<request_nonce>:<nonce>:<signed_at_unix>
```

Domain, version, and action segments mean a phase-1 signature cannot be replayed as phase-2, and an accept cannot be replayed as a reject. The server builds these from database-resolved values, never from the request body, and stores the exact string — making a completed transfer independently re-verifiable offline.

---

### Breaking Changes

- Both write endpoints now require `Authorization: Bearer`
- `user_id`, `contract_id`, and `transfer_id` body fields are removed; path supplies the IDs; identity comes from the token
- `expires_at` (RFC3339) becomes `expires_at_unix` (i64), and `signed_at_unix` is new — RFC3339 round-trip through serde can change offset or sub-second precision, which would change the signed bytes
- `status` serialises as `"pending"`, not `"Pending"`
- The migration expires all in-flight transfers

No consumers were found: no docs, no OpenAPI entries, no frontend references.

---

### How Has This Been Tested?

Tested against a real Postgres container and a real running `api` process — not mocks, not a hand-built `AppState`.

```bash
# Pure tests: no database, no server
cd backend && cargo test -p api --test ownership_transfer_tests

# Live suite: real database + real API
docker run -d --name pg -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres \
  -e POSTGRES_DB=soroban_registry -p 5433:5432 postgres:16

DATABASE_URL="postgresql://postgres:postgres@localhost:5433/soroban_registry" \
ELASTICSEARCH_URL="http://localhost:9200" HOST=0.0.0.0 LOG_LEVEL=info \
JWT_SECRET="test-jwt-secret-at-least-32-chars-long" PORT=3099 \
OWNERSHIP_TRANSFER_MIN_EXPIRY_SECS=1 \
RATE_LIMIT_WRITE_ANON_PER_HOUR=100000 RATE_LIMIT_WRITE_AUTH_PER_HOUR=100000 \
cargo run --bin api

TEST_API_BASE_URL=http://localhost:3099 OWNERSHIP_TRANSFER_MIN_EXPIRY_SECS=1 \
  cargo test -p api --test ownership_transfer_tests -- --ignored --test-threads=2

# Regression / hygiene
cargo check --workspace
cargo check --workspace --all-targets
cargo clippy -p api -p shared
cargo test -p shared
bash .github/scripts/validate-migrations.sh
```

| Check | Result |
|-------|--------|
| Pure tests (payloads, freshness, verification, serde) | 12 passed |
| Live HTTP suite | 23 passed, 0 failed |
| `cargo test -p shared` | 45 passed, unchanged |
| `cargo check --workspace` | pass |
| `cargo check --workspace --all-targets` | same 11 pre-existing errors as `main`, none in touched files |
| `cargo clippy -p api -p shared` | `api` lib 167 → 166 warnings, `shared` 5 unchanged, 0 in new code |
| `rustfmt --check` on all 8 touched files | clean |
| Migration validation script | pass |
| `cd cli && cargo check` | same single pre-existing error as `main` |
| No-emoji scan on changed files | clean |

**Acceptance criteria, mapped to tests:**
- `test_two_phase_transfer_moves_ownership_only_after_both_signatures` — owner unchanged after create, moved after signed accept
- `test_stored_signatures_verify_offline` — re-verifies both stored payload/signature pairs with raw `ed25519_dalek`, deliberately not calling this crate's verification code, asserts the two signer addresses differ
- `test_expired_transfer_cannot_be_accepted`, `test_expired_accept_leaves_no_partial_transfer`, `test_concurrent_accepts_complete_exactly_once` — fires 10 independently signed acceptances through `tokio::spawn`, asserts exactly one 200, nine 409, exactly one `transfer_completed` history row, and one ownership move
- `test_transfer_history_is_queryable_per_contract` — rejection and completion on the same contract; both remain visible
- `test_transfer_logs_contain_full_provenance_chain` — asserts ordered chain; every entry records what was actually signed

**Two things verified by hand against the live database:**
1. Direct SQL bypassing the handler entirely was rejected: `UPDATE ... SET status='completed'` with `decision_signature IS NULL` fails `chk_ownership_transfer_signature_completeness`
2. With `OWNERSHIP_TRANSFER_EXPIRY_INTERVAL_SECS=5`, a past-due row inserted directly — never read, so lazy expiry cannot be what did it — was moved to `expired` with a `transfer_expired` history row authored by `system`

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing completed

---

### Pre-existing Bugs Found — NOT Fixed Here

**1. API cannot boot against a fresh database.** `20260726000000_artifact_scan_status.sql` and `20260726000000_dependency_scan_runs.sql` share a version prefix; sqlx keys migrations by that prefix, so the second insert into `_sqlx_migrations` violates the primary key and startup aborts. Needs a deliberate decision — renaming a file affects environments that already applied one of the two.

**2. `normalize_error_code` never inserts underscores.** `error.rs:163` decides whether to add `_` by testing whether the previous character of the already uppercased output is lowercase, which it never is. So `"TransferExpired"` emits `TRANSFEREXPIRED`. Fixing it is a breaking change deserving its own PR. These handlers keep passing PascalCase for consistency, and tests assert what is actually emitted.

**3. Every contract published without a wasm artifact is private and unreadable, including by its own publisher.** `handlers.rs` sets visibility to `public` only when `artifact_scan_status = 'passed'`, which requires `wasm_artifact_base64`. Otherwise the contract is private with no `organization_id`, so `GET /api/contracts/:id` returns 403 to everyone. The test fixture works around it by publishing a minimal valid wasm module.

---

### Design Decisions

**"On-chain-anchored" means the on-chain account keypair, not a ledger transaction.** Transfers are authorised by an ed25519 signature verified against `publishers.stellar_address`. No RPC or Horizon call; no transaction hash. Anchoring to the keypair that controls the account gives the property the issue is after at no operational cost. Expecting a submitted transaction verified via RPC is a materially larger change worth raising now.

**Both a JWT and a signature are required.** The JWT proves session; the signature proves key control; the two must agree. Uses the `AuthClaims` extractor, not `AuthenticatedUser` — the latter does `Uuid::parse_str(&claims.sub).unwrap_or(Uuid::nil())` while `sub` holds a `G...` address, so its `publisher_id` is always nil.

**Accepting is the recipient's alone; either party may reject.** The sender's consent is the phase-1 signature. Letting the sender also accept would collapse two-party confirmation into a single-party ownership change. Rejection is open to both — otherwise a transfer sent to the wrong address is unrevocable until expiry.

**Reads stay unauthenticated.** Provenance in a public registry is public, and the stored payload/signature pairs are exactly what a third party needs to audit a takeover without trusting this API.

**`PATCH /api/contracts/:id/publisher` left in place.** [#1094](#) does not ask for its removal; the accept path fails closed against it via compare-and-swap. Gating or removing that endpoint deserves its own PR.

---

### Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] Comments added for complex logic
- [ ] Documentation updated *(no markdown, OpenAPI entry, or frontend code references these endpoints today — verified rather than assumed; happy to add `#[utoipa::path]` annotations on request)*
- [x] No new warnings (`cargo clippy`, `pnpm lint`)
- [x] Tests prove the fix/feature works
- [x] All existing tests pass locally for files touched by this PR *(pre-existing failures in `api --lib`, `verifier`, `cli`, and the frontend are unaffected)*
- [x] Branch rebased on latest `main` — clean descendant of `f2ec6a1`; verified clean merge alongside in-flight `feat/smart-contract-ci` branch
- [ ] No breaking changes *(breaking changes exist and are documented above)*