### PR TITLE
feat: add network passphrase validation to contract verification (#1117)

### DIFF
--- a/backend/api/src/verification_handlers.rs
+++ b/backend/api/src/verification_handlers.rs
@@ -11,8 +11,10 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use shared::Network;
 use std::time::Duration;
 use uuid::Uuid;
+use verifier::{check_passphrase, known_passphrase_for_network, PassphraseCheckOutcome};
 
 use crate::{
     error::{ApiError, ApiResult},
@@ -30,6 +32,18 @@ pub struct ContractVerifyRequest {
     /// Optional free-text notes from the submitter
     #[serde(default)]
     pub notes: Option<String>,
+    /// The Soroban network passphrase used when the contract was deployed.
+    ///
+    /// For the three well-known networks (mainnet / testnet / futurenet) this
+    /// field is optional – the registry will infer the canonical passphrase
+    /// from the network enum.  For custom or private networks it should always
+    /// be supplied to prevent silent passphrase mismatches.
+    ///
+    /// If the registry already holds a passphrase for this contract (from a
+    /// previous verification attempt) and this field does not match, the
+    /// request is rejected with a 422 PassphraseMismatch error.
+    #[serde(default)]
+    pub network_passphrase: Option<String>,
 }
 
 /// Verification level filter for history queries
@@ -53,6 +67,12 @@ pub struct VerificationStatusResponse {
     pub report_url: Option<String>,
     pub verification_notes: Option<String>,
     pub cached: bool,
+    /// The network passphrase recorded for this contract, if any.
+    /// `null` for contracts that were published before issue-1117 support
+    /// was added (these are backward-compatible – passphrase validation is
+    /// skipped when this field is absent).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network_passphrase: Option<String>,
 }
 
 /// One entry in the verification history
@@ -82,6 +102,11 @@ pub struct VerificationSubmitResponse {
     pub status: String,
     pub message: String,
     pub submitted_at: DateTime<Utc>,
+    /// Present when `provided_passphrase` was `None` and the registry already
+    /// holds a passphrase for this contract.  Callers should start supplying
+    /// the passphrase in future requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub passphrase_warning: Option<String>,
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -119,6 +144,10 @@ async fn resolve_contract_uuid(state: &AppState, id: &str) -> ApiResult<(Uuid, S
 /// Creates a `pending` verification record and queues the contract for
 /// source-code / on-chain verification.  Returns immediately with the new
 /// record ID and initial status.
+///
+/// If `network_passphrase` is supplied and the registry already holds a
+/// different passphrase for this contract, the request is rejected with a
+/// 422 status and a `PassphraseMismatch` error code.
 #[utoipa::path(
     post,
     path = "/api/contracts/{id}/verify",
@@ -127,7 +156,8 @@ async fn resolve_contract_uuid(state: &AppState, id: &str) -> ApiResult<(Uuid, S
     responses(
         (status = 201, description = "Verification submitted", body = VerificationSubmitResponse),
         (status = 404, description = "Contract not found"),
-        (status = 400, description = "Invalid request")
+        (status = 400, description = "Invalid request"),
+        (status = 422, description = "Passphrase mismatch")
     ),
     tag = "Verification"
 )]
@@ -138,6 +168,75 @@ pub async fn submit_contract_verification(
 ) -> ApiResult<Json<VerificationSubmitResponse>> {
     let (contract_uuid, contract_address) = resolve_contract_uuid(&state, &id).await?;
 
+    // ── Passphrase pre-check ──────────────────────────────────────────────────
+    //
+    // Fetch the contract's recorded passphrase and network enum so we can:
+    //  1. Validate the provided passphrase before any writes.
+    //  2. Infer the canonical passphrase for well-known networks if the caller
+    //     didn't supply one.
+    //  3. Persist the passphrase into the verifications record.
+    let (recorded_passphrase, contract_network): (Option<String>, Option<Network>) =
+        sqlx::query_as(
+            "SELECT network_passphrase, network FROM contracts WHERE id = $1",
+        )
+        .bind(contract_uuid)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| db_err("fetch contract passphrase for validation", e))?
+        .unwrap_or((None, None));
+
+    // For well-known networks, if the caller didn't provide a passphrase we
+    // can fill it in from the known constant.  This guarantees new records are
+    // always stored with the canonical passphrase.
+    let effective_provided: Option<String> = req.network_passphrase.clone().or_else(|| {
+        contract_network
+            .as_ref()
+            .and_then(known_passphrase_for_network)
+            .map(str::to_owned)
+    });
+
+    // Perform the passphrase check before opening a transaction.
+    let passphrase_to_store: Option<String>;
+    let passphrase_warning: Option<String>;
+
+    match check_passphrase(
+        recorded_passphrase.as_deref(),
+        effective_provided.as_deref(),
+    ) {
+        PassphraseCheckOutcome::Mismatch { recorded, provided } => {
+            return Err(ApiError::unprocessable(
+                "PassphraseMismatch",
+                format!(
+                    "The network passphrase supplied ('{}') does not match the passphrase \
+                     recorded for this contract ('{}').  Verify that you are targeting the \
+                     correct network.",
+                    provided, recorded
+                ),
+            ));
+        }
+        PassphraseCheckOutcome::Pass => {
+            passphrase_to_store = effective_provided.clone().or(recorded_passphrase.clone());
+            // Emit a soft warning when the caller didn't supply a passphrase and
+            // there is no recorded one either (fully opaque – could be a custom
+            // network).
+            passphrase_warning = if req.network_passphrase.is_none()
+                && recorded_passphrase.is_none()
+                && effective_provided.is_none()
+            {
+                Some(
+                    "No network passphrase was supplied or inferred.  For custom or private \
+                     networks, include `network_passphrase` in the request body to enable \
+                     passphrase mismatch detection."
+                        .to_owned(),
+                )
+            } else {
+                None
+            };
+        }
+    }
+
+    // ── Transactional write ───────────────────────────────────────────────────
+    //
     // Wrap the INSERT + conditional UPDATE in a transaction so that:
     //   • The verifications row and the contracts.verification_status change
     //     are committed atomically.
@@ -160,8 +259,8 @@ pub async fn submit_contract_verification(
         r#"
         INSERT INTO verifications
             (contract_id, status, source_code, build_params, compiler_version,
-             error_message, version)
-        VALUES ($1, 'pending', $2, $3, $4, NULL, 0)
+             error_message, version, network_passphrase)
+        VALUES ($1, 'pending', $2, $3, $4, NULL, 0, $5)
         RETURNING id
         "#,
     )
@@ -169,6 +268,7 @@ pub async fn submit_contract_verification(
     .bind(&req.source_code)
     .bind(&req.build_params)
     .bind(&req.compiler_version)
+    .bind(passphrase_to_store.as_deref())
     .fetch_one(&mut *tx)
     .await
     .map_err(|e| db_err("insert verification record", e))?;
@@ -176,17 +276,22 @@ pub async fn submit_contract_verification(
     // Transition contract status to 'pending' only if it is currently
     // 'unverified'.  The FOR UPDATE lock above ensures no other transaction
     // can race this conditional update.
+    //
+    // Also persist the passphrase on the contracts row when it wasn't already
+    // present so future verifications can detect mismatches.
     sqlx::query(
         r#"
         UPDATE contracts
         SET    verification_status  = 'pending',
                verification_version = verification_version + 1,
+               network_passphrase   = COALESCE(network_passphrase, $2),
                updated_at           = NOW()
         WHERE  id = $1
           AND  verification_status = 'unverified'
         "#,
     )
     .bind(contract_uuid)
+    .bind(passphrase_to_store.as_deref())
     .execute(&mut *tx)
     .await
     .map_err(|e| db_err("set contract verification_status to pending", e))?;
@@ -204,6 +309,7 @@ pub async fn submit_contract_verification(
         status: "pending".to_string(),
         message: "Verification request submitted and queued for processing".to_string(),
         submitted_at: Utc::now(),
+        passphrase_warning,
     }))
 }
 
@@ -245,6 +351,7 @@ pub async fn get_contract_verification_status(
         Option<Uuid>,          // verified_by
         Option<String>,        // verification_notes
         Option<String>,        // compiler_version (used as verification_method)
+        Option<String>,        // network_passphrase (issue #1117)
     )> = sqlx::query_as(
         r#"
         SELECT
@@ -253,7 +360,8 @@ pub async fn get_contract_verification_status(
             c.verified_at,
             c.verified_by,
             c.verification_notes,
-            v.compiler_version
+            v.compiler_version,
+            c.network_passphrase
         FROM   contracts c
         LEFT   JOIN verifications v
                ON  v.contract_id = c.id
@@ -271,7 +379,7 @@ pub async fn get_contract_verification_status(
     .await
     .map_err(|e| db_err("fetch verification status", e))?;
 
-    let (vs, is_verified, verified_at, verified_by, notes, method) =
+    let (vs, is_verified, verified_at, verified_by, notes, method, network_passphrase) =
         row.ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
 
     let resp = VerificationStatusResponse {
@@ -284,6 +392,7 @@ pub async fn get_contract_verification_status(
         report_url: None,
         verification_notes: notes,
         cached: false,
+        network_passphrase,
     };
 
     // Cache for 1 hour

--- a/backend/verifier/src/lib.rs
+++ b/backend/verifier/src/lib.rs
@@ -19,6 +19,31 @@ use tracing::instrument;
 const DEFAULT_SOROBAN_SDK_VERSION: &str = "21.7.7";
 const BUILD_TIMEOUT: Duration = Duration::from_secs(120);
 
+// ── Well-known Soroban network passphrases ────────────────────────────────────
+//
+// These are the canonical passphrases used by Stellar's public networks.
+// They are embedded in every transaction envelope and uniquely identify a
+// network at the protocol level.  Storing them alongside verification records
+// allows the registry to detect mismatches for custom / private networks that
+// happen to share the same enum label.
+
+/// Stellar Mainnet passphrase.
+pub const PASSPHRASE_MAINNET: &str = "Public Global Stellar Network ; September 2015";
+/// Stellar Testnet passphrase.
+pub const PASSPHRASE_TESTNET: &str = "Test SDF Network ; September 2015";
+/// Stellar Futurenet passphrase.
+pub const PASSPHRASE_FUTURENET: &str = "Test SDF Future Network ; October 2022";
+
+/// Return the canonical passphrase for one of the three well-known networks,
+/// or `None` for any custom / private network that has no fixed passphrase.
+pub fn known_passphrase_for_network(network: &shared::Network) -> Option<&'static str> {
+    match network {
+        shared::Network::Mainnet => Some(PASSPHRASE_MAINNET),
+        shared::Network::Testnet => Some(PASSPHRASE_TESTNET),
+        shared::Network::Futurenet => Some(PASSPHRASE_FUTURENET),
+    }
+}
+
 /// Precise reason a source-level verification step failed.
 ///
 /// Returned alongside the boolean `verified` flag so callers can present
@@ -40,6 +65,19 @@ pub enum VerificationFailureKind {
     NetworkMismatch { network: String },
     /// No on-chain wasm artifact was found to verify against.
     MissingArtifact,
+    /// The passphrase supplied (or recorded at publish time) does not match
+    /// the passphrase used during this verification attempt.
+    ///
+    /// This catches the case where two contracts share the same enum label
+    /// (mainnet / testnet / futurenet) but belong to different physical
+    /// networks (e.g. a private fork that recycles the "testnet" label).
+    PassphraseMismatch {
+        /// Passphrase that was recorded at publish / first verification time.
+        recorded: String,
+        /// Passphrase supplied in the current verification request.
+        provided: String,
+        hint: String,
+    },
 }
 
 impl std::fmt::Display for VerificationFailureKind {
@@ -51,6 +89,15 @@ impl std::fmt::Display for VerificationFailureKind {
                 write!(f, "network_mismatch: contract not found on {network}")
             }
             Self::MissingArtifact => write!(f, "missing_artifact: no on-chain artifact found"),
+            Self::PassphraseMismatch {
+                recorded, provided, ..
+            } => {
+                write!(
+                    f,
+                    "passphrase_mismatch: recorded passphrase '{recorded}' does not match \
+                     provided passphrase '{provided}'"
+                )
+            }
         }
     }
 }
@@ -63,6 +110,46 @@ pub struct VerificationResult {
     pub message: Option<String>,
     /// Structured failure reason; `None` when `verified` is `true`.
     pub failure_kind: Option<VerificationFailureKind>,
+}
+
+/// Outcome of a passphrase compatibility check.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PassphraseCheckOutcome {
+    /// Passphrases match (or one / both were absent – treated as a soft pass
+    /// for backward compatibility).
+    Pass,
+    /// The provided passphrase conflicts with the passphrase that was recorded
+    /// for this contract at publish / first-verification time.
+    Mismatch {
+        recorded: String,
+        provided: String,
+    },
+}
+
+/// Compare a `provided` passphrase against the `recorded` one stored in the
+/// registry.
+///
+/// # Rules
+/// 1. If `recorded` is `None` the contract predates passphrase tracking; we
+///    cannot reject it, so the check passes with a soft warning (the caller is
+///    responsible for logging the warning).
+/// 2. If `provided` is `None` the submitter did not supply a passphrase.  This
+///    is also treated as a soft pass so existing tooling keeps working.
+/// 3. Only when *both* sides are `Some` and they disagree do we return
+///    `Mismatch`.
+///
+/// Comparisons are case-sensitive because Stellar passphrases are case-sensitive.
+pub fn check_passphrase(
+    recorded: Option<&str>,
+    provided: Option<&str>,
+) -> PassphraseCheckOutcome {
+    match (recorded, provided) {
+        (Some(rec), Some(prov)) if rec != prov => PassphraseCheckOutcome::Mismatch {
+            recorded: rec.to_owned(),
+            provided: prov.to_owned(),
+        },
+        _ => PassphraseCheckOutcome::Pass,
+    }
 }
 
 #[instrument(skip(source_code, build_params), fields(component = "verifier", deployed_wasm_hash = %deployed_wasm_hash))]
@@ -118,6 +205,63 @@ pub async fn verify_contract(
         compiled_wasm_hash: compiled_hash,
         deployed_wasm_hash: deployed_normalized,
     })
+}
+
+/// Passphrase-aware entry-point for contract verification.
+///
+/// Performs the same bytecode check as [`verify_contract`] **and** validates
+/// the network passphrase before compiling anything.  A passphrase mismatch
+/// is returned as a hard failure (`verified = false`) with a structured
+/// [`VerificationFailureKind::PassphraseMismatch`] reason.
+///
+/// # Arguments
+/// * `source_code`          – Rust source or `wasm_base64:…` payload.
+/// * `deployed_wasm_hash`   – 64-char hex SHA-256 of the deployed WASM.
+/// * `compiler_version`     – Optional Soroban SDK version string.
+/// * `build_params`         – Optional extra cargo build flags.
+/// * `recorded_passphrase`  – Passphrase stored in the registry for this
+///                            contract (may be `None` for pre-1117 records).
+/// * `provided_passphrase`  – Passphrase supplied by the verification caller
+///                            (may be `None` for tooling that hasn't been
+///                            updated yet).
+#[instrument(
+    skip(source_code, build_params),
+    fields(component = "verifier", deployed_wasm_hash = %deployed_wasm_hash)
+)]
+pub async fn verify_contract_with_passphrase(
+    source_code: &str,
+    deployed_wasm_hash: &str,
+    compiler_version: Option<&str>,
+    build_params: Option<&Value>,
+    recorded_passphrase: Option<&str>,
+    provided_passphrase: Option<&str>,
+) -> Result<VerificationResult, RegistryError> {
+    // ── Passphrase guard ──────────────────────────────────────────────────────
+    match check_passphrase(recorded_passphrase, provided_passphrase) {
+        PassphraseCheckOutcome::Mismatch { recorded, provided } => {
+            let hint = format!(
+                "The network passphrase recorded at publish time ('{}') does not match \
+                 the passphrase supplied in this verification request ('{}').  \
+                 Ensure you are verifying against the correct network.",
+                recorded, provided
+            );
+            return Ok(VerificationResult {
+                verified: false,
+                compiled_wasm_hash: String::new(),
+                deployed_wasm_hash: deployed_wasm_hash.to_owned(),
+                message: Some(hint.clone()),
+                failure_kind: Some(VerificationFailureKind::PassphraseMismatch {
+                    recorded: recorded.clone(),
+                    provided: provided.clone(),
+                    hint,
+                }),
+            });
+        }
+        PassphraseCheckOutcome::Pass => {}
+    }
+
+    // ── Bytecode check (delegates to existing logic) ──────────────────────────
+    verify_contract(source_code, deployed_wasm_hash, compiler_version, build_params).await
 }
 
 /// Compile Rust source code to WASM.
@@ -346,5 +490,189 @@ mod tests {
         let source = format!("wasm_base64:{}", BASE64.encode(b"wasm"));
         let result = verify_contract(&source, "not-a-hex-hash", None, None).await;
         assert!(result.is_err(), "invalid hash should be rejected");
+    }
+
+    // ── Passphrase check unit tests ───────────────────────────────────────────
+
+    #[test]
+    fn check_passphrase_both_match_returns_pass() {
+        let outcome = check_passphrase(Some(PASSPHRASE_MAINNET), Some(PASSPHRASE_MAINNET));
+        assert_eq!(outcome, PassphraseCheckOutcome::Pass);
+    }
+
+    #[test]
+    fn check_passphrase_mismatch_returns_mismatch() {
+        let outcome = check_passphrase(Some(PASSPHRASE_MAINNET), Some(PASSPHRASE_TESTNET));
+        assert!(
+            matches!(outcome, PassphraseCheckOutcome::Mismatch { .. }),
+            "expected Mismatch, got {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn check_passphrase_recorded_none_returns_pass() {
+        // No recorded passphrase means the contract predates passphrase tracking –
+        // treat as soft pass so existing records remain verifiable.
+        let outcome = check_passphrase(None, Some(PASSPHRASE_TESTNET));
+        assert_eq!(outcome, PassphraseCheckOutcome::Pass);
+    }
+
+    #[test]
+    fn check_passphrase_provided_none_returns_pass() {
+        // Caller didn't supply a passphrase – backward-compatible soft pass.
+        let outcome = check_passphrase(Some(PASSPHRASE_MAINNET), None);
+        assert_eq!(outcome, PassphraseCheckOutcome::Pass);
+    }
+
+    #[test]
+    fn check_passphrase_both_none_returns_pass() {
+        let outcome = check_passphrase(None, None);
+        assert_eq!(outcome, PassphraseCheckOutcome::Pass);
+    }
+
+    #[test]
+    fn known_passphrases_differ_across_networks() {
+        assert_ne!(PASSPHRASE_MAINNET, PASSPHRASE_TESTNET);
+        assert_ne!(PASSPHRASE_MAINNET, PASSPHRASE_FUTURENET);
+        assert_ne!(PASSPHRASE_TESTNET, PASSPHRASE_FUTURENET);
+    }
+
+    #[test]
+    fn known_passphrase_for_network_returns_correct_values() {
+        assert_eq!(
+            known_passphrase_for_network(&shared::Network::Mainnet),
+            Some(PASSPHRASE_MAINNET)
+        );
+        assert_eq!(
+            known_passphrase_for_network(&shared::Network::Testnet),
+            Some(PASSPHRASE_TESTNET)
+        );
+        assert_eq!(
+            known_passphrase_for_network(&shared::Network::Futurenet),
+            Some(PASSPHRASE_FUTURENET)
+        );
+    }
+
+    // ── Passphrase-aware verify_contract_with_passphrase tests ───────────────
+
+    #[tokio::test]
+    async fn passphrase_aware_verify_passes_when_passphrases_match() {
+        let wasm = b"passphrase-good-wasm";
+        let hash = hash_wasm(wasm);
+        let source = format!("wasm_base64:{}", BASE64.encode(wasm));
+
+        let result = verify_contract_with_passphrase(
+            &source,
+            &hash,
+            None,
+            None,
+            Some(PASSPHRASE_TESTNET),
+            Some(PASSPHRASE_TESTNET),
+        )
+        .await
+        .expect("verify_contract_with_passphrase should not return Err");
+
+        assert!(result.verified, "matching passphrases + matching wasm should pass");
+        assert!(result.failure_kind.is_none());
+    }
+
+    #[tokio::test]
+    async fn passphrase_aware_verify_fails_on_mismatch() {
+        let wasm = b"passphrase-mismatch-wasm";
+        let hash = hash_wasm(wasm);
+        let source = format!("wasm_base64:{}", BASE64.encode(wasm));
+
+        let result = verify_contract_with_passphrase(
+            &source,
+            &hash,
+            None,
+            None,
+            Some(PASSPHRASE_MAINNET),  // recorded: mainnet
+            Some(PASSPHRASE_TESTNET),  // provided: testnet  ← mismatch
+        )
+        .await
+        .expect("verify_contract_with_passphrase should not return Err");
+
+        assert!(!result.verified, "passphrase mismatch must reject verification");
+        match &result.failure_kind {
+            Some(VerificationFailureKind::PassphraseMismatch { recorded, provided, .. }) => {
+                assert_eq!(recorded, PASSPHRASE_MAINNET);
+                assert_eq!(provided, PASSPHRASE_TESTNET);
+            }
+            other => panic!("expected PassphraseMismatch, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn passphrase_aware_verify_passes_when_recorded_is_none() {
+        // Pre-existing contracts that lack a recorded passphrase must still
+        // be verifiable (backward compatibility requirement).
+        let wasm = b"legacy-wasm-no-passphrase";
+        let hash = hash_wasm(wasm);
+        let source = format!("wasm_base64:{}", BASE64.encode(wasm));
+
+        let result = verify_contract_with_passphrase(
+            &source,
+            &hash,
+            None,
+            None,
+            None,                      // recorded: none (legacy record)
+            Some(PASSPHRASE_TESTNET),  // provided: testnet
+        )
+        .await
+        .expect("verify_contract_with_passphrase should not return Err");
+
+        assert!(
+            result.verified,
+            "missing recorded passphrase should not block verification"
+        );
+    }
+
+    #[tokio::test]
+    async fn passphrase_aware_verify_passes_when_provided_is_none() {
+        // Legacy tooling that doesn't supply a passphrase must keep working.
+        let wasm = b"legacy-client-wasm";
+        let hash = hash_wasm(wasm);
+        let source = format!("wasm_base64:{}", BASE64.encode(wasm));
+
+        let result = verify_contract_with_passphrase(
+            &source,
+            &hash,
+            None,
+            None,
+            Some(PASSPHRASE_MAINNET), // recorded: mainnet
+            None,                     // provided: none (old client)
+        )
+        .await
+        .expect("verify_contract_with_passphrase should not return Err");
+
+        assert!(
+            result.verified,
+            "missing provided passphrase should not block verification (backward compat)"
+        );
+    }
+
+    #[tokio::test]
+    async fn passphrase_mismatch_takes_priority_over_bytecode_mismatch() {
+        // Even if the bytecode would also mismatch, passphrase guard fires first.
+        let source = format!("wasm_base64:{}", BASE64.encode(b"some-wasm"));
+        let wrong_hash = hash_wasm(b"different-wasm");
+
+        let result = verify_contract_with_passphrase(
+            &source,
+            &wrong_hash,
+            None,
+            None,
+            Some(PASSPHRASE_MAINNET),
+            Some(PASSPHRASE_FUTURENET),
+        )
+        .await
+        .expect("should not error");
+
+        assert!(!result.verified);
+        assert!(
+            matches!(result.failure_kind, Some(VerificationFailureKind::PassphraseMismatch { .. })),
+            "PassphraseMismatch must take priority over SourceMismatch"
+        );
     }
 }

--- a/database/migrations/20260727000001_issue1117_network_passphrase_verification.sql
+++ b/database/migrations/20260727000001_issue1117_network_passphrase_verification.sql
@@ -1,0 +1,57 @@
+-- Migration: Issue #1117 – Store network passphrase alongside verification records
+--
+-- Soroban network identity is tied to a network passphrase.  The enum
+-- (mainnet/testnet/futurenet) is a convenience label; the authoritative
+-- identifier is the passphrase that is hashed into every transaction.
+-- Storing the passphrase at publish / verification time lets us detect
+-- silent mismatches when a custom or private network reuses an enum label.
+--
+-- Design decisions:
+--   • NULL means "passphrase not supplied" – treated as a soft-warning, not
+--     an outright failure, to keep existing rows backward-compatible.
+--   • A non-NULL passphrase must match any previous non-NULL passphrase for
+--     the same contract; a mismatch is a hard reject.
+--   • The three well-known passphrases are stored as constants in application
+--     code (verifier crate) so DB rows can be validated offline.
+
+-- 1. Add network_passphrase to the verifications table so every verification
+--    attempt records which passphrase was used.
+ALTER TABLE verifications
+    ADD COLUMN IF NOT EXISTS network_passphrase TEXT;
+
+-- 2. Add network_passphrase to the contracts table so the authoritative
+--    passphrase established at first publish is available for comparison on
+--    subsequent verification attempts.
+ALTER TABLE contracts
+    ADD COLUMN IF NOT EXISTS network_passphrase TEXT;
+
+-- 3. Backfill well-known passphrases for existing rows based on the network
+--    enum value.  Custom / private networks cannot be backfilled and stay NULL.
+UPDATE contracts
+SET network_passphrase = CASE network
+    WHEN 'mainnet'   THEN 'Public Global Stellar Network ; September 2015'
+    WHEN 'testnet'   THEN 'Test SDF Network ; September 2015'
+    WHEN 'futurenet' THEN 'Test SDF Future Network ; October 2022'
+    ELSE NULL
+END
+WHERE network_passphrase IS NULL;
+
+UPDATE verifications v
+SET network_passphrase = CASE c.network
+    WHEN 'mainnet'   THEN 'Public Global Stellar Network ; September 2015'
+    WHEN 'testnet'   THEN 'Test SDF Network ; September 2015'
+    WHEN 'futurenet' THEN 'Test SDF Future Network ; October 2022'
+    ELSE NULL
+END
+FROM contracts c
+WHERE v.contract_id = c.id
+  AND v.network_passphrase IS NULL;
+
+-- 4. Index to speed up passphrase-based look-ups and consistency checks.
+CREATE INDEX IF NOT EXISTS idx_contracts_network_passphrase
+    ON contracts (network_passphrase)
+    WHERE network_passphrase IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_verifications_network_passphrase
+    ON verifications (contract_id, network_passphrase)
+    WHERE network_passphrase IS NOT NULL;


### PR DESCRIPTION
## Summary

Closes #1117

Soroban network identity is tied to a network passphrase, not just the enum label (mainnet/testnet/futurenet). This PR stores the passphrase alongside every verification record and validates it on each verification attempt, so mismatches for custom/private networks are detected and rejected rather than silently passing.

## Changes

### Database migration
`database/migrations/20260727000001_issue1117_network_passphrase_verification.sql`
- Adds `network_passphrase TEXT` to both `contracts` and `verifications` tables
- Backfills the three well-known passphrases for all existing rows
- Adds indexes for passphrase lookups

### `backend/verifier/src/lib.rs`
- Adds `PASSPHRASE_MAINNET`, `PASSPHRASE_TESTNET`, `PASSPHRASE_FUTURENET` constants
- Adds `known_passphrase_for_network()` helper
- Adds `PassphraseCheckOutcome` enum and `check_passphrase()` pure function
- Adds `PassphraseMismatch` variant to `VerificationFailureKind`
- Adds `verify_contract_with_passphrase()` — passphrase guard fires before bytecode check
- 10 new unit tests covering: match, mismatch, recorded-None, provided-None, both-None, passphrase priority over bytecode mismatch

### `backend/api/src/verification_handlers.rs`
- `ContractVerifyRequest` gains optional `network_passphrase` field
- `submit_contract_verification`: fetches recorded passphrase, infers canonical passphrase for well-known networks, rejects mismatches with HTTP 422 `PassphraseMismatch`, persists passphrase on both DB rows, emits soft warning when passphrase is fully absent
- `VerificationSubmitResponse` gains optional `passphrase_warning`
- `get_contract_verification_status`: exposes `network_passphrase` in response

## Acceptance criteria

- [x] Passphrase mismatches for otherwise-identical network enum values are detected and rejected with a clear error (HTTP 422)
- [x] Existing mainnet/testnet/futurenet flows are unaffected — missing passphrase treated as soft pass (backward compatible)
- [x] Tests cover matching, mismatched, and missing passphrase scenarios