### PR TITLE
Add retention policy for proposal history tables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# Copy to .env and adjust for your environment.
+
+# ── Database ────────────────────────────────────────────────────────────────
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/soroban_registry
+
+# ── Logging ─────────────────────────────────────────────────────────────────
+RUST_LOG=api=debug,tower_http=debug
+
+# ── Cache ───────────────────────────────────────────────────────────────────
+CACHE_ENABLED=true
+CACHE_TTL_SECONDS=300
+CACHE_POLICY=lru
+CACHE_MAX_CAPACITY=10000
+
+# ── Rate limiting ───────────────────────────────────────────────────────────
+RATE_LIMIT_READ_PER_MINUTE=100
+RATE_LIMIT_WRITE_PER_MINUTE=20
+RATE_LIMIT_AUTH_PER_MINUTE=1000
+RATE_LIMIT_HEALTH_PER_MINUTE=10000
+RATE_LIMIT_WINDOW_SECONDS=60
+
+# ── History table retention ─────────────────────────────────────────────────
+# Archives terminal-state proposals (executed, expired, rejected, cancelled)
+# into the *_archive tables once they fall outside the retention window.
+# Active records are never archived, regardless of age.
+
+# Set to false to stop the background retention task from starting.
+RETENTION_ENABLED=true
+
+# How long terminal records stay in the live tables, in days. A record sitting
+# exactly on this boundary is still inside the window and is retained.
+RETENTION_DAYS=90
+
+# How often the retention task runs, in seconds. Defaults to daily.
+RETENTION_INTERVAL_SECONDS=86400
+
+# Maximum records archived per table per run, to bound transaction size.
+RETENTION_BATCH_SIZE=1000
+
+# ── Frontend ────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_USE_MOCKS=false

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -9,6 +9,7 @@ mod aggregation;
 mod cache;
 mod metrics_handler;
 mod metrics;
+mod retention;
 // mod resource_handlers;
 // mod resource_tracking;
 mod analytics;
@@ -57,6 +58,9 @@ async fn main() -> Result<()> {
 
     // Spawn the hourly analytics aggregation background task
     aggregation::spawn_aggregation_task(pool.clone());
+
+    // Spawn the history table retention task
+    retention::spawn_retention_task(pool.clone(), retention::RetentionConfig::from_env());
 
     // Create prometheus registry for metrics
     let registry = Registry::new();

--- a/backend/api/src/metrics_handler.rs
+++ b/backend/api/src/metrics_handler.rs
@@ -20,13 +20,11 @@ pub async fn metrics_endpoint(State(state): State<AppState>) -> impl IntoRespons
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::auth::AuthManager;
     use crate::cache::{CacheConfig, CacheLayer};
-    use crate::resource_tracking::ResourceManager;
     use axum::extract::State;
     use axum::response::IntoResponse;
     use prometheus::Registry;
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
     use std::time::Instant;
 
     fn test_state() -> AppState {
@@ -37,8 +35,6 @@ mod tests {
             started_at: Instant::now(),
             cache: Arc::new(CacheLayer::new(CacheConfig::default())),
             registry,
-            resource_mgr: Arc::new(RwLock::new(ResourceManager::new())),
-            auth_mgr: Arc::new(RwLock::new(AuthManager::new("test-secret".to_string()))),
         }
     }
 

--- a/backend/api/src/retention.rs
+++ b/backend/api/src/retention.rs
@@ -1,0 +1,734 @@
+//! Retention policy for proposal history tables.
+//!
+//! Terminal-state proposals (`executed`, `expired`, `rejected`, `cancelled`) are
+//! never read back in normal operation but keep growing the live tables and the
+//! indexes on their status and timestamp columns. This job moves them into the
+//! `*_archive` tables past a configurable retention window.
+//!
+//! Records in a non-terminal state are never touched regardless of age: a
+//! `pending` proposal is still collecting signatures, an `approved` deploy
+//! proposal is still awaiting execution, and a `passed` governance proposal is
+//! still inside its execution delay.
+
+use chrono::{DateTime, Duration, Utc};
+use sqlx::PgPool;
+use std::env;
+use uuid::Uuid;
+
+const DEFAULT_RETENTION_DAYS: u32 = 90;
+const DEFAULT_INTERVAL_SECONDS: u64 = 86_400;
+const DEFAULT_BATCH_SIZE: i64 = 1_000;
+
+/// Statuses a deploy proposal can no longer transition out of.
+///
+/// `pending` and `approved` are excluded: an approved proposal has collected its
+/// signatures but has not been executed yet.
+pub const DEPLOY_PROPOSAL_TERMINAL_STATES: [&str; 3] = ["executed", "expired", "rejected"];
+
+/// Statuses a governance proposal can no longer transition out of.
+///
+/// `pending`, `active`, and `passed` are excluded: a passed proposal is waiting
+/// out `execution_delay_hours` before it can be executed.
+pub const GOVERNANCE_PROPOSAL_TERMINAL_STATES: [&str; 3] = ["executed", "rejected", "cancelled"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionConfig {
+    pub enabled: bool,
+    pub retention_days: u32,
+    pub interval_seconds: u64,
+    pub batch_size: i64,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            retention_days: DEFAULT_RETENTION_DAYS,
+            interval_seconds: DEFAULT_INTERVAL_SECONDS,
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+}
+
+impl RetentionConfig {
+    pub fn from_env() -> Self {
+        let config = Self {
+            enabled: env_bool("RETENTION_ENABLED", true),
+            retention_days: env_u32("RETENTION_DAYS", DEFAULT_RETENTION_DAYS),
+            interval_seconds: env_u64("RETENTION_INTERVAL_SECONDS", DEFAULT_INTERVAL_SECONDS),
+            batch_size: env_u32("RETENTION_BATCH_SIZE", DEFAULT_BATCH_SIZE as u32) as i64,
+        };
+
+        tracing::info!(
+            enabled = config.enabled,
+            retention_days = config.retention_days,
+            interval_seconds = config.interval_seconds,
+            batch_size = config.batch_size,
+            "retention: config loaded"
+        );
+
+        config
+    }
+
+    /// The instant a record must predate to be eligible for archival.
+    pub fn cutoff(&self, now: DateTime<Utc>) -> DateTime<Utc> {
+        now - Duration::days(i64::from(self.retention_days))
+    }
+}
+
+/// Number of rows moved into archive tables by a single run.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RetentionOutcome {
+    pub deploy_proposals: u64,
+    pub proposal_signatures: u64,
+    pub governance_proposals: u64,
+    pub governance_votes: u64,
+}
+
+/// Reference definition of the eligibility rule the purge queries implement.
+///
+/// A record sitting exactly on the retention threshold is still inside the
+/// window and is retained; only records strictly older than the cutoff are
+/// archived. The filter itself runs in SQL, so this is not called on the
+/// production path — it pins the boundary semantics the queries must match.
+#[allow(dead_code)]
+pub fn is_purgeable(
+    status: &str,
+    terminal_states: &[&str],
+    terminal_at: DateTime<Utc>,
+    cutoff: DateTime<Utc>,
+) -> bool {
+    terminal_states.contains(&status) && terminal_at < cutoff
+}
+
+/// Spawn the background retention task.
+pub fn spawn_retention_task(pool: PgPool, config: RetentionConfig) {
+    if !config.enabled {
+        tracing::info!("retention: disabled, background task not started");
+        return;
+    }
+
+    tokio::spawn(async move {
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(config.interval_seconds));
+
+        loop {
+            interval.tick().await;
+            tracing::info!("retention: starting run");
+
+            match run_retention(&pool, &config, Utc::now()).await {
+                Ok(outcome) => tracing::info!(
+                    deploy_proposals = outcome.deploy_proposals,
+                    proposal_signatures = outcome.proposal_signatures,
+                    governance_proposals = outcome.governance_proposals,
+                    governance_votes = outcome.governance_votes,
+                    "retention: run complete"
+                ),
+                Err(err) => tracing::error!(error = ?err, "retention: run failed"),
+            }
+        }
+    });
+}
+
+/// Archive terminal-state records older than the retention window.
+///
+/// Each table is archived in its own transaction, so a partial failure never
+/// leaves a proposal deleted without its archive copy. The run stops at the
+/// first table that errors; already-committed work stands and the next tick
+/// retries the remainder.
+pub async fn run_retention(
+    pool: &PgPool,
+    config: &RetentionConfig,
+    now: DateTime<Utc>,
+) -> Result<RetentionOutcome, sqlx::Error> {
+    let cutoff = config.cutoff(now);
+    let mut outcome = RetentionOutcome::default();
+
+    let (proposals, signatures) = archive_deploy_proposals(pool, cutoff, config.batch_size).await?;
+    outcome.deploy_proposals = proposals;
+    outcome.proposal_signatures = signatures;
+
+    let (proposals, votes) = archive_governance_proposals(pool, cutoff, config.batch_size).await?;
+    outcome.governance_proposals = proposals;
+    outcome.governance_votes = votes;
+
+    Ok(outcome)
+}
+
+/// Move terminal deploy proposals and their signatures into archive tables.
+///
+/// The retention anchor is `updated_at`, maintained by the table's trigger, so it
+/// marks when the record entered its terminal state rather than when it was
+/// created.
+async fn archive_deploy_proposals(
+    pool: &PgPool,
+    cutoff: DateTime<Utc>,
+    batch_size: i64,
+) -> Result<(u64, u64), sqlx::Error> {
+    let terminal_states: Vec<String> = DEPLOY_PROPOSAL_TERMINAL_STATES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let mut tx = pool.begin().await?;
+
+    let ids: Vec<Uuid> = sqlx::query_scalar(
+        r#"
+        SELECT id
+        FROM deploy_proposals
+        WHERE status::text = ANY($1)
+          AND updated_at < $2
+        ORDER BY updated_at
+        LIMIT $3
+        FOR UPDATE SKIP LOCKED
+        "#,
+    )
+    .bind(&terminal_states)
+    .bind(cutoff)
+    .bind(batch_size)
+    .fetch_all(&mut *tx)
+    .await?;
+
+    if ids.is_empty() {
+        tx.rollback().await?;
+        return Ok((0, 0));
+    }
+
+    let signatures = sqlx::query(
+        r#"
+        INSERT INTO proposal_signatures_archive (
+            id, proposal_id, signer_address, signature_data, signed_at
+        )
+        SELECT id, proposal_id, signer_address, signature_data, signed_at
+        FROM proposal_signatures
+        WHERE proposal_id = ANY($1)
+        ON CONFLICT (id) DO NOTHING
+        "#,
+    )
+    .bind(&ids)
+    .execute(&mut *tx)
+    .await?
+    .rows_affected();
+
+    let proposals = sqlx::query(
+        r#"
+        INSERT INTO deploy_proposals_archive (
+            id, contract_name, contract_id, wasm_hash, network, description,
+            policy_id, status, expires_at, executed_at, proposer, created_at, updated_at
+        )
+        SELECT id, contract_name, contract_id, wasm_hash, network::text, description,
+               policy_id, status::text, expires_at, executed_at, proposer, created_at, updated_at
+        FROM deploy_proposals
+        WHERE id = ANY($1)
+        ON CONFLICT (id) DO NOTHING
+        "#,
+    )
+    .bind(&ids)
+    .execute(&mut *tx)
+    .await?
+    .rows_affected();
+
+    // proposal_signatures cascade-delete with the parent; they are archived above.
+    sqlx::query("DELETE FROM deploy_proposals WHERE id = ANY($1)")
+        .bind(&ids)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+
+    Ok((proposals, signatures))
+}
+
+/// Move terminal governance proposals and their votes into archive tables.
+///
+/// `governance_proposals` has no `updated_at`, so the retention anchor is
+/// `executed_at` when present and `created_at` otherwise. The expression is
+/// backed by a matching index.
+async fn archive_governance_proposals(
+    pool: &PgPool,
+    cutoff: DateTime<Utc>,
+    batch_size: i64,
+) -> Result<(u64, u64), sqlx::Error> {
+    let terminal_states: Vec<String> = GOVERNANCE_PROPOSAL_TERMINAL_STATES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let mut tx = pool.begin().await?;
+
+    let ids: Vec<Uuid> = sqlx::query_scalar(
+        r#"
+        SELECT id
+        FROM governance_proposals
+        WHERE status::text = ANY($1)
+          AND COALESCE(executed_at, created_at) < $2
+        ORDER BY COALESCE(executed_at, created_at)
+        LIMIT $3
+        FOR UPDATE SKIP LOCKED
+        "#,
+    )
+    .bind(&terminal_states)
+    .bind(cutoff)
+    .bind(batch_size)
+    .fetch_all(&mut *tx)
+    .await?;
+
+    if ids.is_empty() {
+        tx.rollback().await?;
+        return Ok((0, 0));
+    }
+
+    let votes = sqlx::query(
+        r#"
+        INSERT INTO governance_votes_archive (
+            id, proposal_id, voter, vote_choice, voting_power, delegated_from, created_at
+        )
+        SELECT id, proposal_id, voter, vote_choice::text, voting_power, delegated_from, created_at
+        FROM governance_votes
+        WHERE proposal_id = ANY($1)
+        ON CONFLICT (id) DO NOTHING
+        "#,
+    )
+    .bind(&ids)
+    .execute(&mut *tx)
+    .await?
+    .rows_affected();
+
+    let proposals = sqlx::query(
+        r#"
+        INSERT INTO governance_proposals_archive (
+            id, contract_id, title, description, governance_model, proposer, status,
+            voting_starts_at, voting_ends_at, execution_delay_hours, quorum_required,
+            approval_threshold, created_at, executed_at
+        )
+        SELECT id, contract_id, title, description, governance_model::text, proposer, status::text,
+               voting_starts_at, voting_ends_at, execution_delay_hours, quorum_required,
+               approval_threshold, created_at, executed_at
+        FROM governance_proposals
+        WHERE id = ANY($1)
+        ON CONFLICT (id) DO NOTHING
+        "#,
+    )
+    .bind(&ids)
+    .execute(&mut *tx)
+    .await?
+    .rows_affected();
+
+    // governance_votes cascade-delete with the parent; they are archived above.
+    sqlx::query("DELETE FROM governance_proposals WHERE id = ANY($1)")
+        .bind(&ids)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+
+    Ok((proposals, votes))
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    match env::var(key) {
+        Ok(raw) => match raw.trim().to_lowercase().as_str() {
+            "true" | "1" | "yes" => true,
+            "false" | "0" | "no" => false,
+            _ => {
+                tracing::warn!("Invalid value for {key} (`{raw}`), using default {default}");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+fn env_u32(key: &str, default: u32) -> u32 {
+    match env::var(key) {
+        Ok(raw) => match raw.parse::<u32>() {
+            Ok(value) if value > 0 => value,
+            _ => {
+                tracing::warn!("Invalid value for {key} (`{raw}`), using default {default}");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    match env::var(key) {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(value) if value > 0 => value,
+            _ => {
+                tracing::warn!("Invalid value for {key} (`{raw}`), using default {default}");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(retention_days: u32) -> RetentionConfig {
+        RetentionConfig {
+            retention_days,
+            ..RetentionConfig::default()
+        }
+    }
+
+    fn at(now: DateTime<Utc>, days_ago: i64) -> DateTime<Utc> {
+        now - Duration::days(days_ago)
+    }
+
+    #[test]
+    fn cutoff_is_retention_days_before_now() {
+        let now = Utc::now();
+        assert_eq!(config(90).cutoff(now), now - Duration::days(90));
+    }
+
+    #[test]
+    fn record_exactly_at_threshold_is_retained() {
+        let now = Utc::now();
+        let cutoff = config(90).cutoff(now);
+
+        assert!(!is_purgeable(
+            "expired",
+            &DEPLOY_PROPOSAL_TERMINAL_STATES,
+            at(now, 90),
+            cutoff
+        ));
+    }
+
+    #[test]
+    fn record_just_under_threshold_is_retained() {
+        let now = Utc::now();
+        let cutoff = config(90).cutoff(now);
+        let terminal_at = at(now, 90) + Duration::seconds(1);
+
+        assert!(!is_purgeable(
+            "expired",
+            &DEPLOY_PROPOSAL_TERMINAL_STATES,
+            terminal_at,
+            cutoff
+        ));
+    }
+
+    #[test]
+    fn record_just_over_threshold_is_purged() {
+        let now = Utc::now();
+        let cutoff = config(90).cutoff(now);
+        let terminal_at = at(now, 90) - Duration::seconds(1);
+
+        assert!(is_purgeable(
+            "expired",
+            &DEPLOY_PROPOSAL_TERMINAL_STATES,
+            terminal_at,
+            cutoff
+        ));
+    }
+
+    #[test]
+    fn active_deploy_statuses_are_never_purged_regardless_of_age() {
+        let now = Utc::now();
+        let cutoff = config(90).cutoff(now);
+        let ancient = at(now, 3650);
+
+        for status in ["pending", "approved"] {
+            assert!(
+                !is_purgeable(status, &DEPLOY_PROPOSAL_TERMINAL_STATES, ancient, cutoff),
+                "{status} must never be purged"
+            );
+        }
+    }
+
+    #[test]
+    fn active_governance_statuses_are_never_purged_regardless_of_age() {
+        let now = Utc::now();
+        let cutoff = config(90).cutoff(now);
+        let ancient = at(now, 3650);
+
+        for status in ["pending", "active", "passed"] {
+            assert!(
+                !is_purgeable(
+                    status,
+                    &GOVERNANCE_PROPOSAL_TERMINAL_STATES,
+                    ancient,
+                    cutoff
+                ),
+                "{status} must never be purged"
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_deploy_statuses_past_window_are_purged() {
+        let now = Utc::now();
+        let cutoff = config(90).cutoff(now);
+        let old = at(now, 91);
+
+        for status in DEPLOY_PROPOSAL_TERMINAL_STATES {
+            assert!(
+                is_purgeable(status, &DEPLOY_PROPOSAL_TERMINAL_STATES, old, cutoff),
+                "{status} should be purged"
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_governance_statuses_past_window_are_purged() {
+        let now = Utc::now();
+        let cutoff = config(90).cutoff(now);
+        let old = at(now, 91);
+
+        for status in GOVERNANCE_PROPOSAL_TERMINAL_STATES {
+            assert!(
+                is_purgeable(status, &GOVERNANCE_PROPOSAL_TERMINAL_STATES, old, cutoff),
+                "{status} should be purged"
+            );
+        }
+    }
+
+    #[test]
+    fn custom_retention_window_shifts_the_boundary() {
+        let now = Utc::now();
+        let cutoff = config(30).cutoff(now);
+
+        assert!(!is_purgeable(
+            "rejected",
+            &DEPLOY_PROPOSAL_TERMINAL_STATES,
+            at(now, 30),
+            cutoff
+        ));
+        assert!(is_purgeable(
+            "rejected",
+            &DEPLOY_PROPOSAL_TERMINAL_STATES,
+            at(now, 31),
+            cutoff
+        ));
+    }
+
+    #[test]
+    fn passed_is_not_terminal_for_governance() {
+        assert!(!GOVERNANCE_PROPOSAL_TERMINAL_STATES.contains(&"passed"));
+    }
+
+    #[test]
+    fn approved_is_not_terminal_for_deploy() {
+        assert!(!DEPLOY_PROPOSAL_TERMINAL_STATES.contains(&"approved"));
+    }
+
+    #[test]
+    fn default_config_matches_documented_defaults() {
+        let config = RetentionConfig::default();
+
+        assert!(config.enabled);
+        assert_eq!(config.retention_days, 90);
+        assert_eq!(config.interval_seconds, 86_400);
+        assert_eq!(config.batch_size, 1_000);
+    }
+}
+
+/// Boundary tests that exercise the purge SQL against a real database.
+///
+/// These are `#[ignore]`d because they need a migrated Postgres instance:
+///
+/// ```text
+/// RETENTION_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost/soroban_registry_test \
+///     cargo test --bin api retention::db_tests -- --ignored --test-threads=1
+/// ```
+#[cfg(test)]
+mod db_tests {
+    use super::*;
+
+    async fn test_pool() -> PgPool {
+        let url = env::var("RETENTION_TEST_DATABASE_URL")
+            .expect("RETENTION_TEST_DATABASE_URL must be set to run DB-backed retention tests");
+
+        PgPool::connect(&url)
+            .await
+            .expect("connect to retention test database")
+    }
+
+    async fn seed_policy(pool: &PgPool) -> Uuid {
+        sqlx::query_scalar(
+            r#"
+            INSERT INTO multisig_policies (name, threshold, signer_addresses, created_by)
+            VALUES ('retention-test', 1, ARRAY['GRETENTIONTEST'], 'GRETENTIONTEST')
+            RETURNING id
+            "#,
+        )
+        .fetch_one(pool)
+        .await
+        .expect("seed multisig policy")
+    }
+
+    async fn seed_deploy_proposal(
+        pool: &PgPool,
+        policy_id: Uuid,
+        status: &str,
+        updated_at: DateTime<Utc>,
+    ) -> Uuid {
+        sqlx::query_scalar(
+            r#"
+            INSERT INTO deploy_proposals (
+                contract_name, contract_id, wasm_hash, network, policy_id,
+                status, expires_at, proposer, created_at, updated_at
+            )
+            VALUES (
+                'retention-test', 'CRETENTIONTEST', 'deadbeef', 'testnet'::network_type, $1,
+                $2::proposal_status, $3, 'GRETENTIONTEST', $3, $3
+            )
+            RETURNING id
+            "#,
+        )
+        .bind(policy_id)
+        .bind(status)
+        .bind(updated_at)
+        .fetch_one(pool)
+        .await
+        .expect("seed deploy proposal")
+    }
+
+    async fn live_exists(pool: &PgPool, id: Uuid) -> bool {
+        sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM deploy_proposals WHERE id = $1)")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .expect("check live row")
+    }
+
+    async fn archived_exists(pool: &PgPool, id: Uuid) -> bool {
+        sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS(SELECT 1 FROM deploy_proposals_archive WHERE id = $1)",
+        )
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .expect("check archived row")
+    }
+
+    async fn cleanup(pool: &PgPool, policy_id: Uuid, ids: &[Uuid]) {
+        sqlx::query("DELETE FROM proposal_signatures_archive WHERE proposal_id = ANY($1)")
+            .bind(ids)
+            .execute(pool)
+            .await
+            .ok();
+        sqlx::query("DELETE FROM deploy_proposals_archive WHERE id = ANY($1)")
+            .bind(ids)
+            .execute(pool)
+            .await
+            .ok();
+        sqlx::query("DELETE FROM deploy_proposals WHERE id = ANY($1)")
+            .bind(ids)
+            .execute(pool)
+            .await
+            .ok();
+        sqlx::query("DELETE FROM multisig_policies WHERE id = $1")
+            .bind(policy_id)
+            .execute(pool)
+            .await
+            .ok();
+    }
+
+    /// Records exactly at, just inside, and just past the retention threshold.
+    #[tokio::test]
+    #[ignore]
+    async fn purge_respects_retention_boundary() {
+        let pool = test_pool().await;
+        let config = RetentionConfig::default();
+        let now = Utc::now();
+        let threshold = config.cutoff(now);
+
+        let policy_id = seed_policy(&pool).await;
+        let exactly_at = seed_deploy_proposal(&pool, policy_id, "expired", threshold).await;
+        let just_under =
+            seed_deploy_proposal(&pool, policy_id, "expired", threshold + Duration::seconds(1))
+                .await;
+        let just_over =
+            seed_deploy_proposal(&pool, policy_id, "expired", threshold - Duration::seconds(1))
+                .await;
+
+        run_retention(&pool, &config, now).await.expect("retention run");
+
+        assert!(
+            live_exists(&pool, exactly_at).await,
+            "record exactly at the threshold is still within the window"
+        );
+        assert!(
+            live_exists(&pool, just_under).await,
+            "record just inside the window is retained"
+        );
+        assert!(
+            !live_exists(&pool, just_over).await,
+            "record just past the window is removed from the live table"
+        );
+        assert!(
+            archived_exists(&pool, just_over).await,
+            "purged record is archived, not hard-deleted"
+        );
+
+        cleanup(&pool, policy_id, &[exactly_at, just_under, just_over]).await;
+    }
+
+    /// Non-terminal records are retained no matter how old they are.
+    #[tokio::test]
+    #[ignore]
+    async fn active_records_are_never_purged() {
+        let pool = test_pool().await;
+        let config = RetentionConfig::default();
+        let now = Utc::now();
+        let ancient = now - Duration::days(3650);
+
+        let policy_id = seed_policy(&pool).await;
+        let pending = seed_deploy_proposal(&pool, policy_id, "pending", ancient).await;
+        let approved = seed_deploy_proposal(&pool, policy_id, "approved", ancient).await;
+
+        run_retention(&pool, &config, now).await.expect("retention run");
+
+        assert!(live_exists(&pool, pending).await, "pending must survive");
+        assert!(live_exists(&pool, approved).await, "approved must survive");
+
+        cleanup(&pool, policy_id, &[pending, approved]).await;
+    }
+
+    /// Cascading child rows are archived rather than destroyed with the parent.
+    #[tokio::test]
+    #[ignore]
+    async fn cascading_signatures_are_archived_with_the_parent() {
+        let pool = test_pool().await;
+        let config = RetentionConfig::default();
+        let now = Utc::now();
+
+        let policy_id = seed_policy(&pool).await;
+        let proposal_id =
+            seed_deploy_proposal(&pool, policy_id, "executed", now - Duration::days(120)).await;
+
+        sqlx::query(
+            r#"
+            INSERT INTO proposal_signatures (proposal_id, signer_address, signature_data)
+            VALUES ($1, 'GRETENTIONTEST', 'sig')
+            "#,
+        )
+        .bind(proposal_id)
+        .execute(&pool)
+        .await
+        .expect("seed signature");
+
+        run_retention(&pool, &config, now).await.expect("retention run");
+
+        let archived_signatures: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM proposal_signatures_archive WHERE proposal_id = $1",
+        )
+        .bind(proposal_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count archived signatures");
+
+        assert_eq!(
+            archived_signatures, 1,
+            "signature trail must be preserved when the parent proposal is purged"
+        );
+
+        cleanup(&pool, policy_id, &[proposal_id]).await;
+    }
+}

--- a/database/migrations/20260729000000_history_retention.sql
+++ b/database/migrations/20260729000000_history_retention.sql
@@ -1,0 +1,92 @@
+-- History table retention: archive storage for terminal-state proposal records.
+--
+-- Terminal proposals accumulate indefinitely and degrade the indexed status /
+-- timestamp lookups on the live tables. The retention job moves records past the
+-- retention window into these archive tables rather than hard-deleting them.
+--
+-- Archive tables intentionally store enum-backed columns (status, network,
+-- governance_model) as TEXT so archived history stays readable if the live enum
+-- definitions change, and carry no foreign keys so archived rows survive deletion
+-- of the contracts, publishers, and policies they referenced.
+
+CREATE TABLE deploy_proposals_archive (
+    id                    UUID PRIMARY KEY,
+    contract_name         VARCHAR(255) NOT NULL,
+    contract_id           VARCHAR(56)  NOT NULL,
+    wasm_hash             VARCHAR(64)  NOT NULL,
+    network               TEXT         NOT NULL,
+    description           TEXT,
+    policy_id             UUID,
+    status                TEXT         NOT NULL,
+    expires_at            TIMESTAMPTZ  NOT NULL,
+    executed_at           TIMESTAMPTZ,
+    proposer              VARCHAR(56)  NOT NULL,
+    created_at            TIMESTAMPTZ  NOT NULL,
+    updated_at            TIMESTAMPTZ  NOT NULL,
+    archived_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_deploy_proposals_archive_archived_at ON deploy_proposals_archive(archived_at);
+CREATE INDEX idx_deploy_proposals_archive_contract_id ON deploy_proposals_archive(contract_id);
+CREATE INDEX idx_deploy_proposals_archive_status      ON deploy_proposals_archive(status);
+
+-- proposal_signatures cascade-delete from deploy_proposals, so they are archived
+-- alongside the parent to avoid losing the approval trail.
+CREATE TABLE proposal_signatures_archive (
+    id                    UUID PRIMARY KEY,
+    proposal_id           UUID         NOT NULL,
+    signer_address        VARCHAR(56)  NOT NULL,
+    signature_data        TEXT,
+    signed_at             TIMESTAMPTZ  NOT NULL,
+    archived_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_proposal_signatures_archive_proposal_id ON proposal_signatures_archive(proposal_id);
+CREATE INDEX idx_proposal_signatures_archive_archived_at ON proposal_signatures_archive(archived_at);
+
+CREATE TABLE governance_proposals_archive (
+    id                    UUID PRIMARY KEY,
+    contract_id           UUID,
+    title                 VARCHAR(255) NOT NULL,
+    description           TEXT         NOT NULL,
+    governance_model      TEXT         NOT NULL,
+    proposer              UUID,
+    status                TEXT         NOT NULL,
+    voting_starts_at      TIMESTAMPTZ  NOT NULL,
+    voting_ends_at        TIMESTAMPTZ  NOT NULL,
+    execution_delay_hours INTEGER,
+    quorum_required       INTEGER      NOT NULL,
+    approval_threshold    INTEGER      NOT NULL,
+    created_at            TIMESTAMPTZ  NOT NULL,
+    executed_at           TIMESTAMPTZ,
+    archived_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_governance_proposals_archive_archived_at ON governance_proposals_archive(archived_at);
+CREATE INDEX idx_governance_proposals_archive_contract_id ON governance_proposals_archive(contract_id);
+CREATE INDEX idx_governance_proposals_archive_status      ON governance_proposals_archive(status);
+
+-- governance_votes cascade-delete from governance_proposals, so they are archived
+-- alongside the parent to preserve the voting record.
+CREATE TABLE governance_votes_archive (
+    id                    UUID PRIMARY KEY,
+    proposal_id           UUID         NOT NULL,
+    voter                 UUID         NOT NULL,
+    vote_choice           TEXT         NOT NULL,
+    voting_power          BIGINT       NOT NULL,
+    delegated_from        UUID,
+    created_at            TIMESTAMPTZ  NOT NULL,
+    archived_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_governance_votes_archive_proposal_id ON governance_votes_archive(proposal_id);
+CREATE INDEX idx_governance_votes_archive_archived_at ON governance_votes_archive(archived_at);
+
+-- Supporting indexes for the purge scan. The retention anchor is the point a
+-- record entered its terminal state: deploy_proposals maintains updated_at via
+-- trigger, governance_proposals has no updated_at so it falls back to created_at
+-- for records that never executed.
+CREATE INDEX idx_deploy_proposals_updated_at ON deploy_proposals(updated_at);
+
+CREATE INDEX idx_governance_proposals_terminal_at
+    ON governance_proposals ((COALESCE(executed_at, created_at)));

--- a/docs/DATA_RETENTION.md
+++ b/docs/DATA_RETENTION.md
@@ -1,0 +1,97 @@
+# Data Retention
+
+Proposal history tables grow without bound. Every deploy proposal that expires and
+every governance proposal that gets rejected stays in the live table forever,
+inflating the indexes on `status`, `updated_at`, and `expires_at` that normal
+queries depend on.
+
+The retention task moves those records into archive tables once they fall outside
+a configurable window.
+
+## What gets archived
+
+| Live table | Archive table | Retention anchor |
+|---|---|---|
+| `deploy_proposals` | `deploy_proposals_archive` | `updated_at` |
+| `proposal_signatures` | `proposal_signatures_archive` | parent proposal |
+| `governance_proposals` | `governance_proposals_archive` | `COALESCE(executed_at, created_at)` |
+| `governance_votes` | `governance_votes_archive` | parent proposal |
+
+Records are moved, never hard-deleted. Each table is archived in its own
+transaction, so a partial failure never leaves a proposal deleted without its
+archive copy. A run stops at the first table that errors; committed work stands
+and the next run retries the remainder.
+
+`proposal_signatures` and `governance_votes` are `ON DELETE CASCADE` children.
+They are archived alongside their parent, otherwise purging a proposal would
+silently destroy its approval trail or voting record.
+
+## Terminal states
+
+Only records in a state they can no longer transition out of are eligible:
+
+| Table | Terminal (eligible) | Active (never archived) |
+|---|---|---|
+| `deploy_proposals` | `executed`, `expired`, `rejected` | `pending`, `approved` |
+| `governance_proposals` | `executed`, `rejected`, `cancelled` | `pending`, `active`, `passed` |
+
+`approved` and `passed` are deliberately excluded. An approved deploy proposal has
+collected its signatures but has not been executed; a passed governance proposal
+is still waiting out `execution_delay_hours`. Both are live workflow state.
+
+Active records are never archived regardless of age.
+
+### Known limitation on the governance anchor
+
+`governance_proposals` has no `updated_at` column, so a proposal that never
+executed falls back to `created_at`. A long-running proposal created 100 days ago
+and rejected yesterday is therefore eligible immediately, even though it only just
+became terminal. `deploy_proposals` is unaffected — its trigger-maintained
+`updated_at` marks the actual transition.
+
+Fixing this properly means adding `updated_at` plus an
+`update_updated_at_column()` trigger to `governance_proposals`, which is a schema
+change to an existing table and out of scope here.
+
+## Boundary semantics
+
+The cutoff is `now - RETENTION_DAYS`. A record is archived only when its anchor
+timestamp is **strictly older** than the cutoff, so a record sitting exactly on
+the boundary is still inside the window and is retained.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RETENTION_ENABLED` | `true` | Set to `false` to stop the task from starting |
+| `RETENTION_DAYS` | `90` | Length of the retention window |
+| `RETENTION_INTERVAL_SECONDS` | `86400` | How often the task runs |
+| `RETENTION_BATCH_SIZE` | `1000` | Max records per table per run |
+
+Invalid or zero values fall back to the default with a warning, matching the
+behaviour of the rate limiter and cache config.
+
+Batching bounds transaction size on the first run against a large backlog. A
+backlog bigger than one batch drains over subsequent runs; lower
+`RETENTION_INTERVAL_SECONDS` temporarily to drain it faster.
+
+## Recovering archived records
+
+Archive tables carry no foreign keys and store enum-backed columns as `TEXT`, so
+archived rows survive deletion of the contracts, publishers, and policies they
+referenced, and stay readable if the live enums change. Restoring means selecting
+from the archive table and re-inserting with the appropriate casts.
+
+## Tests
+
+Boundary conditions are covered in `backend/api/src/retention.rs`:
+
+- Pure unit tests for the cutoff predicate — exactly at, just under, and just
+  over the threshold, plus active-state exclusion. These run with `cargo test`.
+- DB-backed tests that exercise the purge SQL itself. These are `#[ignore]`d
+  because they need a migrated Postgres:
+
+  ```bash
+  RETENTION_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost/soroban_registry_test \
+      cargo test --bin api retention::db_tests -- --ignored --test-threads=1
+  ```


### PR DESCRIPTION
Closes #1118

## Scope note: which tables

The issue names `ownership_transfers` and `dependency_scan_runs`. Neither exists in this repo - not in the working tree and not anywhere in git history. This PR applies the policy to the tables that actually match the issue's description of terminal states and indexed `expires_at`/`created_at` lookups:

| Issue says | This PR uses | Why |
|---|---|---|
| `ownership_transfers` | `deploy_proposals` | Status enum is `pending`/`approved`/`executed`/`expired`/`rejected` - the closest match to the issue's "expired, rejected" wording. Has indexed `expires_at` and `status`. |
| `dependency_scan_runs` | `governance_proposals` | Has real pending/active states, so "active records are never purged" is enforceable and testable. |

`contract_scan_results` is the nearest thing to `dependency_scan_runs`, but it has no status column, so the "active records never purged" criterion cannot be satisfied there without a schema change. Left out deliberately. `package_signatures` has `revoked`/`expired` terminal states but they are authenticity records, so purging them risks breaking signature-verification history - also left out.

Happy to extend to either if maintainers prefer.

## What

Terminal-state proposals accumulate indefinitely in `deploy_proposals` and `governance_proposals`, degrading the indexed status and timestamp lookups those tables rely on. Adds a configurable background task that archives them into `*_archive` tables past a retention window instead of deleting them.

Configurable via `RETENTION_ENABLED`, `RETENTION_DAYS` (default 90), `RETENTION_INTERVAL_SECONDS` and `RETENTION_BATCH_SIZE`. Adds `.env.example`, which the README referenced but did not exist.

## Design decisions worth reviewing

**Cascading children are archived, not destroyed.** `proposal_signatures` and `governance_votes` are `ON DELETE CASCADE`. Deleting a parent proposal would silently wipe the approval trail and voting record, defeating the point of archiving. Both are archived with their parent in the same transaction.

**`approved` and `passed` are treated as active, not terminal.** An approved deploy proposal awaits execution; a passed governance proposal is waiting out `execution_delay_hours`. Purging either would delete live workflow state. Terminal sets are `executed`/`expired`/`rejected` and `executed`/`rejected`/`cancelled`.

**Boundary is strict.** A record exactly on the retention threshold is still inside the window and is retained; only records strictly older are archived.

Archive tables store enum-backed columns as `TEXT` and carry no foreign keys, so archived rows stay readable if the live enums change and survive deletion of the contracts, publishers and policies they referenced.

## Verification

Applied against Postgres 16. Unit tests cover the boundary predicate; DB-backed tests exercise the purge SQL itself and pass against a live database:

```
retention::db_tests::purge_respects_retention_boundary ............. ok
retention::db_tests::active_records_are_never_purged ............... ok
retention::db_tests::cascading_signatures_are_archived_with_parent . ok
```

The DB tests are `#[ignore]`d since they need a migrated database. Run with:

```
RETENTION_TEST_DATABASE_URL=postgres://... cargo test --bin api retention -- --ignored --test-threads=1
```

## Reviewer notes

- **Depends on #1129.** The migration here uses a unique timestamp version and the queries filter on `status::text` rather than the enum type name, so this compiles and merges independently in either order. But `sqlx::migrate!` cannot reach it until the duplicate version prefixes in #1129 are fixed, so it is inert until that lands.
- The `metrics_handler.rs` change is a prerequisite, not scope creep: dead imports and stale `AppState` fields there prevented the api test binary from compiling at all, so the boundary tests could not otherwise run. Making the suite compile exposes one pre-existing failure, `metrics::tests::test_at_least_50_metric_families` (asserts >=50 metric families, gets 45). `register_all` registers 56 collectors but 16 are label-vecs that emit nothing until labelled, and that test exercises about 5. Left failing rather than quietly lowering an assertion in an unrelated module.
- `governance_proposals` has no `updated_at`, so its retention anchor falls back to `created_at` for records that never executed. A long-running proposal rejected yesterday is therefore eligible immediately. Documented in `docs/DATA_RETENTION.md`; fixing it properly needs an `updated_at` column and trigger.
