### PR TITLE
Backend: Add policy engine for sensitive action authorization

### DIFF
--- a/backend/api/src/auth.rs
+++ b/backend/api/src/auth.rs
@@ -3,7 +3,7 @@ use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::{
     extract::Request,
-    http::{header, HeaderMap, StatusCode},
+    http::{header, HeaderMap},
     middleware::Next,
     response::Response,
 };
@@ -19,54 +19,38 @@ use stellar_strkey::{ed25519::PublicKey as StellarPublicKey, Strkey};
 
 pub const MIN_JWT_SECRET_LEN: usize = 32;
 
-/// Authenticated user extracted from a valid Bearer JWT.
-/// The `sub` claim is expected to be the publisher's Stellar address,
-/// and `publisher_id` is derived by looking up the publisher in the DB.
-/// For simplicity (matching the existing subscription_handlers pattern),
-/// we store the sub as a string and expose a UUID parsed from it when possible,
-/// falling back to a nil UUID so callers can handle the error themselves.
+/// Authenticated publisher extracted from the canonical Bearer JWT path.
 #[derive(Debug, Clone)]
 pub struct AuthenticatedUser {
-    /// The `sub` claim from the JWT (Stellar address / publisher identifier)
+    /// The Stellar address proven during wallet authentication.
     pub stellar_address: String,
-    /// Publisher UUID — parsed from sub if it is a UUID, otherwise nil
+    /// Publisher UUID carried in the server-signed token.
     pub publisher_id: uuid::Uuid,
-    /// Database user id (publisher primary key)
+    /// Backward-compatible alias for the publisher primary key.
     pub id: uuid::Uuid,
-    /// Full claims for callers that need them
+    /// Full claims for callers that need them.
     pub claims: AuthClaims,
 }
 
 #[axum::async_trait]
-impl<S> axum::extract::FromRequestParts<S> for AuthenticatedUser
-where
-    S: Send + Sync,
-{
-    type Rejection = StatusCode;
+impl axum::extract::FromRequestParts<AppState> for AuthenticatedUser {
+    type Rejection = ApiError;
 
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
-        _state: &S,
+        state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        let auth_header = parts
-            .headers
-            .get(header::AUTHORIZATION)
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.strip_prefix("Bearer "))
-            .ok_or(StatusCode::UNAUTHORIZED)?;
-
-        let auth_manager =
-            AuthManager::from_env().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        let claims = auth_manager
-            .validate_jwt(auth_header)
-            .map_err(|_| StatusCode::UNAUTHORIZED)?;
-
-        let publisher_id = uuid::Uuid::parse_str(&claims.sub).unwrap_or(uuid::Uuid::nil());
+        let claims = AuthClaims::from_request_parts(parts, state).await?;
+        if claims.publisher_id.is_nil() {
+            return Err(ApiError::forbidden(
+                "The authenticated account is not a registered publisher",
+            ));
+        }
 
         Ok(AuthenticatedUser {
             stellar_address: claims.sub.clone(),
-            publisher_id,
-            id: publisher_id,
+            publisher_id: claims.publisher_id,
+            id: claims.publisher_id,
             claims,
         })
     }
@@ -379,6 +363,34 @@ impl AuthManager {
             .map(|data| data.claims)
             .map_err(|_| "invalid_token")
     }
+
+    /// Validate a JWT and, when it references a server-side session, ensure the
+    /// session is still active and describes the same authenticated identity.
+    ///
+    /// Sessionless JWTs remain valid for backward compatibility (including
+    /// externally-issued admin tokens). New wallet logins use session-backed
+    /// token pairs and therefore receive revocation checks here.
+    pub fn validate_access_token(&self, token: &str) -> Result<AuthClaims, &'static str> {
+        let claims = self.validate_jwt(token)?;
+        let Some(session_id) = claims.session_id else {
+            return Ok(claims);
+        };
+
+        let session = self.sessions.get(&session_id).ok_or("session_not_found")?;
+        if Utc::now().timestamp() > session.expires_at {
+            return Err("session_expired");
+        }
+        if session.subject != claims.sub
+            || session.publisher_id != claims.publisher_id
+            || session.role != claims.role
+            || session.scopes != claims.scopes
+            || session.mfa_verified != claims.mfa_verified
+        {
+            return Err("session_identity_mismatch");
+        }
+
+        Ok(claims)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -459,7 +471,7 @@ pub fn authenticate_headers(
         .read()
         .map_err(|_| ApiError::internal("Authentication state unavailable"))?;
     let claims = mgr
-        .validate_jwt(token)
+        .validate_access_token(token)
         .map_err(|_| ApiError::unauthorized("Invalid or expired token"))?;
 
     let role = claims.role.clone().unwrap_or_else(|| {
@@ -473,7 +485,7 @@ pub fn authenticate_headers(
     audit_auth_attempt(&claims.sub, true, "token accepted");
     Ok(AuthContext {
         subject: claims.sub,
-        publisher_id: Some(claims.publisher_id),
+        publisher_id: (!claims.publisher_id.is_nil()).then_some(claims.publisher_id),
         role,
         permissions: claims.scopes,
         method,
@@ -590,7 +602,7 @@ fn hash_refresh_token(token: &str) -> String {
 impl FromRequestParts<AppState> for AuthClaims {
     type Rejection = ApiError;
 
-    async fn from_request_parts(parts: &mut Parts, _state: &AppState) -> Result<Self, ApiError> {
+    async fn from_request_parts(parts: &mut Parts, state: &AppState) -> Result<Self, ApiError> {
         let auth_header = parts
             .headers
             .get(header::AUTHORIZATION)
@@ -604,11 +616,12 @@ impl FromRequestParts<AppState> for AuthClaims {
         }
 
         let token = &auth_header[7..];
-        let auth_manager = AuthManager::from_env()
-            .map_err(|_| ApiError::internal("Authentication configuration error"))?;
-
+        let auth_manager = state
+            .auth_mgr
+            .read()
+            .map_err(|_| ApiError::internal("Authentication state unavailable"))?;
         let claims = auth_manager
-            .validate_jwt(token)
+            .validate_access_token(token)
             .map_err(|_| ApiError::unauthorized("Invalid or expired token"))?;
 
         Ok(claims)
@@ -624,10 +637,6 @@ fn extract_bearer_token(req: &Request) -> Option<&str> {
         .filter(|token| !token.is_empty())
 }
 
-fn is_admin(claims: &AuthClaims) -> bool {
-    claims.admin || matches!(claims.role.as_deref(), Some("admin" | "ADMIN" | "Admin"))
-}
-
 pub async fn require_admin(req: Request, next: Next) -> Result<Response, ApiError> {
     let Some(token) = extract_bearer_token(&req) else {
         return Err(ApiError::unauthorized(
@@ -635,17 +644,16 @@ pub async fn require_admin(req: Request, next: Next) -> Result<Response, ApiErro
         ));
     };
 
+    // Router-level middleware is constructed before AppState is available to
+    // `from_fn`, so admin tokens use the same validated JWT configuration
+    // without attempting a server-side session lookup. Publisher-sensitive
+    // handlers use `PolicyActor` and the live AppState-backed session path.
     let auth = AuthManager::from_env()
         .map_err(|_| ApiError::internal("Authentication configuration error"))?;
     let claims = auth
         .validate_jwt(token)
         .map_err(|_| ApiError::unauthorized("Invalid or expired authentication token"))?;
-
-    if !is_admin(&claims) {
-        return Err(ApiError::forbidden(
-            "Administrative privileges are required for this endpoint",
-        ));
-    }
+    crate::policy::require_admin_claims(&claims)?;
 
     Ok(next.run(req).await)
 }
@@ -767,5 +775,75 @@ mod tests {
 
         let valid = "a".repeat(MIN_JWT_SECRET_LEN);
         assert!(AuthManager::validate_jwt_secret(&valid).is_ok());
+    }
+
+    #[test]
+    fn access_tokens_are_bound_to_their_live_session_identity() {
+        let mut auth = AuthManager::new("test-secret".to_string());
+        let session_id = uuid::Uuid::new_v4();
+        let publisher_id = uuid::Uuid::new_v4();
+        let address = "GSESSION";
+        auth.sessions.insert(
+            session_id,
+            SessionRecord {
+                subject: address.to_string(),
+                publisher_id,
+                role: None,
+                scopes: vec!["write".to_string()],
+                mfa_verified: false,
+                expires_at: Utc::now().timestamp() + 3_600,
+            },
+        );
+
+        let token = auth
+            .issue_access_token_for_session(
+                session_id,
+                address,
+                publisher_id,
+                vec!["write".to_string()],
+                None,
+                false,
+                3_600,
+            )
+            .expect("session token");
+        assert!(auth.validate_access_token(&token).is_ok());
+
+        auth.sessions.get_mut(&session_id).unwrap().expires_at = Utc::now().timestamp() - 1;
+        assert!(matches!(
+            auth.validate_access_token(&token),
+            Err("session_expired")
+        ));
+
+        auth.sessions.get_mut(&session_id).unwrap().expires_at = Utc::now().timestamp() + 3_600;
+        auth.sessions.get_mut(&session_id).unwrap().publisher_id = uuid::Uuid::new_v4();
+        assert!(matches!(
+            auth.validate_access_token(&token),
+            Err("session_identity_mismatch")
+        ));
+
+        auth.revoke_session(session_id);
+        assert!(matches!(
+            auth.validate_access_token(&token),
+            Err("session_not_found")
+        ));
+    }
+
+    #[test]
+    fn sessionless_tokens_remain_backward_compatible() {
+        let auth = AuthManager::new("test-secret".to_string());
+        let claims = AuthClaims {
+            sub: "GLEGACY".to_string(),
+            publisher_id: uuid::Uuid::nil(),
+            iat: Utc::now().timestamp(),
+            exp: Utc::now().timestamp() + 3_600,
+            scopes: vec![],
+            role: Some("admin".to_string()),
+            admin: true,
+            mfa_verified: false,
+            session_id: None,
+        };
+        let token = encode(&Header::default(), &claims, &auth.encoding_key).expect("legacy token");
+
+        assert!(auth.validate_access_token(&token).is_ok());
     }
 }

--- a/backend/api/src/dependency_vulnerability_handlers.rs
+++ b/backend/api/src/dependency_vulnerability_handlers.rs
@@ -20,10 +20,10 @@ use shared::{
 };
 
 use crate::{
-    auth::AuthClaims,
     dependency_vulnerability::{scan_dependencies, sync_known_advisories},
     error::{ApiError, ApiResult},
     handlers::db_internal_error,
+    policy::{self, PolicyActor},
     state::AppState,
 };
 
@@ -45,41 +45,17 @@ struct ScanFindingRow {
     recommended_version: Option<String>,
 }
 
-async fn require_contract_owner(
-    state: &AppState,
-    contract_id: Uuid,
-    claims: &AuthClaims,
-) -> ApiResult<()> {
-    let publisher_id: Option<Uuid> =
-        sqlx::query_scalar("SELECT publisher_id FROM contracts WHERE id = $1")
-            .bind(contract_id)
-            .fetch_optional(&state.db)
-            .await
-            .map_err(|e| db_internal_error("lookup contract publisher", e))?;
-
-    let publisher_id = publisher_id
-        .ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
-
-    if publisher_id != claims.publisher_id {
-        return Err(ApiError::forbidden(
-            "Only the contract's publisher can manage dependency scanning",
-        ));
-    }
-
-    Ok(())
-}
-
 /// POST /api/contracts/:id/package-dependencies
 ///
 /// Declares (replacing) the package/crate dependencies for a contract and
 /// immediately scans them against known vulnerability sources.
 pub async fn declare_package_dependencies(
     State(state): State<AppState>,
-    claims: AuthClaims,
+    actor: PolicyActor,
     Path(id): Path<Uuid>,
     Json(body): Json<DeclarePackageDependenciesRequest>,
 ) -> ApiResult<(StatusCode, Json<DependencyScanReport>)> {
-    require_contract_owner(&state, id, &claims).await?;
+    policy::require_contract_owner(&state, &actor, id).await?;
 
     if body.dependencies.len() > MAX_DECLARED_DEPENDENCIES {
         return Err(ApiError::bad_request(
@@ -186,10 +162,10 @@ pub async fn get_dependency_scan_report(
 /// without requiring the dependency list to be re-declared.
 pub async fn trigger_dependency_scan(
     State(state): State<AppState>,
-    claims: AuthClaims,
+    actor: PolicyActor,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<DependencyScanReport>> {
-    require_contract_owner(&state, id, &claims).await?;
+    policy::require_contract_owner(&state, &actor, id).await?;
     let report = run_scan(&state, id, "manual").await?;
     Ok(Json(report))
 }

--- a/backend/api/src/deprecation_handlers.rs
+++ b/backend/api/src/deprecation_handlers.rs
@@ -12,6 +12,8 @@ use std::collections::HashSet;
 use uuid::Uuid;
 
 use crate::error::{ApiError, ApiResult};
+use crate::ownership_transfer;
+use crate::policy::{self, PolicyActor};
 use crate::state::AppState;
 
 // ─── Public helper ────────────────────────────────────────────────────────────
@@ -245,10 +247,13 @@ pub async fn get_deprecation_info(
 )]
 pub async fn deprecate_contract(
     State(state): State<AppState>,
+    actor: PolicyActor,
     Path(id): Path<String>,
     ValidatedJson(req): ValidatedJson<DeprecateContractRequest>,
 ) -> ApiResult<Json<DeprecationInfo>> {
     let (contract_uuid, contract_id) = fetch_contract_identity(&state, &id).await?;
+    policy::require_contract_owner(&state, &actor, contract_uuid).await?;
+    verify_deprecation_signature(&actor, &contract_id, &req)?;
 
     let reason = req.deprecated_reason.clone().or_else(|| req.notes.clone());
 
@@ -398,10 +403,12 @@ pub async fn deprecate_contract(
 )]
 pub async fn undeprecate_contract(
     State(state): State<AppState>,
+    actor: PolicyActor,
     Path(id): Path<String>,
     Query(req): Query<UndeprecateContractRequest>,
 ) -> ApiResult<Json<DeprecationInfo>> {
     let (contract_uuid, contract_id) = fetch_contract_identity(&state, &id).await?;
+    policy::require_contract_owner(&state, &actor, contract_uuid).await?;
 
     let is_deprecated: bool = sqlx::query_scalar(
         "SELECT COALESCE(is_deprecated, FALSE) FROM contracts WHERE id = $1",
@@ -566,7 +573,10 @@ fn build_lineage_warnings(
 )]
 pub async fn purge_expired_deprecated_contracts(
     State(state): State<AppState>,
+    actor: PolicyActor,
 ) -> ApiResult<Json<serde_json::Value>> {
+    actor.require_admin()?;
+
     // Find contracts whose grace period has fully elapsed:
     //   deprecated_at + grace_period_days < NOW()
     let expired: Vec<(Uuid, String)> = sqlx::query_as(
@@ -608,6 +618,61 @@ pub async fn purge_expired_deprecated_contracts(
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
+
+fn verify_deprecation_signature(
+    actor: &PolicyActor,
+    contract_id: &str,
+    req: &DeprecateContractRequest,
+) -> ApiResult<()> {
+    let (payload, signature, signing_address) =
+        match (&req.payload, &req.signature, &req.signing_address) {
+            (None, None, None) => return Ok(()),
+            (Some(payload), Some(signature), Some(signing_address)) => {
+                (payload, signature, signing_address)
+            }
+            _ => {
+                return Err(ApiError::bad_request(
+                    "IncompleteSignatureEnvelope",
+                    "payload, signature, and signing_address must be supplied together",
+                ))
+            }
+        };
+
+    actor.require_signature_identity(signing_address)?;
+    if payload.action != "deprecate" || payload.contract_id != contract_id {
+        return Err(ApiError::bad_request(
+            "SignaturePayloadMismatch",
+            "The signed payload does not describe this contract deprecation",
+        ));
+    }
+    if !(16..=128).contains(&payload.nonce.len())
+        || !payload
+            .nonce
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(ApiError::bad_request(
+            "InvalidSignatureNonce",
+            "The signature nonce must be 16-128 ASCII letters, digits, hyphens, or underscores",
+        ));
+    }
+
+    let signed_at = DateTime::parse_from_rfc3339(&payload.timestamp)
+        .map_err(|_| {
+            ApiError::bad_request(
+                "InvalidSignatureTimestamp",
+                "The signature timestamp must be RFC 3339",
+            )
+        })?
+        .timestamp();
+    ownership_transfer::check_signature_freshness(signed_at, Utc::now().timestamp())?;
+
+    let message = format!(
+        "{}:{}:{}:{}",
+        payload.action, payload.contract_id, payload.timestamp, payload.nonce
+    );
+    ownership_transfer::verify_transfer_signature(actor.stellar_address(), &message, signature)
+}
 
 async fn notify_dependents(
     state: &AppState,

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -79,7 +79,6 @@ pub struct ContractStatsResponse {
 
 use crate::{
     analytics,
-    auth::AuthClaims,
     breaking_changes::{diff_abi, has_breaking_changes, resolve_abi},
     cache::IdempotencyClaim,
     contract_events::ContractEventEnvelope,
@@ -87,6 +86,7 @@ use crate::{
     error::{ApiError, ApiResult},
     onchain_verification::OnChainVerifier,
     ownership_transfer as transfer,
+    policy::PolicyActor,
     state::{AppState, ContractEventVisibility},
 };
 
@@ -4550,10 +4550,14 @@ fn extract_idempotency_key(headers: &HeaderMap) -> ApiResult<Option<String>> {
 )]
 pub async fn publish_contract(
     State(state): State<AppState>,
+    actor: PolicyActor,
     headers: HeaderMap,
     ValidatedJson(req): ValidatedJson<PublishRequest>,
 ) -> ApiResult<Json<Contract>> {
-    let idempotency_key = extract_idempotency_key(&headers)?;
+    actor.require_publisher_address(&req.publisher_address)?;
+    let publisher_id = actor.publisher_id()?;
+    let idempotency_key =
+        extract_idempotency_key(&headers)?.map(|key| format!("publish:{publisher_id}:{key}"));
 
     if let Some(key) = &idempotency_key {
         match state.cache.claim_idempotency_key(key).await {
@@ -4576,7 +4580,7 @@ pub async fn publish_contract(
         }
     }
 
-    let result = publish_contract_inner(&state, &headers, req).await;
+    let result = publish_contract_inner(&state, &headers, &actor, req).await;
 
     if let Some(key) = &idempotency_key {
         match &result {
@@ -4606,8 +4610,10 @@ pub async fn publish_contract(
 async fn publish_contract_inner(
     state: &AppState,
     headers: &HeaderMap,
+    actor: &PolicyActor,
     req: PublishRequest,
 ) -> ApiResult<Json<Contract>> {
+    let publisher_id = actor.publisher_id()?;
     let artifact_scan = match req.wasm_artifact_base64.as_deref() {
         Some(encoded) => {
             let bytes = BASE64.decode(encoded).map_err(|_| {
@@ -4623,22 +4629,6 @@ async fn publish_contract_inner(
             findings: vec!["artifact_not_supplied".to_string()],
         },
     };
-    let mut tx = state
-        .db
-        .begin()
-        .await
-        .map_err(|err| db_internal_error("begin publish tx", err))?;
-
-    let publisher: Publisher = sqlx::query_as(
-        "INSERT INTO publishers (stellar_address) VALUES ($1)
-         ON CONFLICT (stellar_address) DO UPDATE SET stellar_address = EXCLUDED.stellar_address
-         RETURNING *",
-    )
-    .bind(&req.publisher_address)
-    .fetch_one(&mut *tx)
-    .await
-    .map_err(|err| db_internal_error("upsert publisher", err))?;
-
     let wasm_hash = req.wasm_hash.clone();
 
     // Duplicate detection (Issue #953): a contract is uniquely identified by
@@ -4652,13 +4642,11 @@ async fn publish_contract_inner(
     )
     .bind(&req.contract_id)
     .bind(&req.network)
-    .fetch_optional(&mut *tx)
+    .fetch_optional(&state.db)
     .await
     .map_err(|err| db_internal_error("check existing contract", err))?
     {
-        tx.rollback()
-            .await
-            .map_err(|err| db_internal_error("rollback publish tx", err))?;
+        actor.require_contract_owner(existing.publisher_id)?;
 
         if existing.wasm_hash == wasm_hash {
             return Ok(Json(existing));
@@ -4682,18 +4670,6 @@ async fn publish_contract_inner(
             }
         })));
     }
-
-    // Pre-existing bug found while verifying #1055 end-to-end, unrelated to
-    // idempotency: `tx` was never committed. Everything below this point
-    // already runs against `&state.db` (a fresh pool connection), not `tx`,
-    // so the upserted publisher row was invisible to it under any pool size
-    // above 1 — the INSERT into `contracts` a few lines down would fail with
-    // a `contracts_publisher_id_fkey` violation for any publisher not
-    // already committed by a prior request. Reproduced directly against a
-    // real Postgres + this exact `main` code before this fix.
-    tx.commit()
-        .await
-        .map_err(|err| db_internal_error("commit publish tx", err))?;
 
     let network_key = req.network.to_string();
     let mut config_map = serde_json::Map::new();
@@ -4720,7 +4696,7 @@ async fn publish_contract_inner(
     .bind(&req.name)
     .bind(&slug)
     .bind(&req.description)
-    .bind(publisher.id)
+    .bind(publisher_id)
     .bind(&req.network)
     .bind(&req.category)
     .bind(&req.tags)
@@ -4838,7 +4814,7 @@ async fn publish_contract_inner(
         &state.db,
         AuditActionType::ContractPublished,
         contract.id,
-        publisher.id,
+        publisher_id,
         creation_changes,
         &extract_ip_address(headers),
     )
@@ -4850,7 +4826,7 @@ async fn publish_contract_inner(
         ContractInteractionInsert {
             contract_id: contract.id,
             target_contract_id: None,
-            account: Some(&publisher.stellar_address),
+            account: Some(&req.publisher_address),
             interaction_type: "publish_success",
             transaction_hash: None,
             method: None,
@@ -4867,7 +4843,7 @@ async fn publish_contract_inner(
         &state.db,
         AnalyticsEventType::ContractPublished,
         Some(contract.id),
-        Some(publisher.id),
+        Some(publisher_id),
         None,
         Some(&contract.network),
         Some(json!({ "name": contract.name })),
@@ -4878,7 +4854,7 @@ async fn publish_contract_inner(
         .contract_events
         .publish(ContractEventEnvelope::deployed(
             &contract,
-            Some(publisher.stellar_address.clone()),
+            Some(req.publisher_address.clone()),
         ));
 
     if req.is_cicd {
@@ -6291,6 +6267,7 @@ pub async fn update_contract_metadata(
 )]
 pub async fn change_contract_publisher(
     State(state): State<AppState>,
+    actor: PolicyActor,
     Path(id): Path<String>,
     headers: HeaderMap,
     ValidatedJson(req): ValidatedJson<ChangePublisherRequest>,
@@ -6313,6 +6290,9 @@ pub async fn change_contract_publisher(
             ),
             _ => db_internal_error("fetch contract for publisher change", err),
         })?;
+
+    actor.require_contract_owner(before.publisher_id)?;
+    let actor_id = actor.publisher_id()?;
 
     require_multisig_approval_for_sensitive_update(
         &state,
@@ -6362,7 +6342,7 @@ pub async fn change_contract_publisher(
             &state.db,
             AuditActionType::PublisherChanged,
             after.id,
-            req.user_id.unwrap_or(before.publisher_id),
+            actor_id,
             changes,
             &extract_ip_address(&headers),
         )
@@ -6447,27 +6427,6 @@ async fn resolve_publisher_by_id(
     .await
 }
 
-/// Resolve the caller's publisher row from the bearer token subject.
-///
-/// `AuthClaims::sub` holds the Stellar address the session authenticated with. Note this
-/// deliberately does not use the `AuthenticatedUser` extractor: its `publisher_id` is
-/// produced by `Uuid::parse_str(&claims.sub).unwrap_or(Uuid::nil())`, and `sub` is a `G...`
-/// address, so that field is always nil.
-async fn resolve_actor(
-    conn: &mut sqlx::PgConnection,
-    claims: &AuthClaims,
-) -> ApiResult<TransferParty> {
-    resolve_publisher_by_address(conn, &claims.sub)
-        .await
-        .map_err(|err| db_internal_error("resolve acting publisher", err))?
-        .ok_or_else(|| {
-            ApiError::forbidden_with_error(
-                "UnknownPublisher",
-                "the authenticated account is not registered as a publisher",
-            )
-        })
-}
-
 /// Translate a unique-violation on the transfer table into the specific 409 it means.
 ///
 /// #1058 returned a 500 here: its duplicate branch wrote a history row against a freshly
@@ -6505,7 +6464,7 @@ fn map_transfer_conflict(operation: &str, err: sqlx::Error) -> ApiError {
 pub async fn create_ownership_transfer(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    claims: AuthClaims,
+    actor: PolicyActor,
     headers: HeaderMap,
     ValidatedJson(req): ValidatedJson<CreateOwnershipTransferRequest>,
 ) -> ApiResult<Json<OwnershipTransfer>> {
@@ -6567,14 +6526,8 @@ pub async fn create_ownership_transfer(
                 )
             })?;
 
-    let actor = resolve_actor(&mut tx, &claims).await?;
-
-    if actor.id != contract.publisher_id {
-        return Err(ApiError::forbidden_with_error(
-            "NotContractOwner",
-            "only the current publisher of this contract can initiate an ownership transfer",
-        ));
-    }
+    actor.require_contract_owner(contract.publisher_id)?;
+    let actor_id = actor.publisher_id()?;
 
     let recipient = resolve_publisher_by_address(&mut tx, &req.to_publisher_address)
         .await
@@ -6589,7 +6542,7 @@ pub async fn create_ownership_transfer(
             )
         })?;
 
-    if recipient.id == actor.id {
+    if recipient.id == actor_id {
         return Err(ApiError::bad_request(
             "SelfTransfer",
             "a contract cannot be transferred to its current publisher",
@@ -6620,14 +6573,14 @@ pub async fn create_ownership_transfer(
     // verbatim so the signature can be re-checked later without reconstructing it.
     let payload = transfer::initiate_payload(
         contract_uuid,
-        &actor.stellar_address,
+        actor.stellar_address(),
         &recipient.stellar_address,
         req.expires_at_unix,
         &req.nonce,
         req.signed_at_unix,
     );
 
-    transfer::verify_transfer_signature(&actor.stellar_address, &payload, &req.signature)?;
+    transfer::verify_transfer_signature(actor.stellar_address(), &payload, &req.signature)?;
 
     let signed_at = DateTime::from_timestamp(req.signed_at_unix, 0).ok_or_else(|| {
         ApiError::bad_request(
@@ -6647,13 +6600,13 @@ pub async fn create_ownership_transfer(
          RETURNING *",
     )
     .bind(contract_uuid)
-    .bind(actor.id)
+    .bind(actor_id)
     .bind(recipient.id)
     .bind(expires_at)
     .bind(algorithm)
     .bind(&req.nonce)
     .bind(&req.signature)
-    .bind(&actor.stellar_address)
+    .bind(actor.stellar_address())
     .bind(signed_at)
     .bind(&payload)
     .fetch_one(&mut *tx)
@@ -6666,12 +6619,12 @@ pub async fn create_ownership_transfer(
         &mut *tx,
         AuditActionType::OwnershipTransferred,
         contract_uuid,
-        actor.id,
+        actor_id,
         json!({
             "action": "transfer_request_created",
             "transfer_id": transfer_row.id,
-            "from_publisher_id": actor.id,
-            "from_signer_address": actor.stellar_address,
+            "from_publisher_id": actor_id,
+            "from_signer_address": actor.stellar_address(),
             "to_publisher_id": recipient.id,
             "to_publisher_address": recipient.stellar_address,
             "expires_at": expires_at,
@@ -6684,12 +6637,12 @@ pub async fn create_ownership_transfer(
     write_ownership_transfer_log(
         &mut *tx,
         transfer_row.id,
-        Some(actor.id),
+        Some(actor_id),
         "publisher",
         "transfer_request_created",
         Some(json!({
-            "from_publisher_id": actor.id,
-            "from_signer_address": actor.stellar_address,
+            "from_publisher_id": actor_id,
+            "from_signer_address": actor.stellar_address(),
             "to_publisher_id": recipient.id,
             "to_publisher_address": recipient.stellar_address,
             "expires_at": expires_at,
@@ -6709,7 +6662,7 @@ pub async fn create_ownership_transfer(
         target: "ownership_transfer",
         transfer_id = %transfer_row.id,
         contract_id = %contract_uuid,
-        from_publisher_id = %actor.id,
+        from_publisher_id = %actor_id,
         to_publisher_id = %recipient.id,
         expires_at = %expires_at,
         "ownership transfer initiated and sender signature verified"
@@ -6728,7 +6681,7 @@ pub async fn create_ownership_transfer(
 pub async fn confirm_ownership_transfer(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    claims: AuthClaims,
+    actor: PolicyActor,
     headers: HeaderMap,
     ValidatedJson(req): ValidatedJson<ConfirmOwnershipTransferRequest>,
 ) -> ApiResult<Json<OwnershipTransfer>> {
@@ -6800,29 +6753,13 @@ pub async fn confirm_ownership_transfer(
                 )
             })?;
 
-    let actor = resolve_actor(&mut tx, &claims).await?;
-
-    // Authorization is checked once, ahead of the accept/reject split. #1058 checked it
-    // only inside the accept branch, so any caller could reject anyone's transfer.
-    let is_sender = actor.id == transfer_row.from_publisher_id;
-    let is_recipient = actor.id == transfer_row.to_publisher_id;
-
-    if !is_sender && !is_recipient {
-        return Err(ApiError::forbidden_with_error(
-            "UnauthorizedConfirmation",
-            "only the sender or the recipient of this transfer can act on it",
-        ));
-    }
-
-    // Accepting is the recipient's alone: the sender's consent is already recorded as the
-    // phase-1 signature, and letting the sender also accept would collapse the two-party
-    // requirement into one.
-    if req.accept && !is_recipient {
-        return Err(ApiError::forbidden_with_error(
-            "UnauthorizedConfirmation",
-            "only the recipient of this transfer can accept it",
-        ));
-    }
+    actor.require_transfer_action(
+        transfer_row.from_publisher_id,
+        transfer_row.to_publisher_id,
+        req.accept,
+    )?;
+    let actor_id = actor.publisher_id()?;
+    let is_recipient = actor_id == transfer_row.to_publisher_id;
 
     // Expiry is applied here, under the row lock, and the write is committed even though
     // the response is an error; otherwise the expiry would roll back with the 409 and the
@@ -6846,7 +6783,7 @@ pub async fn confirm_ownership_transfer(
             "transfer_expired",
             Some(json!({
                 "reason": "Transfer request passed its expiry without a verified acceptance",
-                "observed_by_publisher_id": actor.id,
+                "observed_by_publisher_id": actor_id,
             })),
         )
         .await
@@ -6908,7 +6845,7 @@ pub async fn confirm_ownership_transfer(
     );
 
     // Verified before any state change, so a forged signature mutates nothing.
-    transfer::verify_transfer_signature(&actor.stellar_address, &payload, &req.signature)?;
+    transfer::verify_transfer_signature(actor.stellar_address(), &payload, &req.signature)?;
 
     let ip_address = extract_ip_address(&headers);
 
@@ -6939,10 +6876,10 @@ pub async fn confirm_ownership_transfer(
         .bind(transfer_uuid)
         .bind(&req.nonce)
         .bind(&req.signature)
-        .bind(&actor.stellar_address)
+        .bind(actor.stellar_address())
         .bind(signed_at)
         .bind(&payload)
-        .bind(actor.id)
+        .bind(actor_id)
         .bind(algorithm)
         .fetch_optional(&mut *tx)
         .await
@@ -6990,7 +6927,7 @@ pub async fn confirm_ownership_transfer(
             &mut *tx,
             AuditActionType::OwnershipTransferred,
             transfer_row.contract_id,
-            actor.id,
+            actor_id,
             json!({
                 "action": "transfer_completed",
                 "transfer_id": transfer_uuid,
@@ -6999,7 +6936,7 @@ pub async fn confirm_ownership_transfer(
                     "after": recipient.id,
                 },
                 "from_signer_address": sender.stellar_address,
-                "decision_signer_address": actor.stellar_address,
+                "decision_signer_address": actor.stellar_address(),
             }),
             &ip_address,
         )
@@ -7009,7 +6946,7 @@ pub async fn confirm_ownership_transfer(
         write_ownership_transfer_log(
             &mut *tx,
             transfer_uuid,
-            Some(actor.id),
+            Some(actor_id),
             "publisher",
             "transfer_completed",
             Some(json!({
@@ -7017,7 +6954,7 @@ pub async fn confirm_ownership_transfer(
                 "to_publisher_id": recipient.id,
                 "contract_id": transfer_row.contract_id,
                 "decision_nonce": req.nonce,
-                "decision_signer_address": actor.stellar_address,
+                "decision_signer_address": actor.stellar_address(),
                 "signature_algorithm": algorithm,
                 "signed_payload": payload,
             })),
@@ -7081,10 +7018,10 @@ pub async fn confirm_ownership_transfer(
     .bind(transfer_uuid)
     .bind(&req.nonce)
     .bind(&req.signature)
-    .bind(&actor.stellar_address)
+    .bind(actor.stellar_address())
     .bind(signed_at)
     .bind(&payload)
-    .bind(actor.id)
+    .bind(actor_id)
     .bind(algorithm)
     .fetch_optional(&mut *tx)
     .await
@@ -7100,14 +7037,14 @@ pub async fn confirm_ownership_transfer(
         &mut *tx,
         AuditActionType::OwnershipTransferred,
         transfer_row.contract_id,
-        actor.id,
+        actor_id,
         json!({
             "action": "transfer_rejected",
             "transfer_id": transfer_uuid,
             "rejected_by": if is_recipient { "recipient" } else { "sender" },
             "from_publisher_id": transfer_row.from_publisher_id,
             "to_publisher_id": transfer_row.to_publisher_id,
-            "decision_signer_address": actor.stellar_address,
+            "decision_signer_address": actor.stellar_address(),
         }),
         &ip_address,
     )
@@ -7117,7 +7054,7 @@ pub async fn confirm_ownership_transfer(
     write_ownership_transfer_log(
         &mut *tx,
         transfer_uuid,
-        Some(actor.id),
+        Some(actor_id),
         "publisher",
         "transfer_rejected",
         Some(json!({
@@ -7126,7 +7063,7 @@ pub async fn confirm_ownership_transfer(
             "to_publisher_id": transfer_row.to_publisher_id,
             "contract_id": transfer_row.contract_id,
             "decision_nonce": req.nonce,
-            "decision_signer_address": actor.stellar_address,
+            "decision_signer_address": actor.stellar_address(),
             "signature_algorithm": algorithm,
             "signed_payload": payload,
         })),
@@ -7142,7 +7079,7 @@ pub async fn confirm_ownership_transfer(
         target: "ownership_transfer",
         transfer_id = %transfer_uuid,
         contract_id = %transfer_row.contract_id,
-        rejected_by_publisher_id = %actor.id,
+        rejected_by_publisher_id = %actor_id,
         "ownership transfer rejected with a verified signature"
     );
 

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -66,6 +66,7 @@ pub mod pagination;
 pub mod patch_handlers;
 pub mod performance_handlers;
 pub mod plugin_marketplace_handlers;
+pub mod policy;
 pub mod post_incident_handlers;
 pub mod post_incident_routes;
 pub mod publisher_verification_handlers;

--- a/backend/api/src/policy.rs
+++ b/backend/api/src/policy.rs
@@ -1,0 +1,332 @@
+//! Central authorization policy for security-sensitive actions.
+//!
+//! Authentication proves who made the request. This module resolves that
+//! identity to a publisher record and decides what the actor may do.
+
+use axum::extract::FromRequestParts;
+use uuid::Uuid;
+
+use crate::{
+    auth::AuthClaims,
+    error::{ApiError, ApiResult},
+    handlers::db_internal_error,
+    state::AppState,
+};
+
+#[derive(Debug, Clone)]
+pub struct PolicyActor {
+    publisher_id: Option<Uuid>,
+    stellar_address: String,
+    is_admin: bool,
+}
+
+#[axum::async_trait]
+impl FromRequestParts<AppState> for PolicyActor {
+    type Rejection = ApiError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let claims = AuthClaims::from_request_parts(parts, state).await?;
+        Self::from_claims(state, claims).await
+    }
+}
+
+impl PolicyActor {
+    async fn from_claims(state: &AppState, claims: AuthClaims) -> ApiResult<Self> {
+        let publisher_id = if claims.publisher_id.is_nil() {
+            None
+        } else {
+            let publisher_address: Option<String> =
+                sqlx::query_scalar("SELECT stellar_address FROM publishers WHERE id = $1")
+                    .bind(claims.publisher_id)
+                    .fetch_optional(&state.db)
+                    .await
+                    .map_err(|err| db_internal_error("resolve authenticated publisher", err))?;
+
+            match publisher_address {
+                Some(address) if address == claims.sub => Some(claims.publisher_id),
+                Some(_) => {
+                    return Err(ApiError::unauthorized(
+                        "The token publisher ID and Stellar address do not match",
+                    ))
+                }
+                None => None,
+            }
+        };
+
+        let is_admin = claims_are_admin(&claims);
+        Ok(Self {
+            publisher_id,
+            stellar_address: claims.sub,
+            is_admin,
+        })
+    }
+
+    pub fn publisher_id(&self) -> ApiResult<Uuid> {
+        self.publisher_id.ok_or_else(|| {
+            ApiError::forbidden_with_error(
+                "UnknownPublisher",
+                "The authenticated account is not registered as a publisher",
+            )
+        })
+    }
+
+    pub fn stellar_address(&self) -> &str {
+        &self.stellar_address
+    }
+
+    pub fn require_admin(&self) -> ApiResult<()> {
+        if self.is_admin {
+            Ok(())
+        } else {
+            Err(ApiError::forbidden(
+                "Administrative privileges are required for this action",
+            ))
+        }
+    }
+
+    pub fn require_contract_owner(&self, owner_id: Uuid) -> ApiResult<()> {
+        if self.publisher_id()? == owner_id {
+            Ok(())
+        } else {
+            Err(ApiError::forbidden_with_error(
+                "NotContractOwner",
+                "Only the contract's current publisher can perform this action",
+            ))
+        }
+    }
+
+    fn require_resource_owner(&self, owner_id: Uuid, resource: &str) -> ApiResult<()> {
+        if self.publisher_id()? == owner_id {
+            Ok(())
+        } else {
+            Err(ApiError::forbidden_with_error(
+                "NotResourceOwner",
+                format!("Only the {resource} owner can perform this action"),
+            ))
+        }
+    }
+
+    pub fn require_publisher_address(&self, address: &str) -> ApiResult<()> {
+        self.publisher_id()?;
+        self.require_signature_identity(address)
+    }
+
+    pub fn require_signature_identity(&self, signer_address: &str) -> ApiResult<()> {
+        if self.stellar_address == signer_address {
+            Ok(())
+        } else {
+            Err(ApiError::forbidden_with_error(
+                "SignatureIdentityMismatch",
+                "The signing address does not match the authenticated account",
+            ))
+        }
+    }
+
+    pub fn require_transfer_action(
+        &self,
+        sender_id: Uuid,
+        recipient_id: Uuid,
+        accepting: bool,
+    ) -> ApiResult<()> {
+        let actor_id = self.publisher_id()?;
+        let is_sender = actor_id == sender_id;
+        let is_recipient = actor_id == recipient_id;
+
+        if !is_sender && !is_recipient {
+            return Err(ApiError::forbidden_with_error(
+                "UnauthorizedConfirmation",
+                "Only the sender or recipient of this transfer can act on it",
+            ));
+        }
+        if accepting && !is_recipient {
+            return Err(ApiError::forbidden_with_error(
+                "UnauthorizedConfirmation",
+                "Only the recipient of this transfer can accept it",
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+pub fn require_admin_claims(claims: &AuthClaims) -> ApiResult<()> {
+    if claims_are_admin(claims) {
+        Ok(())
+    } else {
+        Err(ApiError::forbidden(
+            "Administrative privileges are required for this action",
+        ))
+    }
+}
+
+pub async fn require_contract_owner(
+    state: &AppState,
+    actor: &PolicyActor,
+    contract_id: Uuid,
+) -> ApiResult<()> {
+    let owner_id: Option<Uuid> =
+        sqlx::query_scalar("SELECT publisher_id FROM contracts WHERE id = $1")
+            .bind(contract_id)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|err| db_internal_error("resolve contract owner", err))?;
+
+    let owner_id =
+        owner_id.ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
+    actor.require_contract_owner(owner_id)
+}
+
+pub async fn require_webhook_owner(
+    state: &AppState,
+    actor: &PolicyActor,
+    webhook_id: Uuid,
+) -> ApiResult<()> {
+    let owner_id: Option<Option<Uuid>> =
+        sqlx::query_scalar("SELECT user_id FROM webhook_configurations WHERE id = $1")
+            .bind(webhook_id)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|err| db_internal_error("resolve webhook owner", err))?;
+
+    let owner_id = owner_id
+        .flatten()
+        .ok_or_else(|| ApiError::not_found("webhook", "Webhook not found"))?;
+    actor
+        .require_resource_owner(owner_id, "webhook")
+        .map_err(|_| ApiError::not_found("webhook", "Webhook not found"))
+}
+
+pub async fn require_webhook_delivery_owner(
+    state: &AppState,
+    actor: &PolicyActor,
+    delivery_id: Uuid,
+) -> ApiResult<()> {
+    let owner_id: Option<Option<Uuid>> = sqlx::query_scalar(
+        "SELECT wc.user_id
+         FROM notification_delivery_logs ndl
+         JOIN webhook_configurations wc ON wc.id = ndl.webhook_id
+         WHERE ndl.id = $1",
+    )
+    .bind(delivery_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|err| db_internal_error("resolve webhook delivery owner", err))?;
+
+    let owner_id = owner_id
+        .flatten()
+        .ok_or_else(|| ApiError::not_found("delivery", "Delivery log not found"))?;
+    actor
+        .require_resource_owner(owner_id, "webhook delivery")
+        .map_err(|_| ApiError::not_found("delivery", "Delivery log not found"))
+}
+
+fn claims_are_admin(claims: &AuthClaims) -> bool {
+    claims.admin
+        || claims
+            .role
+            .as_deref()
+            .is_some_and(|role| role.eq_ignore_ascii_case("admin"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn actor(publisher_id: Option<Uuid>, address: &str, is_admin: bool) -> PolicyActor {
+        PolicyActor {
+            publisher_id,
+            stellar_address: address.to_string(),
+            is_admin,
+        }
+    }
+
+    #[test]
+    fn publisher_policy_requires_a_registered_identity() {
+        let publisher_id = Uuid::new_v4();
+        assert_eq!(
+            actor(Some(publisher_id), "GOWNER", false)
+                .publisher_id()
+                .unwrap(),
+            publisher_id
+        );
+        assert!(actor(None, "GUNKNOWN", false).publisher_id().is_err());
+        assert!(actor(None, "GADMIN", true).publisher_id().is_err());
+    }
+
+    #[test]
+    fn owner_policy_has_no_admin_bypass() {
+        let owner_id = Uuid::new_v4();
+        assert!(actor(Some(owner_id), "GOWNER", false)
+            .require_contract_owner(owner_id)
+            .is_ok());
+        assert!(actor(Some(Uuid::new_v4()), "GOTHER", false)
+            .require_contract_owner(owner_id)
+            .is_err());
+        assert!(actor(Some(Uuid::new_v4()), "GADMIN", true)
+            .require_contract_owner(owner_id)
+            .is_err());
+    }
+
+    #[test]
+    fn admin_policy_rejects_publishers() {
+        assert!(actor(None, "GADMIN", true).require_admin().is_ok());
+        assert!(actor(Some(Uuid::new_v4()), "GPUBLISHER", false)
+            .require_admin()
+            .is_err());
+    }
+
+    #[test]
+    fn admin_claims_are_case_insensitive_and_explicit() {
+        let claims = |role: Option<&str>, admin| AuthClaims {
+            sub: "GSUBJECT".to_string(),
+            publisher_id: Uuid::nil(),
+            iat: 0,
+            exp: i64::MAX,
+            scopes: vec![],
+            role: role.map(str::to_string),
+            admin,
+            mfa_verified: false,
+            session_id: None,
+        };
+
+        assert!(require_admin_claims(&claims(Some("AdMiN"), false)).is_ok());
+        assert!(require_admin_claims(&claims(None, true)).is_ok());
+        assert!(require_admin_claims(&claims(Some("publisher"), false)).is_err());
+    }
+
+    #[test]
+    fn publisher_and_signature_addresses_must_match() {
+        let owner = actor(Some(Uuid::new_v4()), "GOWNER", false);
+        assert!(owner.require_publisher_address("GOWNER").is_ok());
+        assert!(owner.require_publisher_address("GOTHER").is_err());
+        assert!(owner.require_signature_identity("GOTHER").is_err());
+    }
+
+    #[test]
+    fn transfer_policy_enforces_participant_roles() {
+        let sender_id = Uuid::new_v4();
+        let recipient_id = Uuid::new_v4();
+        let sender = actor(Some(sender_id), "GSENDER", false);
+        let recipient = actor(Some(recipient_id), "GRECIPIENT", false);
+        let outsider = actor(Some(Uuid::new_v4()), "GOUTSIDER", false);
+
+        assert!(sender
+            .require_transfer_action(sender_id, recipient_id, false)
+            .is_ok());
+        assert!(sender
+            .require_transfer_action(sender_id, recipient_id, true)
+            .is_err());
+        assert!(recipient
+            .require_transfer_action(sender_id, recipient_id, true)
+            .is_ok());
+        assert!(recipient
+            .require_transfer_action(sender_id, recipient_id, false)
+            .is_ok());
+        assert!(outsider
+            .require_transfer_action(sender_id, recipient_id, false)
+            .is_err());
+    }
+}

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -508,10 +508,6 @@ pub fn contract_routes() -> Router<AppState> {
             post(deprecation_handlers::deprecate_contract)
                 .delete(deprecation_handlers::undeprecate_contract),
         )
-        .route(
-            "/api/admin/deprecation/purge-expired",
-            post(deprecation_handlers::purge_expired_deprecated_contracts),
-        )
         // AI-Powered Contract Code Assistant
         .route(
             "/api/contracts/:id/ai/chat",
@@ -1129,6 +1125,10 @@ pub fn performance_routes() -> Router<AppState> {
 
 pub fn admin_routes() -> Router<AppState> {
     Router::new()
+        .route(
+            "/api/admin/deprecation/purge-expired",
+            post(deprecation_handlers::purge_expired_deprecated_contracts),
+        )
         .route("/api/admin/audit-logs", get(handlers::get_all_audit_logs))
         .route(
             "/api/admin/audit-logs/export",

--- a/backend/api/src/security_scan_handlers.rs
+++ b/backend/api/src/security_scan_handlers.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 use crate::{
     error::{ApiError, ApiResult},
     ml_detector,
+    policy::{self, PolicyActor},
     state::AppState,
     vulnerability_database,
 };
@@ -36,20 +37,11 @@ pub struct ListScansQuery {
 /// POST /api/contracts/:id/scans
 pub async fn trigger_security_scan(
     State(state): State<AppState>,
+    actor: PolicyActor,
     Path(contract_id): Path<Uuid>,
     ValidatedJson(req): ValidatedJson<TriggerSecurityScanRequest>,
 ) -> ApiResult<Json<SecurityScan>> {
-    // Verify contract exists
-    let contract_exists: bool =
-        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM contracts WHERE id = $1)")
-            .bind(contract_id)
-            .fetch_one(&state.db)
-            .await
-            .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
-
-    if !contract_exists {
-        return Err(ApiError::not_found("contract", "Contract not found"));
-    }
+    policy::require_contract_owner(&state, &actor, contract_id).await?;
 
     // Get contract version if specified, otherwise fall back to the latest version.
     let contract_version_id = if let Some(version) = &req.version {
@@ -357,8 +349,11 @@ pub struct ListIssuesQuery {
 pub async fn update_security_issue(
     State(state): State<AppState>,
     Path((contract_id, issue_id)): Path<(Uuid, Uuid)>,
+    actor: PolicyActor,
     ValidatedJson(req): ValidatedJson<UpdateSecurityIssueRequest>,
 ) -> ApiResult<Json<shared::SecurityIssue>> {
+    policy::require_contract_owner(&state, &actor, contract_id).await?;
+
     // Verify issue belongs to contract
     let existing: Option<shared::SecurityIssue> =
         sqlx::query_as("SELECT * FROM security_issues WHERE id = $1 AND contract_id = $2")
@@ -430,8 +425,11 @@ pub async fn list_security_scanners(
 /// POST /api/security/scanners
 pub async fn create_security_scanner(
     State(state): State<AppState>,
+    actor: PolicyActor,
     ValidatedJson(req): ValidatedJson<CreateSecurityScannerRequest>,
 ) -> ApiResult<Json<SecurityScanner>> {
+    actor.require_admin()?;
+
     // In production, api_key should be encrypted before storage
     let scanner = sqlx::query_as::<_, SecurityScanner>(
         r#"

--- a/backend/api/src/subscription_handlers.rs
+++ b/backend/api/src/subscription_handlers.rs
@@ -14,6 +14,7 @@ use crate::{
     auth,
     error::{ApiError, ApiResult},
     pagination::PagedJson,
+    policy::{self, PolicyActor},
     state::AppState,
 };
 use shared::{
@@ -634,9 +635,10 @@ pub async fn list_webhooks(
     State(state): State<AppState>,
     headers: HeaderMap,
     OriginalUri(uri): OriginalUri,
-    auth_user: auth::AuthenticatedUser,
+    actor: PolicyActor,
     Query(query): Query<ListWebhooksQuery>,
 ) -> ApiResult<PagedJson<WebhookConfiguration>> {
+    let publisher_id = actor.publisher_id()?;
     let per_page = query.limit.unwrap_or(20).clamp(1, 100);
     let page = query.page.unwrap_or(1).max(1);
     let offset = (page - 1) * per_page;
@@ -649,7 +651,7 @@ pub async fn list_webhooks(
         LIMIT $2 OFFSET $3
         "#,
     )
-    .bind(auth_user.publisher_id)
+    .bind(publisher_id)
     .bind(per_page)
     .bind(offset)
     .fetch_all(&state.db)
@@ -658,7 +660,7 @@ pub async fn list_webhooks(
 
     let total: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM webhook_configurations WHERE user_id = $1")
-            .bind(auth_user.publisher_id)
+            .bind(publisher_id)
             .fetch_one(&state.db)
             .await
             .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
@@ -673,9 +675,10 @@ pub async fn list_webhooks(
 /// POST /api/webhooks
 pub async fn create_webhook(
     State(state): State<AppState>,
-    auth_user: auth::AuthenticatedUser,
+    actor: PolicyActor,
     ValidatedJson(req): ValidatedJson<CreateWebhookRequest>,
 ) -> ApiResult<Json<WebhookConfiguration>> {
+    let publisher_id = actor.publisher_id()?;
     // Validate URL scheme — only https allowed in production.
     if !req.url.starts_with("https://") && !req.url.starts_with("http://localhost") {
         return Err(ApiError::bad_request_with(
@@ -703,7 +706,7 @@ pub async fn create_webhook(
         RETURNING *
         "#,
     )
-    .bind(auth_user.publisher_id)
+    .bind(publisher_id)
     .bind(&req.name)
     .bind(&req.url)
     .bind(&secret)
@@ -723,12 +726,14 @@ pub async fn create_webhook(
 pub async fn delete_webhook(
     State(state): State<AppState>,
     Path(webhook_id): Path<Uuid>,
-    auth_user: auth::AuthenticatedUser,
+    actor: PolicyActor,
 ) -> ApiResult<StatusCode> {
+    let publisher_id = actor.publisher_id()?;
+    policy::require_webhook_owner(&state, &actor, webhook_id).await?;
     let rows_affected =
         sqlx::query("DELETE FROM webhook_configurations WHERE id = $1 AND user_id = $2")
             .bind(webhook_id)
-            .bind(auth_user.publisher_id)
+            .bind(publisher_id)
             .execute(&state.db)
             .await
             .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
@@ -748,21 +753,11 @@ pub async fn get_webhook_deliveries(
     headers: HeaderMap,
     OriginalUri(uri): OriginalUri,
     Path(webhook_id): Path<Uuid>,
-    auth_user: auth::AuthenticatedUser,
+    actor: PolicyActor,
     Query(query): Query<DeliveriesQuery>,
 ) -> ApiResult<PagedJson<WebhookDeliveryLog>> {
-    let owned: bool = sqlx::query_scalar(
-        "SELECT EXISTS(SELECT 1 FROM webhook_configurations WHERE id = $1 AND user_id = $2)",
-    )
-    .bind(webhook_id)
-    .bind(auth_user.publisher_id)
-    .fetch_one(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
-
-    if !owned {
-        return Err(ApiError::not_found("webhook", "Webhook not found"));
-    }
+    actor.publisher_id()?;
+    policy::require_webhook_owner(&state, &actor, webhook_id).await?;
 
     let per_page = query.limit.unwrap_or(50).clamp(1, 200);
     let page = query.page.unwrap_or(1).max(1);
@@ -803,13 +798,15 @@ pub async fn get_webhook_deliveries(
 pub async fn test_webhook(
     State(state): State<AppState>,
     Path(webhook_id): Path<Uuid>,
-    auth_user: auth::AuthenticatedUser,
+    actor: PolicyActor,
 ) -> ApiResult<StatusCode> {
+    let publisher_id = actor.publisher_id()?;
+    policy::require_webhook_owner(&state, &actor, webhook_id).await?;
     let webhook = sqlx::query_as::<_, WebhookConfiguration>(
         "SELECT * FROM webhook_configurations WHERE id = $1 AND user_id = $2",
     )
     .bind(webhook_id)
-    .bind(auth_user.publisher_id)
+    .bind(publisher_id)
     .fetch_optional(&state.db)
     .await
     .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?
@@ -835,28 +832,10 @@ pub async fn test_webhook(
 pub async fn retry_webhook_delivery(
     State(state): State<AppState>,
     Path(delivery_id): Path<Uuid>,
-    auth_user: auth::AuthenticatedUser,
+    actor: PolicyActor,
 ) -> ApiResult<StatusCode> {
-    // Verify the delivery belongs to a webhook owned by this user.
-    let owned: bool = sqlx::query_scalar(
-        r#"
-        SELECT EXISTS(
-            SELECT 1
-            FROM notification_delivery_logs ndl
-            JOIN webhook_configurations wc ON wc.id = ndl.webhook_id
-            WHERE ndl.id = $1 AND wc.user_id = $2
-        )
-        "#,
-    )
-    .bind(delivery_id)
-    .bind(auth_user.publisher_id)
-    .fetch_one(&state.db)
-    .await
-    .map_err(|e| ApiError::internal(format!("Database error: {}", e)))?;
-
-    if !owned {
-        return Err(ApiError::not_found("delivery", "Delivery log not found"));
-    }
+    actor.publisher_id()?;
+    policy::require_webhook_delivery_owner(&state, &actor, delivery_id).await?;
 
     // Reset the delivery so the background worker picks it up again.
     let rows = sqlx::query(

--- a/backend/api/tests/ownership_transfer_tests.rs
+++ b/backend/api/tests/ownership_transfer_tests.rs
@@ -33,7 +33,7 @@
 // Fixture note: the random_strkey helper used elsewhere in this suite produces
 // format-valid addresses with no private key behind them, so it cannot sign anything. Here
 // each actor is a real ed25519 keypair whose Stellar address is derived from its public
-// key, registered as a publisher through the public publish endpoint, and issued a real JWT
+// key, registered through the publisher endpoint, and issued a real JWT
 // through the challenge/verify flow. Payloads are built with the same functions the server
 // uses, so test and server agree byte for byte by construction rather than by copy.
 // ═══════════════════════════════════════════════════════════════════════════
@@ -372,9 +372,36 @@ fn unique_wasm_module() -> Vec<u8> {
     wasm
 }
 
-/// Publish a contract owned by `address`. `publish_contract` upserts `publishers`, which is
-/// how an actor comes to exist at all; returns the contract JSON.
-async fn publish_contract(client: &reqwest::Client, base: &str, address: &str) -> Value {
+/// Register the publisher identity used by the auth challenge.
+async fn register_publisher(client: &reqwest::Client, base: &str, address: &str) {
+    let res = client
+        .post(format!("{}/api/publishers", base))
+        .json(&json!({
+            "id": Uuid::nil(),
+            "stellar_address": address,
+            "username": null,
+            "email": null,
+            "github_url": null,
+            "website": null,
+            "created_at": chrono::Utc::now(),
+        }))
+        .send()
+        .await
+        .expect("publisher registration failed");
+    assert!(
+        res.status().is_success(),
+        "publisher registration failed: {}",
+        res.text().await.unwrap_or_default()
+    );
+}
+
+/// Publish a contract as an authenticated, registered publisher.
+async fn publish_contract(
+    client: &reqwest::Client,
+    base: &str,
+    address: &str,
+    token: &str,
+) -> Value {
     use sha2::{Digest, Sha256};
 
     let wasm = unique_wasm_module();
@@ -382,6 +409,7 @@ async fn publish_contract(client: &reqwest::Client, base: &str, address: &str) -
 
     let res = client
         .post(format!("{}/api/contracts", base))
+        .bearer_auth(token)
         .json(&json!({
             "contract_id": random_contract_strkey(),
             "wasm_hash": wasm_hash,
@@ -459,10 +487,11 @@ async fn mint_token(
 /// A registered, authenticated actor plus the uuid of a contract it owns.
 async fn new_actor_with_contract(client: &reqwest::Client, base: &str) -> (Actor, Uuid) {
     let (signing, address) = new_keypair();
-    let contract = publish_contract(client, base, &address).await;
+    register_publisher(client, base, &address).await;
+    let token = mint_token(client, base, &signing, &address).await;
+    let contract = publish_contract(client, base, &address, &token).await;
     let contract_id = Uuid::parse_str(contract["id"].as_str().expect("contract id"))
         .expect("contract id was not a uuid");
-    let token = mint_token(client, base, &signing, &address).await;
     (
         Actor {
             signing,

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -1148,16 +1148,33 @@ pub struct DeprecationInfo {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct DeprecationSignaturePayload {
+    pub contract_id: String,
+    pub action: String,
+    pub timestamp: String,
+    pub nonce: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DeprecateContractRequest {
     pub retirement_at: DateTime<Utc>,
     pub replacement_contract_id: Option<String>,
     pub migration_guide_url: Option<String>,
     pub notes: Option<String>,
     /// Human-readable reason for the deprecation, shown in API deprecation warnings.
+    #[serde(default, alias = "reason")]
     pub deprecated_reason: Option<String>,
     /// Number of days after deprecation before the contract is hard-deleted.
     /// If `None`, the contract is soft-deleted but never automatically removed.
     pub grace_period_days: Option<i32>,
+    /// Optional signed action envelope used by clients that require additional wallet proof.
+    /// When any envelope field is supplied, all fields are required and verified.
+    #[serde(default)]
+    pub payload: Option<DeprecationSignaturePayload>,
+    #[serde(default)]
+    pub signature: Option<String>,
+    #[serde(default)]
+    pub signing_address: Option<String>,
 }
 
 /// Query parameters for clearing deprecation. Reactivating a deprecated contract

--- a/cli/src/contract_deprecate.rs
+++ b/cli/src/contract_deprecate.rs
@@ -36,8 +36,10 @@ pub struct DeprecationPayload {
 /// The full request body sent to the deprecation API endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignedDeprecationRequest {
+    /// When the contract should be considered retired.
+    pub retirement_at: String,
     /// Deprecation reason visible to consumers.
-    pub reason: String,
+    pub deprecated_reason: String,
     /// Replacement contract ID for migration.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replacement_contract_id: Option<String>,
@@ -50,8 +52,6 @@ pub struct SignedDeprecationRequest {
     pub payload: DeprecationPayload,
     /// Base64-encoded Ed25519 signature of the payload.
     pub signature: String,
-    /// Base64-encoded Ed25519 public key of the signer.
-    pub public_key: String,
     /// Stellar address derived from the public key.
     pub signing_address: String,
 }
@@ -89,7 +89,6 @@ pub async fn run(
     let signing_key = decode_private_key(private_key)?;
     let verifying_key = signing_key.verifying_key();
     let public_key_bytes = verifying_key.to_bytes();
-    let public_key_b64 = BASE64.encode(public_key_bytes);
     let signing_address = derive_stellar_address(&public_key_bytes);
 
     // 2. Fetch current contract state so we can show a diff
@@ -106,7 +105,8 @@ pub async fn run(
 
     // 4. Build and sign the deprecation payload
     let nonce = uuid::Uuid::new_v4().to_string();
-    let timestamp = Utc::now().to_rfc3339();
+    let now = Utc::now();
+    let timestamp = now.to_rfc3339();
 
     let canonical_contract_id = contract_info
         .get("contract_id")
@@ -126,13 +126,13 @@ pub async fn run(
     let signature_b64 = BASE64.encode(signature.to_bytes());
 
     let request = SignedDeprecationRequest {
-        reason: reason.to_string(),
+        retirement_at: (now + chrono::Duration::days(i64::from(grace_period_days))).to_rfc3339(),
+        deprecated_reason: reason.to_string(),
         replacement_contract_id: replacement.map(String::from),
         migration_guide_url: migration_guide.map(String::from),
         grace_period_days,
         payload,
         signature: signature_b64,
-        public_key: public_key_b64,
         signing_address: signing_address.clone(),
     };
 
@@ -427,16 +427,10 @@ fn decode_private_key(key: &str) -> Result<SigningKey> {
 
 /// Derive a Stellar-style address from a 32-byte Ed25519 public key.
 fn derive_stellar_address(public_key_bytes: &[u8; 32]) -> String {
-    use ripemd::Ripemd160;
-    use sha2::{Digest, Sha256};
-
-    let sha256_hash = Sha256::digest(public_key_bytes);
-    let ripemd_hash = Ripemd160::digest(sha256_hash);
-    let mut versioned = vec![0x00];
-    versioned.extend_from_slice(&ripemd_hash);
-    let checksum = Sha256::digest(&Sha256::digest(&versioned));
-    versioned.extend_from_slice(&checksum[..4]);
-    bs58::encode(&versioned).into_string()
+    stellar_strkey::ed25519::PublicKey(*public_key_bytes)
+        .to_string()
+        .as_str()
+        .to_owned()
 }
 
 // ── Contract info fetch ──────────────────────────────────────────────────────
@@ -763,7 +757,8 @@ mod tests {
         let addr1 = derive_stellar_address(&bytes);
         let addr2 = derive_stellar_address(&bytes);
         assert_eq!(addr1, addr2);
-        assert!(!addr1.is_empty());
+        assert!(addr1.starts_with('G'));
+        assert_eq!(addr1.len(), 56);
     }
 
     #[test]
@@ -792,26 +787,25 @@ mod tests {
         let (signing_key, verifying_key) = generate_test_keypair();
         let payload = make_payload("CTEST", "ser-nonce");
         let sig = sign_deprecation(&payload, &signing_key);
-        let pub_key = BASE64.encode(verifying_key.to_bytes());
         let address = derive_stellar_address(&verifying_key.to_bytes());
 
         let request = SignedDeprecationRequest {
-            reason: "end of life".to_string(),
+            retirement_at: "2030-01-01T00:00:00Z".to_string(),
+            deprecated_reason: "end of life".to_string(),
             replacement_contract_id: Some("CNEW".to_string()),
             migration_guide_url: Some("https://example.com/migrate".to_string()),
             grace_period_days: 30,
             payload,
             signature: sig,
-            public_key: pub_key,
             signing_address: address,
         };
 
         let json = serde_json::to_value(&request).unwrap();
-        assert_eq!(json["reason"], "end of life");
+        assert_eq!(json["deprecated_reason"], "end of life");
+        assert_eq!(json["retirement_at"], "2030-01-01T00:00:00Z");
         assert_eq!(json["replacement_contract_id"], "CNEW");
         assert_eq!(json["grace_period_days"], 30);
         assert!(json["signature"].is_string());
-        assert!(json["public_key"].is_string());
         assert!(json["signing_address"].is_string());
         assert!(json["payload"]["contract_id"].is_string());
     }

--- a/docs/sensitive-action-authorization.md
+++ b/docs/sensitive-action-authorization.md
@@ -1,0 +1,167 @@
+# Sensitive Action Authorization
+
+Issue: #1123 — Backend: Add policy engine for sensitive action authorization
+
+## Objective
+
+Centralize authorization for sensitive mutations so handlers no longer make
+inconsistent decisions from JWT fields, request-supplied publisher IDs, or
+locally duplicated owner checks.
+
+The implementation deliberately separates:
+
+1. **Authentication** — validates the bearer JWT and its referenced session.
+2. **Identity resolution** — matches the server-signed publisher UUID to the
+   same publisher's Stellar address in the database.
+3. **Authorization policy** — decides whether that actor is a publisher,
+   resource owner, contract owner, transfer participant, or administrator.
+4. **Cryptographic verification** — verifies signed action payloads against
+   the Stellar address already resolved for the authenticated actor.
+
+## Policy decisions
+
+- Owner-only actions do not receive an automatic administrator bypass.
+- For the migrated actions, acting identity never comes from request fields
+  such as `publisher_address` or `user_id`.
+- A valid publisher actor requires both the JWT `publisher_id` and `sub`
+  Stellar address to resolve to the same database row.
+- A missing, expired, revoked, or identity-mismatched referenced session
+  invalidates the access token.
+- Sessionless JWTs remain supported for backward compatibility and externally
+  issued administrator tokens.
+- Resource-specific SQL predicates remain in place as defense in depth.
+- Webhooks owned by another publisher return `404`, preserving resource
+  existence confidentiality.
+
+## Shared policy surface
+
+`backend/api/src/policy.rs` provides the database-verified `PolicyActor` and
+the explicit checks used by sensitive handlers:
+
+- registered publisher
+- submitted publisher/signing address
+- contract owner
+- generic resource owner
+- administrator
+- ownership-transfer sender/recipient action
+- webhook owner
+- webhook-delivery owner
+
+This is intentionally not a generic RBAC framework. The named rules represent
+the actions the application currently has and can be audited directly.
+
+## Protected actions
+
+| Action | Policy |
+| --- | --- |
+| Publish contract | Registered publisher; submitted address must equal authenticated address |
+| Deprecate contract | Contract owner |
+| Undeprecate contract | Contract owner |
+| Purge expired deprecated contracts | Administrator only |
+| Declare package dependencies | Contract owner |
+| Trigger dependency vulnerability re-scan | Contract owner |
+| Trigger manual security scan | Contract owner |
+| Update a security issue status | Contract owner |
+| Register a security scanner | Administrator only |
+| Directly change a contract publisher | Current owner plus the existing multisig approval |
+| Initiate ownership transfer | Current owner plus existing Ed25519 signature verification |
+| Accept ownership transfer | Intended recipient only |
+| Reject ownership transfer | Sender or intended recipient |
+| Create/list webhooks | Registered publisher |
+| Delete/test/read deliveries for a webhook | Webhook owner |
+| Retry a webhook delivery | Owner of the associated webhook |
+
+The expired-deprecation purge route was also moved into the admin router, while
+the handler retains its own admin policy check.
+
+## Identity and session corrections
+
+Previously, `AuthenticatedUser` parsed the JWT `sub` field as a UUID. `sub` is
+a Stellar `G...` address, so publisher IDs became the nil UUID. The extractor
+now uses the server-signed `publisher_id` claim and the shared AppState-backed
+JWT/session validation path.
+
+Session-backed tokens are checked against the in-memory session record for:
+
+- session existence
+- session expiry
+- Stellar subject
+- publisher UUID
+- role
+- scopes
+- MFA state
+
+The general JWT claims extractor and `AuthContext` now use the same validation
+path.
+
+## Signature identity
+
+Ownership-transfer signatures continue using their existing domain-separated,
+nonce-protected payloads. Transfer authorization decisions now come from the
+shared policy actor, and signature verification always uses that actor's
+database-verified Stellar address.
+
+The CLI deprecation request was aligned with the backend request model. When a
+deprecation signature envelope is present, the backend verifies:
+
+- all signature-envelope fields are present
+- signing address equals the authenticated actor's address
+- action is `deprecate`
+- signed contract ID equals the resolved contract
+- nonce syntax and length
+- timestamp freshness
+- Ed25519 signature against the actor's Stellar account
+
+Unsigned deprecation requests remain supported and rely on the authenticated
+owner policy. This preserves existing API clients while making signed clients
+verifiable instead of silently ignoring their signature data.
+
+## Client compatibility
+
+The frontend API wrapper now preserves caller-provided headers and attaches the
+existing `soroban_registry_token` bearer token when the caller did not provide
+an explicit authorization header. This gives affected mutation callers one
+consistent authentication path instead of duplicating header plumbing.
+
+The CLI request layer already attaches its stored access token. The deprecation
+CLI now sends the backend's required retirement and reason fields together with
+the signed envelope, and derives the signing identity with Stellar StrKey
+encoding so it matches the canonical `G...` account used by authentication.
+
+## Tests
+
+Policy-focused unit tests cover:
+
+- registered and unregistered publishers
+- owner allow and non-owner deny
+- no automatic admin owner bypass
+- admin allow and publisher deny
+- case-insensitive admin role claims
+- submitted publisher/signature address match and mismatch
+- transfer sender reject
+- transfer sender accept denial
+- transfer recipient accept/reject
+- outsider denial
+
+Authentication tests cover:
+
+- valid live session
+- expired session
+- session identity mismatch
+- revoked/missing session
+- backward-compatible sessionless JWT
+
+The ownership-transfer live fixture now registers and authenticates a publisher
+before publishing. The frontend API test verifies automatic bearer-token
+attachment.
+
+## Operational notes
+
+- No dependency or database migration was added.
+- Existing compare-and-swap, row-locking, multisig, and resource-scoped SQL
+  checks were retained.
+- Authorization covers the currently exposed `/api/webhooks` management API.
+  The separate lifecycle `webhook_subscriptions` storage has no management
+  handlers to migrate in this issue.
+- Scheduled callers of the deprecation purge endpoint must supply an
+  administrator bearer token.

--- a/frontend/__tests__/lib/api.test.ts
+++ b/frontend/__tests__/lib/api.test.ts
@@ -4,6 +4,7 @@ import fetchMock from "jest-fetch-mock";
 describe("api", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
+    window.localStorage.clear();
   });
 
   describe("getContracts", () => {
@@ -53,6 +54,35 @@ describe("api", () => {
         expect.stringContaining("/api/v1/contracts/test-id"),
         expect.any(Object),
       );
+    });
+  });
+
+  describe("authenticated mutations", () => {
+    it("attaches the canonical stored bearer token", async () => {
+      window.localStorage.setItem("soroban_registry_token", "publisher-token");
+      fetchMock.mockResponseOnce(JSON.stringify({ id: "contract-id" }));
+
+      await api.publishContract({
+        contract_id: "CTEST",
+        name: "Test",
+        network: "testnet",
+        publisher_address: "GTEST",
+        tags: [],
+      });
+
+      const headers = new Headers(fetchMock.mock.calls[0][1]?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer publisher-token");
+      expect(headers.get("Content-Type")).toBe("application/json");
+    });
+
+    it("does not overwrite an explicit authorization header", async () => {
+      window.localStorage.setItem("soroban_registry_token", "stored-token");
+      fetchMock.mockResponseOnce(JSON.stringify({ favorites: [] }));
+
+      await api.getPreferences("explicit-token");
+
+      const headers = new Headers(fetchMock.mock.calls[0][1]?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer explicit-token");
     });
   });
 });

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -816,6 +816,7 @@ export interface LegacyStatsResponse extends StatsResponse {
 }
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+const AUTH_TOKEN_KEY = "soroban_registry_token";
 const USE_MOCKS = process.env.NEXT_PUBLIC_USE_MOCKS === "true";
 
 const CATEGORY_SYNONYMS: Record<string, string> = {
@@ -940,11 +941,24 @@ function semanticScore(contract: Contract, queryTokens: string[], intent: Search
 
 async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const url = `${API_URL}${path}`;
+  const headers = new Headers(options?.headers);
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  if (!headers.has("Authorization") && typeof window !== "undefined") {
+    try {
+      const token = window.localStorage.getItem(AUTH_TOKEN_KEY);
+      if (token) headers.set("Authorization", `Bearer ${token}`);
+    } catch {
+      // Storage may be unavailable in hardened/private browsing contexts.
+    }
+  }
+
   let response: Response;
   try {
     response = await fetch(url, {
-      headers: { "Content-Type": "application/json", ...(options?.headers || {}) },
       ...options,
+      headers,
     });
   } catch (err) {
     throw new NetworkError(`Network request failed: ${String(err)}`);


### PR DESCRIPTION
## Summary

Centralizes authorization for sensitive backend actions in a shared policy module so owner-only, publisher-only, and administrator-only decisions are consistent and auditable. Sensitive handlers now derive actors from the canonical JWT/session or signature path, with no automatic administrator bypass.

## Related Issue

Closes #1123

## Type of Change

- [x] Feature — new functionality
- [ ] Bug fix — fixes an issue without changing existing behavior
- [ ] Documentation — updates or adds documentation only
- [ ] Refactor — code restructuring with no behavior change
- [ ] Test — adds or updates tests only
- [ ] Chore — build, CI, or tooling changes

## Changes Made

- Add a shared policy layer for owner, publisher, administrator, and signed-identity authorization decisions.
- Migrate publish, deprecate, transfer, re-scan, security-scanner, and webhook-management handlers to canonical authenticated actors.
- Add policy-focused unit tests, auth-header coverage, an ownership-transfer fixture, and an authorization matrix/migration guide.

## How Has This Been Tested?

### Test Commands

```bash
cargo check -p api --lib --locked --offline
rustfmt --edition 2021 --check api/src/policy.rs
frontend/node_modules/.bin/jest.cmd __tests__/lib/api.test.ts --runInBand --coverage=false --testNamePattern "authenticated mutations"
git diff --check upstream/main...HEAD
```

### Test Coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing completed

### Testing Notes

- Backend library compilation passes on the rebased commit; its 64 warnings are pre-existing baseline warnings.
- The two focused frontend bearer-token tests pass.
- The new policy module passes focused rustfmt and produced no changed-file Clippy diagnostic.
- Full policy-test compilation is currently blocked by 11 pre-existing test compilation errors elsewhere in the API crate.
- Full CLI checking reaches the changed deprecation module, then remains blocked by four pre-existing errors in unchanged CLI files.
- Repository-wide strict Clippy and global formatting checks remain blocked by existing baseline debt; no unrelated baseline files were changed.

## Checklist

- [x] My code follows the project's [style guidelines](CONTRIBUTING.md#code-standards)
- [x] I have performed a self-review of my code
- [x] I have added/updated comments for complex logic
- [x] I have updated documentation where applicable
- [ ] My changes generate no new warnings (`cargo clippy`, `pnpm lint`)
- [x] I have added tests that prove my fix/feature works
- [ ] All existing tests pass locally (`cargo test`, `pnpm test`)
- [x] My branch is rebased on the latest `main` with no merge conflicts
- [x] I have not introduced any breaking changes (or have documented them above)

## Additional Context

This intentionally tightens sensitive operations: callers must now present a canonical authenticated identity, and administrators do not implicitly bypass owner or publisher checks. No dependencies, database schema, or public response shapes were changed.