### PR TITLE
Add retention policy for terminal-state history records

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -223,3 +223,20 @@ GRAFANA_ADMIN_PASSWORD=changeme_use_a_strong_password
 #
 # Per-API-key overrides: KEY=LIMIT pairs (comma-separated)
 # RATE_LIMIT_API_KEY_LIMITS=key1=500,key2=2000
+
+# Data archival and retention (#881, #1118)
+#
+# Retention windows are configured per data type in the `archival_policies`
+# table (`retention_days`), not here, and can be changed at runtime via
+# PATCH /api/admin/archival/policies/:data_type. Policies that declare
+# terminal_states only ever archive records in one of those states, so
+# in-flight records are never archived however old they are.
+#
+# These settings control the scheduled sweep that applies those policies.
+# Set to false to stop the sweep from starting; the admin trigger endpoint
+# still works.
+ARCHIVAL_ENABLED=true
+# How often the sweep runs, in seconds. Defaults to daily.
+ARCHIVAL_INTERVAL_SECONDS=86400
+# Maximum records archived per policy per run, bounding transaction size.
+ARCHIVAL_BATCH_SIZE=5000

--- a/backend/api/src/archival.rs
+++ b/backend/api/src/archival.rs
@@ -16,6 +16,93 @@ use std::time::Duration;
 use crate::error::ApiError;
 use crate::state::AppState;
 
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const DEFAULT_INTERVAL_SECONDS: u64 = 86_400;
+const DEFAULT_BATCH_SIZE: u32 = 5_000;
+
+/// Operational settings for the scheduled archival sweep.
+///
+/// The retention window itself is per-policy and lives in
+/// `archival_policies.retention_days`, adjustable at runtime through
+/// `PATCH /api/admin/archival/policies/:data_type`. These control the job that
+/// applies those policies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArchivalConfig {
+    pub enabled: bool,
+    pub interval_seconds: u64,
+    pub batch_size: u32,
+}
+
+impl Default for ArchivalConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval_seconds: DEFAULT_INTERVAL_SECONDS,
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+}
+
+impl ArchivalConfig {
+    pub fn from_env() -> Self {
+        let config = Self {
+            enabled: env_bool("ARCHIVAL_ENABLED", true),
+            interval_seconds: env_u64("ARCHIVAL_INTERVAL_SECONDS", DEFAULT_INTERVAL_SECONDS),
+            batch_size: env_u32("ARCHIVAL_BATCH_SIZE", DEFAULT_BATCH_SIZE),
+        };
+
+        tracing::info!(
+            enabled = config.enabled,
+            interval_seconds = config.interval_seconds,
+            batch_size = config.batch_size,
+            "archival: config loaded"
+        );
+
+        config
+    }
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    match std::env::var(key) {
+        Ok(raw) => match raw.trim().to_lowercase().as_str() {
+            "true" | "1" | "yes" => true,
+            "false" | "0" | "no" => false,
+            _ => {
+                tracing::warn!("Invalid value for {key} (`{raw}`), using default {default}");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+fn env_u32(key: &str, default: u32) -> u32 {
+    match std::env::var(key) {
+        Ok(raw) => match raw.parse::<u32>() {
+            Ok(value) if value > 0 => value,
+            _ => {
+                tracing::warn!("Invalid value for {key} (`{raw}`), using default {default}");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    match std::env::var(key) {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(value) if value > 0 => value,
+            _ => {
+                tracing::warn!("Invalid value for {key} (`{raw}`), using default {default}");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
@@ -26,6 +113,11 @@ pub struct ArchivalPolicy {
     pub retention_days: i32,
     pub archive_storage: String,
     pub is_enabled: bool,
+    /// Column compared against the retention cutoff.
+    pub timestamp_column: String,
+    /// When set, only rows whose `status` matches one of these values are
+    /// eligible. `None` means age-only retention.
+    pub terminal_states: Option<Vec<String>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -85,7 +177,7 @@ pub async fn get_archival_status(
     State(state): State<AppState>,
 ) -> Result<Json<ArchivalStatus>, ApiError> {
     let policies = sqlx::query_as::<_, ArchivalPolicy>(
-        "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at FROM archival_policies ORDER BY data_type",
+        "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, timestamp_column, terminal_states, created_at, updated_at FROM archival_policies ORDER BY data_type",
     )
     .fetch_all(&state.db)
     .await
@@ -123,7 +215,7 @@ pub async fn get_archival_policies(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<ArchivalPolicy>>, ApiError> {
     let rows = sqlx::query_as::<_, ArchivalPolicy>(
-        "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at FROM archival_policies ORDER BY data_type",
+        "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, timestamp_column, terminal_states, created_at, updated_at FROM archival_policies ORDER BY data_type",
     )
     .fetch_all(&state.db)
     .await
@@ -147,7 +239,7 @@ pub async fn update_archival_policy(
             archive_storage = COALESCE($3, archive_storage),
             updated_at      = NOW()
         WHERE data_type = $4
-        RETURNING id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at
+        RETURNING id, data_type, source_table, retention_days, archive_storage, is_enabled, timestamp_column, terminal_states, created_at, updated_at
         "#,
     )
     .bind(req.retention_days)
@@ -171,14 +263,14 @@ pub async fn trigger_archival(
 ) -> Result<Json<Vec<ArchivalRun>>, ApiError> {
     let policies: Vec<ArchivalPolicy> = match req.data_type {
         Some(ref dt) => sqlx::query_as::<_, ArchivalPolicy>(
-            "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at FROM archival_policies WHERE data_type = $1 AND is_enabled = true",
+            "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, timestamp_column, terminal_states, created_at, updated_at FROM archival_policies WHERE data_type = $1 AND is_enabled = true",
         )
         .bind(dt)
         .fetch_all(&state.db)
         .await
         .map_err(|e| ApiError::internal_error("POLICY_FETCH_ERROR", e.to_string()))?,
         None => sqlx::query_as::<_, ArchivalPolicy>(
-            "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at FROM archival_policies WHERE is_enabled = true ORDER BY data_type",
+            "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, timestamp_column, terminal_states, created_at, updated_at FROM archival_policies WHERE is_enabled = true ORDER BY data_type",
         )
         .fetch_all(&state.db)
         .await
@@ -266,6 +358,14 @@ pub async fn restore_archived_record(
 // ── Core archival logic ───────────────────────────────────────────────────────
 
 async fn execute_archival_policy(pool: &PgPool, policy: &ArchivalPolicy) -> ArchivalRun {
+    execute_archival_policy_with(pool, policy, ArchivalConfig::from_env().batch_size).await
+}
+
+async fn execute_archival_policy_with(
+    pool: &PgPool,
+    policy: &ArchivalPolicy,
+    batch_size: u32,
+) -> ArchivalRun {
     let run_id: i64 = sqlx::query_scalar(
         "INSERT INTO archival_runs (policy_id, data_type, status) VALUES ($1, $2, 'running') RETURNING id",
     )
@@ -277,7 +377,7 @@ async fn execute_archival_policy(pool: &PgPool, policy: &ArchivalPolicy) -> Arch
 
     let cutoff = Utc::now() - chrono::Duration::days(policy.retention_days as i64);
 
-    let archived = archive_rows(pool, policy, cutoff, run_id).await;
+    let archived = archive_rows(pool, policy, cutoff, run_id, batch_size).await;
 
     match archived {
         Ok((rows_archived, rows_deleted)) => {
@@ -340,44 +440,118 @@ async fn execute_archival_policy(pool: &PgPool, policy: &ArchivalPolicy) -> Arch
     }
 }
 
+/// Reject anything that is not a plain SQL identifier.
+///
+/// `source_table` and `timestamp_column` are interpolated into the archival
+/// statements rather than bound, so they must not carry arbitrary SQL even
+/// though they originate from an admin-managed table.
+fn validate_identifier(value: &str) -> Result<(), sqlx::Error> {
+    let valid = !value.is_empty()
+        && value.len() <= 63
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_');
+
+    if valid {
+        Ok(())
+    } else {
+        Err(sqlx::Error::Protocol(format!(
+            "archival policy contains an invalid SQL identifier: {value}"
+        )))
+    }
+}
+
+/// Whether a record qualifies for archival.
+///
+/// A record sitting exactly on the retention threshold is still inside the
+/// window and is retained; only records strictly older than the cutoff are
+/// archived. Where a policy declares terminal states, records in any other
+/// state are retained regardless of age. The filtering itself runs in SQL, so
+/// this is not called on the production path — it pins the boundary semantics
+/// the queries below must match.
+#[allow(dead_code)]
+pub fn is_eligible(
+    status: Option<&str>,
+    terminal_states: Option<&[String]>,
+    timestamp: DateTime<Utc>,
+    cutoff: DateTime<Utc>,
+) -> bool {
+    let state_ok = match terminal_states {
+        Some(states) => match status {
+            Some(status) => states.iter().any(|s| s == status),
+            None => false,
+        },
+        None => true,
+    };
+
+    state_ok && timestamp < cutoff
+}
+
 async fn archive_rows(
     pool: &PgPool,
     policy: &ArchivalPolicy,
     cutoff: DateTime<Utc>,
     run_id: i64,
+    batch_size: u32,
 ) -> Result<(i64, i64), sqlx::Error> {
-    // Copy eligible rows into the audit trail for restore capability
-    let archived: i64 = sqlx::query_scalar(&format!(
+    validate_identifier(&policy.source_table)?;
+    validate_identifier(&policy.timestamp_column)?;
+
+    // Policies that name terminal states only ever archive rows sitting in one
+    // of them, so live workflow records are never touched however old they are.
+    let state_filter = if policy.terminal_states.is_some() {
+        " AND status = ANY($3)"
+    } else {
+        ""
+    };
+
+    // Archive and delete share one transaction so a row can never be removed
+    // from the source table without its audit-trail copy being committed.
+    let mut tx = pool.begin().await?;
+
+    let insert_sql = format!(
         r#"
-        WITH archived AS (
+        WITH eligible AS (
+            SELECT * FROM {table}
+            WHERE {ts} < $2{state_filter}
+            ORDER BY {ts}
+            LIMIT {batch_size}
+        ),
+        archived AS (
             INSERT INTO archival_audit_trail (run_id, source_table, source_id, archived_data, archived_at)
-            SELECT $1, '{table}', id::TEXT, to_jsonb({table}.*), NOW()
-            FROM {table}
-            WHERE created_at < $2
-            LIMIT 5000
+            SELECT $1, '{table}', e.id::TEXT, to_jsonb(e.*), NOW()
+            FROM eligible e
             RETURNING 1
         )
         SELECT COUNT(*) FROM archived
         "#,
         table = policy.source_table,
-    ))
-    .bind(run_id)
-    .bind(cutoff)
-    .fetch_one(pool)
-    .await
-    .unwrap_or(0);
+        ts = policy.timestamp_column,
+        state_filter = state_filter,
+        batch_size = batch_size,
+    );
 
-    // Delete the archived rows from the source table
-    let deleted: u64 = sqlx::query(&format!(
-        "DELETE FROM {} WHERE created_at < $1 AND id IN (SELECT source_id::BIGINT FROM archival_audit_trail WHERE run_id = $2)",
-        policy.source_table,
+    let mut insert = sqlx::query_scalar::<_, i64>(&insert_sql)
+        .bind(run_id)
+        .bind(cutoff);
+    if let Some(states) = &policy.terminal_states {
+        insert = insert.bind(states);
+    }
+    let archived: i64 = insert.fetch_one(&mut *tx).await?;
+
+    // Delete exactly what was archived in this run. Comparing the key as text
+    // keeps this correct for both UUID and integer primary keys; casting the
+    // trail's TEXT source_id to BIGINT would fail outright on UUID tables.
+    let deleted = sqlx::query(&format!(
+        "DELETE FROM {table} WHERE id::TEXT IN (SELECT source_id FROM archival_audit_trail WHERE run_id = $1)",
+        table = policy.source_table,
     ))
-    .bind(cutoff)
     .bind(run_id)
-    .execute(pool)
-    .await
-    .map(|r| r.rows_affected())
-    .unwrap_or(0);
+    .execute(&mut *tx)
+    .await?
+    .rows_affected();
+
+    tx.commit().await?;
 
     Ok((archived, deleted as i64))
 }
@@ -386,20 +560,27 @@ async fn archive_rows(
 
 /// Runs archival daily at midnight UTC.
 pub fn spawn_archival_task(pool: PgPool) {
+    let config = ArchivalConfig::from_env();
+
+    if !config.enabled {
+        tracing::info!("archival: disabled, scheduled sweep not started");
+        return;
+    }
+
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(86_400));
+        let mut interval = tokio::time::interval(Duration::from_secs(config.interval_seconds));
         loop {
             interval.tick().await;
 
             let policies: Vec<ArchivalPolicy> = sqlx::query_as::<_, ArchivalPolicy>(
-                "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, created_at, updated_at FROM archival_policies WHERE is_enabled = true ORDER BY data_type",
+                "SELECT id, data_type, source_table, retention_days, archive_storage, is_enabled, timestamp_column, terminal_states, created_at, updated_at FROM archival_policies WHERE is_enabled = true ORDER BY data_type",
             )
             .fetch_all(&pool)
             .await
             .unwrap_or_default();
 
             for policy in &policies {
-                let run = execute_archival_policy(&pool, policy).await;
+                let run = execute_archival_policy_with(&pool, policy, config.batch_size).await;
                 if run.status == "failed" {
                     tracing::error!(
                         data_type = %policy.data_type,
@@ -410,4 +591,136 @@ pub fn spawn_archival_task(pool: PgPool) {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OWNERSHIP_TERMINAL: [&str; 3] = ["expired", "rejected", "duplicate"];
+
+    fn terminal() -> Vec<String> {
+        OWNERSHIP_TERMINAL.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn cutoff_for(now: DateTime<Utc>, retention_days: i64) -> DateTime<Utc> {
+        now - chrono::Duration::days(retention_days)
+    }
+
+    #[test]
+    fn record_exactly_at_threshold_is_retained() {
+        let now = Utc::now();
+        let cutoff = cutoff_for(now, 90);
+
+        assert!(!is_eligible(
+            Some("expired"),
+            Some(&terminal()),
+            cutoff,
+            cutoff
+        ));
+    }
+
+    #[test]
+    fn record_just_under_threshold_is_retained() {
+        let now = Utc::now();
+        let cutoff = cutoff_for(now, 90);
+
+        assert!(!is_eligible(
+            Some("expired"),
+            Some(&terminal()),
+            cutoff + chrono::Duration::seconds(1),
+            cutoff
+        ));
+    }
+
+    #[test]
+    fn record_just_over_threshold_is_archived() {
+        let now = Utc::now();
+        let cutoff = cutoff_for(now, 90);
+
+        assert!(is_eligible(
+            Some("expired"),
+            Some(&terminal()),
+            cutoff - chrono::Duration::seconds(1),
+            cutoff
+        ));
+    }
+
+    #[test]
+    fn active_transfer_states_are_never_archived_regardless_of_age() {
+        let now = Utc::now();
+        let cutoff = cutoff_for(now, 90);
+        let ancient = now - chrono::Duration::days(3650);
+
+        for status in ["pending", "confirmed", "completed"] {
+            assert!(
+                !is_eligible(Some(status), Some(&terminal()), ancient, cutoff),
+                "{status} must never be archived"
+            );
+        }
+    }
+
+    #[test]
+    fn every_terminal_state_past_the_window_is_archived() {
+        let now = Utc::now();
+        let cutoff = cutoff_for(now, 90);
+        let old = now - chrono::Duration::days(91);
+
+        for status in OWNERSHIP_TERMINAL {
+            assert!(
+                is_eligible(Some(status), Some(&terminal()), old, cutoff),
+                "{status} should be archived"
+            );
+        }
+    }
+
+    #[test]
+    fn completed_is_not_terminal_for_retention() {
+        // 'completed' is the successful end state of a transfer and underpins
+        // the ownership audit trail, so it is deliberately excluded.
+        assert!(!OWNERSHIP_TERMINAL.contains(&"completed"));
+    }
+
+    #[test]
+    fn age_only_policies_ignore_status() {
+        let now = Utc::now();
+        let cutoff = cutoff_for(now, 90);
+
+        // Scan runs have no status column; eligibility is purely age-based.
+        assert!(is_eligible(None, None, cutoff - chrono::Duration::seconds(1), cutoff));
+        assert!(!is_eligible(None, None, cutoff, cutoff));
+    }
+
+    #[test]
+    fn rows_without_status_are_retained_under_a_terminal_state_policy() {
+        let now = Utc::now();
+        let cutoff = cutoff_for(now, 90);
+
+        assert!(!is_eligible(
+            None,
+            Some(&terminal()),
+            now - chrono::Duration::days(3650),
+            cutoff
+        ));
+    }
+
+    #[test]
+    fn default_config_matches_documented_defaults() {
+        let config = ArchivalConfig::default();
+
+        assert!(config.enabled);
+        assert_eq!(config.interval_seconds, 86_400);
+        assert_eq!(config.batch_size, 5_000);
+    }
+
+    #[test]
+    fn identifiers_are_validated() {
+        assert!(validate_identifier("ownership_transfers").is_ok());
+        assert!(validate_identifier("scanned_at").is_ok());
+
+        assert!(validate_identifier("").is_err());
+        assert!(validate_identifier("users; DROP TABLE contracts").is_err());
+        assert!(validate_identifier("table--comment").is_err());
+        assert!(validate_identifier(&"a".repeat(64)).is_err());
+    }
 }

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -203,6 +203,11 @@ async fn main() -> Result<()> {
     // looks at again.
     api::ownership_transfer::spawn_ownership_transfer_expiry_task(pool.clone());
 
+    // Spawn the archival/retention sweeper (Issues #881, #1118). Applies every
+    // enabled archival policy on a daily cycle; previously only the admin
+    // trigger endpoint ran them.
+    api::archival::spawn_archival_task(pool.clone());
+
     // Create prometheus registry for metrics
     let registry = Registry::new();
     if let Err(e) = api::metrics::register_all(&registry) {

--- a/database/migrations/20260729120000_issue1118_retention_terminal_states.sql
+++ b/database/migrations/20260729120000_issue1118_retention_terminal_states.sql
@@ -1,0 +1,70 @@
+-- Issue #1118: configurable retention and purge policy for terminal-state
+-- history records.
+--
+-- The archival engine from #881 selects rows purely by age. History tables like
+-- ownership_transfers hold live workflow state alongside finished records, so an
+-- age-only policy would archive pending transfers. These columns let a policy
+-- restrict itself to records in a state they can no longer transition out of,
+-- and to measure age against a column other than created_at.
+
+ALTER TABLE archival_policies
+    ADD COLUMN IF NOT EXISTS timestamp_column TEXT NOT NULL DEFAULT 'created_at',
+    ADD COLUMN IF NOT EXISTS terminal_states  TEXT[];
+
+COMMENT ON COLUMN archival_policies.timestamp_column IS
+    'Column whose value is compared against the retention cutoff.';
+COMMENT ON COLUMN archival_policies.terminal_states IS
+    'When set, only rows whose status column matches one of these values are eligible. NULL means age-only retention.';
+
+-- ownership_transfers.status is constrained to
+-- ('pending','confirmed','completed','expired','rejected','duplicate').
+-- Only the last three are terminal: pending is awaiting confirmation, confirmed
+-- is awaiting completion, and completed is the successful end state that the
+-- ownership audit trail depends on.
+INSERT INTO archival_policies
+    (data_type, source_table, retention_days, archive_storage, timestamp_column, terminal_states)
+VALUES
+    (
+        'ownership_transfers',
+        'ownership_transfers',
+        90,
+        'database',
+        'created_at',
+        ARRAY['expired', 'rejected', 'duplicate']
+    ),
+    -- Scan runs are an append-only log with no status column, so retention is
+    -- age-only and measured from scanned_at.
+    (
+        'dependency_scan_runs',
+        'contract_dependency_scan_runs',
+        90,
+        'database',
+        'scanned_at',
+        NULL
+    )
+ON CONFLICT (data_type) DO NOTHING;
+
+-- Two policies seeded by #881 have never archived anything. Both failed inside
+-- the engine, which swallowed the error and recorded the run as completed, so
+-- they reported success while doing nothing. Now that errors propagate they
+-- would fail loudly on every sweep, so correct them here.
+--
+--   query_perf_log  -> query_performance_log timestamps its rows recorded_at,
+--                      not created_at.
+--   audit_logs      -> the table is audit_logs; audit_log does not exist.
+UPDATE archival_policies
+SET timestamp_column = 'recorded_at'
+WHERE data_type = 'query_perf_log'
+  AND source_table = 'query_performance_log';
+
+UPDATE archival_policies
+SET source_table = 'audit_logs'
+WHERE data_type = 'audit_logs'
+  AND source_table = 'audit_log';
+
+-- Supports the retention scan on each newly covered table.
+CREATE INDEX IF NOT EXISTS idx_ownership_transfers_status_created_at
+    ON ownership_transfers (status, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_contract_dependency_scan_runs_scanned_at
+    ON contract_dependency_scan_runs (scanned_at);


### PR DESCRIPTION
Closes #1118

## What

`ownership_transfers` and dependency scan runs had no retention policy, so expired, rejected and duplicate records accumulate indefinitely and degrade the indexed status/timestamp lookups on those tables.

The archival engine from #881 already provides configurable per-policy retention, run history and a restorable audit trail — but it selects rows purely by age, which cannot express this. `ownership_transfers` holds live workflow state alongside finished records, so registering it against an age-only policy would archive pending transfers.

This adds `terminal_states` and `timestamp_column` to `archival_policies`. A policy declaring terminal states only ever archives rows sitting in one of them, so in-flight records are never touched however old they are, and a policy can measure age against a column other than `created_at`.

Two policies are registered:

| data_type | source_table | anchor | terminal states |
|---|---|---|---|
| `ownership_transfers` | `ownership_transfers` | `created_at` | `expired`, `rejected`, `duplicate` |
| `dependency_scan_runs` | `contract_dependency_scan_runs` | `scanned_at` | none (age-only) |

`completed` is deliberately excluded from the terminal set — it is the successful end state the ownership audit trail depends on. `pending` and `confirmed` are live workflow state.

## Engine fixes (prerequisites, not cleanup)

The feature cannot work without these:

- **The delete was broken for UUID keys.** It cast `archival_audit_trail.source_id` to `BIGINT`, which fails outright on UUID primary keys. `ownership_transfers`, scan runs and the already-registered `contract_interactions` are all UUID-keyed, so none of them could ever be archived. Comparing the key as text works for both integer and UUID tables.
- **Errors were swallowed.** Both statements ended in `unwrap_or(0)`, so failures were recorded as `completed` runs with zero rows. That is precisely how the above stayed invisible.
- **Archive and delete now share a transaction**, so a row cannot be removed from the source table without its audit-trail copy being committed.

Identifiers interpolated from the policy table are now validated as plain SQL identifiers.

## Two policies that had never worked

With errors propagating, two policies seeded by #881 turned out to have been failing silently since they were added:

- `query_perf_log` queried `created_at`; `query_performance_log` timestamps rows `recorded_at`
- `audit_logs` pointed at a table named `audit_log`, which does not exist (it is `audit_logs`)

Both are corrected in the migration, otherwise this PR would turn two silent no-ops into loud failures on every sweep.

## Scheduled sweep

`spawn_archival_task` was defined but never called, so the scheduled job did not run at all — only the admin trigger endpoint applied policies. It is now started from `main`, gated on `ARCHIVAL_ENABLED`.

## Configuration

`ARCHIVAL_ENABLED`, `ARCHIVAL_INTERVAL_SECONDS`, `ARCHIVAL_BATCH_SIZE` (the batch size was a hardcoded `LIMIT 5000`). Retention windows stay per-policy in `archival_policies.retention_days`, adjustable at runtime via `PATCH /api/admin/archival/policies/:data_type` — that is more capable than a global env var, and `.env.example` says so, so anyone looking for `RETENTION_DAYS` finds where it lives.

## Verification

All 141 migrations apply cleanly against Postgres 16. Verified against live rows, 8 fixtures on the 90-day boundary:

```
PASS expired    91d          -> archived    PASS expired   just-under -> retained
PASS rejected   91d          -> archived    PASS expired   89d        -> retained
PASS duplicate  91d          -> archived    PASS pending   10y        -> retained
                                            PASS confirmed 10y        -> retained
archived=3 deleted=3 err=none               PASS completed 10y        -> retained
```

`rows_deleted=3` is the specific evidence the UUID fix works; the old cast produced `archived=N, deleted=0, completed` with no error surfaced.

## Reviewer notes

- **The exact-boundary case is not verified.** A record sitting precisely on the threshold should be retained (the comparison is strictly-older). That is asserted in a unit test, but `cargo test --lib` does not compile on current main — 11 pre-existing errors in `auth.rs` and `auth_handlers.rs`, identical on a clean checkout and unrelated to this branch — so the assertion has never executed. Wall-clock fixtures cannot express exact equality, hence the "just under" case above.
- This changes shared engine behaviour, so the existing `interactions`, `audit_logs` and `query_perf_log` policies are affected too. All three were non-functional before; `interactions` should begin archiving for the first time.
- The archival admin routes carry no auth middleware. Pre-existing and left alone, but worth a separate issue.