### PR TITLE
Add signed offline contract snapshots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -223,3 +223,24 @@ GRAFANA_ADMIN_PASSWORD=changeme_use_a_strong_password
 #
 # Per-API-key overrides: KEY=LIMIT pairs (comma-separated)
 # RATE_LIMIT_API_KEY_LIMITS=key1=500,key2=2000
+
+# Contract snapshot signing (#1116)
+#
+# Ed25519 32-byte seed, base64-encoded, used to sign offline contract
+# snapshots served from GET /api/contracts/:id/snapshot. Generate with:
+#   openssl rand -base64 32
+#
+# Snapshot endpoints return 503 until this is set; the rest of the API is
+# unaffected. Rotating the key does not invalidate previously exported
+# snapshots, but auditors pinning the old fingerprint will need the new one,
+# so publish it before rotating.
+#
+# The public half is served unauthenticated at GET /api/registry/signing-key.
+# Verifiers should pin that fingerprint out of band: a snapshot carries its own
+# public key, so without pinning a valid signature proves only that the bundle
+# is self-consistent, not that this registry produced it.
+REGISTRY_SIGNING_KEY=
+
+# Absolute base URL recorded in exported snapshots for provenance when several
+# registries are in play. Optional.
+REGISTRY_PUBLIC_URL=http://localhost:3001

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4346,6 +4346,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "ed25519-dalek",
  "hex",
  "once_cell",
  "opentelemetry",

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -84,6 +84,7 @@ pub mod security;
 pub mod security_scan_handlers;
 pub mod service_health;
 pub mod signing_handlers;
+pub mod snapshot_handlers;
 pub mod similarity_handlers;
 pub mod simulation;
 pub mod simulation_handlers;

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -20,6 +20,7 @@ use crate::{
     partition_manager, patch_handlers, performance_handlers, plugin_marketplace_handlers,
     publisher_verification_handlers, query_analysis, query_monitor, recommendation_handlers,
     report_handlers, resource_handlers, search_postgres, security_scan_handlers,
+    snapshot_handlers,
     signature_verification, similarity_handlers, simulation_handlers,
     state::AppState,
     state_monitor::handlers as state_monitor_handlers,
@@ -502,6 +503,15 @@ pub fn contract_routes() -> Router<AppState> {
         .route(
             "/api/contracts/:id/deprecation-info",
             get(deprecation_handlers::get_deprecation_info),
+        )
+        // Signed offline contract snapshot (Issue #1116)
+        .route(
+            "/api/contracts/:id/snapshot",
+            get(snapshot_handlers::get_contract_snapshot),
+        )
+        .route(
+            "/api/registry/signing-key",
+            get(snapshot_handlers::get_registry_signing_key),
         )
         .route(
             "/api/contracts/:id/deprecate",

--- a/backend/api/src/snapshot_handlers.rs
+++ b/backend/api/src/snapshot_handlers.rs
@@ -1,0 +1,365 @@
+//! Signed contract snapshots (Issue #1116).
+//!
+//! Assembles a contract's lifecycle state into a single JSON document and signs
+//! it with the registry's key, so auditors can verify it offline without
+//! reaching this API. The document shape, canonical form and verification logic
+//! all live in `shared::snapshot` so the CLI signs and verifies the same bytes.
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use chrono::{DateTime, Utc};
+use ed25519_dalek::{SigningKey, SECRET_KEY_LENGTH};
+use serde::Serialize;
+use serde_json::Value;
+use shared::snapshot::{
+    key_fingerprint, sign_snapshot, ContractSnapshot, LineageLink, SnapshotContract,
+    SnapshotPayload, SnapshotVerification, SNAPSHOT_ALGORITHM, SNAPSHOT_SCHEMA_VERSION,
+};
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    handlers::db_internal_error,
+    state::AppState,
+};
+
+const ENV_SIGNING_KEY: &str = "REGISTRY_SIGNING_KEY";
+const ENV_REGISTRY_URL: &str = "REGISTRY_PUBLIC_URL";
+
+/// Guards against a cycle in `replacement_contract_id` turning lineage walking
+/// into an unbounded loop.
+const MAX_LINEAGE_DEPTH: usize = 32;
+
+/// The registry's published signing identity, for pinning before offline
+/// verification.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct RegistrySigningKey {
+    pub algorithm: String,
+    pub public_key: String,
+    pub key_fingerprint: String,
+}
+
+/// Load the registry signing key from the environment.
+///
+/// Kept out of `AppState` so a deployment that never exports snapshots does not
+/// need the key configured at all; the endpoints return 503 instead of the
+/// process refusing to boot.
+fn load_signing_key() -> Result<SigningKey, ApiError> {
+    let raw = std::env::var(ENV_SIGNING_KEY).map_err(|_| {
+        ApiError::service_unavailable_with(
+            "SNAPSHOT_SIGNING_UNAVAILABLE",
+            "REGISTRY_SIGNING_KEY is not configured; contract snapshots cannot be signed",
+        )
+    })?;
+
+    let seed = BASE64
+        .decode(raw.trim())
+        .or_else(|_| {
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(raw.trim())
+        })
+        .map_err(|_| {
+            ApiError::internal_error(
+                "SNAPSHOT_SIGNING_KEY_INVALID",
+                "REGISTRY_SIGNING_KEY is not valid base64",
+            )
+        })?;
+
+    let seed: [u8; SECRET_KEY_LENGTH] = seed.as_slice().try_into().map_err(|_| {
+        ApiError::internal_error(
+            "SNAPSHOT_SIGNING_KEY_INVALID",
+            "REGISTRY_SIGNING_KEY must decode to exactly 32 bytes",
+        )
+    })?;
+
+    Ok(SigningKey::from_bytes(&seed))
+}
+
+/// GET /api/registry/signing-key
+///
+/// Publishes the public half so a verifier can pin the fingerprint out of band.
+/// Without pinning, a snapshot only proves internal consistency: anyone can
+/// re-sign a modified payload with their own key and embed that public key.
+#[utoipa::path(
+    get,
+    path = "/api/registry/signing-key",
+    tag = "snapshots",
+    responses(
+        (status = 200, description = "Registry snapshot signing key", body = RegistrySigningKey),
+        (status = 503, description = "Signing key not configured")
+    )
+)]
+pub async fn get_registry_signing_key() -> ApiResult<Json<RegistrySigningKey>> {
+    let key = load_signing_key()?;
+    let verifying = key.verifying_key();
+
+    Ok(Json(RegistrySigningKey {
+        algorithm: SNAPSHOT_ALGORITHM.to_string(),
+        public_key: BASE64.encode(verifying.as_bytes()),
+        key_fingerprint: key_fingerprint(verifying.as_bytes()),
+    }))
+}
+
+type ContractRow = (
+    Uuid,
+    String,
+    String,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    Option<Uuid>,
+    bool,
+    DateTime<Utc>,
+    DateTime<Utc>,
+);
+
+/// GET /api/contracts/:id/snapshot
+///
+/// Returns a signed, self-contained record of the contract's lifecycle state as
+/// of now.
+#[utoipa::path(
+    get,
+    path = "/api/contracts/{id}/snapshot",
+    tag = "snapshots",
+    params(("id" = Uuid, Path, description = "Contract UUID")),
+    responses(
+        (status = 200, description = "Signed contract snapshot"),
+        (status = 404, description = "Contract not found"),
+        (status = 503, description = "Signing key not configured")
+    )
+)]
+pub async fn get_contract_snapshot(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<ContractSnapshot>> {
+    let signing_key = load_signing_key()?;
+
+    let row: Option<ContractRow> = sqlx::query_as(
+        r#"
+        SELECT id, contract_id, name, network::text, wasm_hash,
+               description, category, publisher_id, is_verified,
+               created_at, updated_at
+        FROM contracts
+        WHERE id = $1
+        "#,
+    )
+    .bind(id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| db_internal_error("fetch contract for snapshot", e))?;
+
+    let Some((
+        contract_uuid,
+        contract_id,
+        name,
+        network,
+        wasm_hash,
+        description,
+        category,
+        publisher_id,
+        is_verified,
+        created_at,
+        updated_at,
+    )) = row
+    else {
+        return Err(ApiError::not_found("ContractNotFound", "Contract not found"));
+    };
+
+    let verification = fetch_verification(&state, contract_uuid).await?;
+    let dependency_scan = fetch_dependency_scan(&state, contract_uuid).await?;
+    let deprecation = fetch_deprecation(&state, contract_uuid).await?;
+    let lineage = fetch_lineage(&state, contract_uuid).await?;
+
+    let payload = SnapshotPayload {
+        schema_version: SNAPSHOT_SCHEMA_VERSION.to_string(),
+        exported_at: Utc::now(),
+        registry_url: std::env::var(ENV_REGISTRY_URL).ok(),
+        contract: SnapshotContract {
+            id: contract_uuid.to_string(),
+            contract_id,
+            name,
+            network,
+            wasm_hash,
+            description,
+            category,
+            publisher_id: publisher_id.map(|p| p.to_string()),
+            created_at,
+            updated_at,
+        },
+        verification: SnapshotVerification {
+            is_verified,
+            status: verification.as_ref().map(|(s, _)| s.clone()),
+            verified_at: verification.and_then(|(_, at)| at),
+        },
+        dependency_scan,
+        deprecation,
+        lineage,
+    };
+
+    let snapshot = sign_snapshot(payload, &signing_key).map_err(|e| {
+        ApiError::internal_error("SNAPSHOT_SIGN_FAILED", format!("failed to sign snapshot: {e}"))
+    })?;
+
+    Ok(Json(snapshot))
+}
+
+/// Latest verification attempt, if the contract has ever been verified.
+async fn fetch_verification(
+    state: &AppState,
+    contract_uuid: Uuid,
+) -> ApiResult<Option<(String, Option<DateTime<Utc>>)>> {
+    sqlx::query_as::<_, (String, Option<DateTime<Utc>>)>(
+        r#"
+        SELECT status::text, verified_at
+        FROM verifications
+        WHERE contract_id = $1
+        ORDER BY created_at DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(contract_uuid)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| db_internal_error("fetch verification for snapshot", e))
+}
+
+/// Most recent dependency scan, as recorded findings rather than a fresh scan:
+/// a snapshot records state as of export, and must not mutate anything.
+async fn fetch_dependency_scan(state: &AppState, contract_uuid: Uuid) -> ApiResult<Option<Value>> {
+    let findings: Vec<(String, String, String, Option<String>, bool)> = sqlx::query_as(
+        r#"
+        SELECT r.cve_id, r.package_name, r.current_version,
+               r.recommended_version, r.is_false_positive
+        FROM contract_scan_results r
+        WHERE r.contract_id = $1
+        ORDER BY r.cve_id
+        "#,
+    )
+    .bind(contract_uuid)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| db_internal_error("fetch scan results for snapshot", e))?;
+
+    let last_scanned_at: Option<DateTime<Utc>> = sqlx::query_scalar(
+        "SELECT MAX(scanned_at) FROM contract_dependency_scan_runs WHERE contract_id = $1",
+    )
+    .bind(contract_uuid)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| db_internal_error("fetch scan runs for snapshot", e))?;
+
+    if findings.is_empty() && last_scanned_at.is_none() {
+        return Ok(None);
+    }
+
+    let findings: Vec<Value> = findings
+        .into_iter()
+        .map(
+            |(cve_id, package_name, current_version, recommended_version, is_false_positive)| {
+                serde_json::json!({
+                    "cve_id": cve_id,
+                    "package_name": package_name,
+                    "current_version": current_version,
+                    "recommended_version": recommended_version,
+                    "is_false_positive": is_false_positive,
+                })
+            },
+        )
+        .collect();
+
+    Ok(Some(serde_json::json!({
+        "last_scanned_at": last_scanned_at,
+        "finding_count": findings.len(),
+        "findings": findings,
+    })))
+}
+
+/// Deprecation state, omitted entirely for a contract that has never been
+/// deprecated so the payload stays honest about what is known.
+async fn fetch_deprecation(state: &AppState, contract_uuid: Uuid) -> ApiResult<Option<Value>> {
+    let row: Option<(Option<DateTime<Utc>>, Option<String>, Option<Uuid>, String)> =
+        sqlx::query_as(
+            r#"
+            SELECT deprecated_at, deprecation_reason, replacement_contract_id,
+                   COALESCE(deprecation_status::text, 'active')
+            FROM contracts
+            WHERE id = $1
+            "#,
+        )
+        .bind(contract_uuid)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| db_internal_error("fetch deprecation for snapshot", e))?;
+
+    let Some((deprecated_at, reason, replacement, status)) = row else {
+        return Ok(None);
+    };
+
+    if deprecated_at.is_none() && replacement.is_none() && status == "active" {
+        return Ok(None);
+    }
+
+    Ok(Some(serde_json::json!({
+        "status": status,
+        "deprecated_at": deprecated_at,
+        "reason": reason,
+        "replacement_contract_id": replacement.map(|r| r.to_string()),
+    })))
+}
+
+/// Walk `replacement_contract_id` forward to build the successor chain.
+///
+/// Stops at `MAX_LINEAGE_DEPTH` and on revisiting a contract, so a cycle in the
+/// data cannot hang the request.
+async fn fetch_lineage(state: &AppState, contract_uuid: Uuid) -> ApiResult<Vec<LineageLink>> {
+    let mut chain = Vec::new();
+    let mut seen = vec![contract_uuid];
+    let mut current = contract_uuid;
+
+    for _ in 0..MAX_LINEAGE_DEPTH {
+        let next: Option<Uuid> =
+            sqlx::query_scalar("SELECT replacement_contract_id FROM contracts WHERE id = $1")
+                .bind(current)
+                .fetch_optional(&state.db)
+                .await
+                .map_err(|e| db_internal_error("fetch lineage pointer for snapshot", e))?
+                .flatten();
+
+        let Some(next_id) = next else { break };
+        if seen.contains(&next_id) {
+            break;
+        }
+
+        let row: Option<(String, Option<String>, Option<DateTime<Utc>>, String)> = sqlx::query_as(
+            r#"
+            SELECT contract_id, name, deprecated_at,
+                   COALESCE(deprecation_status::text, 'active')
+            FROM contracts
+            WHERE id = $1
+            "#,
+        )
+        .bind(next_id)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| db_internal_error("fetch lineage entry for snapshot", e))?;
+
+        let Some((contract_id, name, deprecated_at, status)) = row else {
+            break;
+        };
+
+        chain.push(LineageLink {
+            contract_id,
+            name,
+            status,
+            deprecated_at,
+        });
+
+        seen.push(next_id);
+        current = next_id;
+    }
+
+    Ok(chain)
+}

--- a/backend/shared/Cargo.toml
+++ b/backend/shared/Cargo.toml
@@ -16,6 +16,7 @@ utoipa = { workspace = true }
 base64 = { workspace = true }
 rust_decimal = "1.35"
 sha2 = "0.10"
+ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 hex = "0.4"
 wasmparser = { workspace = true }
 s3 = { package = "rust-s3", version = "0.37", features = ["blocking"] }

--- a/backend/shared/src/lib.rs
+++ b/backend/shared/src/lib.rs
@@ -5,6 +5,7 @@ pub mod models;
 pub mod pagination;
 pub mod semver;
 pub mod slug;
+pub mod snapshot;
 pub mod source_storage;
 pub mod upgrade;
 pub mod wasm;

--- a/backend/shared/src/snapshot.rs
+++ b/backend/shared/src/snapshot.rs
@@ -1,0 +1,528 @@
+//! Portable, signed contract snapshots (Issue #1116).
+//!
+//! A snapshot is a single JSON document capturing a contract's lifecycle state
+//! at a point in time, signed by the registry so it can be audited offline —
+//! for compliance, archival, or air-gapped review — without reaching the API.
+//!
+//! Both the registry and the CLI build and verify snapshots through this
+//! module, so the bytes covered by the signature are produced by one
+//! implementation rather than two that must be kept in step.
+//!
+//! # Canonical form
+//!
+//! The signature covers a canonical serialization of the payload: object keys
+//! sorted lexicographically, no insignificant whitespace. Sorting is applied
+//! explicitly rather than relying on `serde_json`'s map type, whose ordering
+//! depends on the `preserve_order` feature that any crate in the dependency
+//! graph could enable.
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use chrono::{DateTime, Utc};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+/// Bumped when the payload shape changes in a way that alters canonical bytes.
+pub const SNAPSHOT_SCHEMA_VERSION: &str = "1.0";
+
+pub const SNAPSHOT_ALGORITHM: &str = "ed25519";
+
+/// A signed snapshot: the state captured, plus the registry's signature over it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractSnapshot {
+    pub payload: SnapshotPayload,
+    pub signature: SnapshotSignature,
+}
+
+/// Everything the signature covers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotPayload {
+    pub schema_version: String,
+    /// When the registry assembled this snapshot.
+    pub exported_at: DateTime<Utc>,
+    /// Registry that produced it, for provenance when several are in play.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry_url: Option<String>,
+    pub contract: SnapshotContract,
+    pub verification: SnapshotVerification,
+    /// Dependency vulnerability report, absent when the contract has never
+    /// been scanned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependency_scan: Option<Value>,
+    /// Deprecation state, absent when the contract is active and has never
+    /// been deprecated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecation: Option<Value>,
+    /// Successor chain, oldest first, built by following
+    /// `replacement_contract_id` transitively. Empty when nothing supersedes
+    /// this contract.
+    pub lineage: Vec<LineageLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotContract {
+    pub id: String,
+    pub contract_id: String,
+    pub name: String,
+    pub network: String,
+    pub wasm_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub publisher_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotVerification {
+    pub is_verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verified_at: Option<DateTime<Utc>>,
+}
+
+/// One hop in the successor chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineageLink {
+    pub contract_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotSignature {
+    pub algorithm: String,
+    /// Base64 ed25519 public key, so the bundle carries what is needed to
+    /// check it. See `verify_snapshot` on why that alone is not authenticity.
+    pub public_key: String,
+    /// Hex sha256 over the raw public key bytes. Pin this out of band.
+    pub key_fingerprint: String,
+    /// Base64 signature over the canonical payload bytes.
+    pub signature: String,
+    pub signed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SnapshotError {
+    UnsupportedSchema(String),
+    UnsupportedAlgorithm(String),
+    MalformedKey(String),
+    MalformedSignature(String),
+    /// The payload does not match the signature: tampered or re-serialized by
+    /// a different implementation.
+    SignatureMismatch,
+    /// Signature is valid but the key is not the one the caller expected.
+    UntrustedKey {
+        expected: String,
+        actual: String,
+    },
+    /// Snapshot is older than the caller's freshness tolerance.
+    Stale {
+        exported_at: DateTime<Utc>,
+        max_age_days: i64,
+    },
+    Serialization(String),
+}
+
+impl std::fmt::Display for SnapshotError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedSchema(v) => {
+                write!(f, "unsupported snapshot schema version: {v}")
+            }
+            Self::UnsupportedAlgorithm(a) => write!(f, "unsupported signature algorithm: {a}"),
+            Self::MalformedKey(e) => write!(f, "malformed public key: {e}"),
+            Self::MalformedSignature(e) => write!(f, "malformed signature: {e}"),
+            Self::SignatureMismatch => write!(
+                f,
+                "signature does not match payload: the snapshot has been modified"
+            ),
+            Self::UntrustedKey { expected, actual } => write!(
+                f,
+                "snapshot is signed by an untrusted key: expected fingerprint {expected}, found {actual}"
+            ),
+            Self::Stale {
+                exported_at,
+                max_age_days,
+            } => write!(
+                f,
+                "snapshot exported at {exported_at} is older than the {max_age_days} day freshness limit"
+            ),
+            Self::Serialization(e) => write!(f, "failed to serialize snapshot payload: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotError {}
+
+/// Recursively sort object keys so the same payload always yields the same
+/// bytes regardless of struct field order or map implementation.
+fn canonicalize(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut sorted = Map::new();
+            let mut entries: Vec<(String, Value)> = map.into_iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            for (k, v) in entries {
+                sorted.insert(k, canonicalize(v));
+            }
+            Value::Object(sorted)
+        }
+        Value::Array(items) => Value::Array(items.into_iter().map(canonicalize).collect()),
+        other => other,
+    }
+}
+
+/// The exact bytes the signature covers.
+pub fn canonical_payload_bytes(payload: &SnapshotPayload) -> Result<Vec<u8>, SnapshotError> {
+    let value =
+        serde_json::to_value(payload).map_err(|e| SnapshotError::Serialization(e.to_string()))?;
+    serde_json::to_vec(&canonicalize(value))
+        .map_err(|e| SnapshotError::Serialization(e.to_string()))
+}
+
+/// Hex sha256 over raw public key bytes.
+pub fn key_fingerprint(public_key: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(public_key);
+    hex::encode(hasher.finalize())
+}
+
+/// Sign a payload with the registry's key, producing a complete snapshot.
+pub fn sign_snapshot(
+    payload: SnapshotPayload,
+    signing_key: &SigningKey,
+) -> Result<ContractSnapshot, SnapshotError> {
+    let bytes = canonical_payload_bytes(&payload)?;
+    let signature = signing_key.sign(&bytes);
+    let verifying = signing_key.verifying_key();
+
+    Ok(ContractSnapshot {
+        payload,
+        signature: SnapshotSignature {
+            algorithm: SNAPSHOT_ALGORITHM.to_string(),
+            public_key: BASE64.encode(verifying.as_bytes()),
+            key_fingerprint: key_fingerprint(verifying.as_bytes()),
+            signature: BASE64.encode(signature.to_bytes()),
+            signed_at: Utc::now(),
+        },
+    })
+}
+
+/// Verify a snapshot's signature without contacting the registry.
+///
+/// A valid result means the payload has not been altered since it was signed by
+/// the holder of the embedded key. It does **not** by itself prove the registry
+/// produced it: anyone can re-sign a modified payload with their own key and
+/// embed that public key. Pass `expected_fingerprint` — obtained out of band
+/// from the registry's published key — to make this an authenticity check.
+pub fn verify_snapshot(
+    snapshot: &ContractSnapshot,
+    expected_fingerprint: Option<&str>,
+    max_age_days: Option<i64>,
+) -> Result<(), SnapshotError> {
+    if snapshot.payload.schema_version != SNAPSHOT_SCHEMA_VERSION {
+        return Err(SnapshotError::UnsupportedSchema(
+            snapshot.payload.schema_version.clone(),
+        ));
+    }
+
+    if snapshot.signature.algorithm != SNAPSHOT_ALGORITHM {
+        return Err(SnapshotError::UnsupportedAlgorithm(
+            snapshot.signature.algorithm.clone(),
+        ));
+    }
+
+    let key_bytes = BASE64
+        .decode(&snapshot.signature.public_key)
+        .map_err(|e| SnapshotError::MalformedKey(e.to_string()))?;
+    let key_array: [u8; 32] = key_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| SnapshotError::MalformedKey(format!("expected 32 bytes, got {}", key_bytes.len())))?;
+    let verifying = VerifyingKey::from_bytes(&key_array)
+        .map_err(|e| SnapshotError::MalformedKey(e.to_string()))?;
+
+    // Check the key before the signature: "signed by the wrong key" is a more
+    // useful diagnosis than "signature valid" for a bundle from an unknown source.
+    let actual_fingerprint = key_fingerprint(verifying.as_bytes());
+    if let Some(expected) = expected_fingerprint {
+        if !expected.eq_ignore_ascii_case(&actual_fingerprint) {
+            return Err(SnapshotError::UntrustedKey {
+                expected: expected.to_string(),
+                actual: actual_fingerprint,
+            });
+        }
+    }
+
+    let sig_bytes = BASE64
+        .decode(&snapshot.signature.signature)
+        .map_err(|e| SnapshotError::MalformedSignature(e.to_string()))?;
+    let sig_array: [u8; 64] = sig_bytes.as_slice().try_into().map_err(|_| {
+        SnapshotError::MalformedSignature(format!("expected 64 bytes, got {}", sig_bytes.len()))
+    })?;
+    let signature = Signature::from_bytes(&sig_array);
+
+    let bytes = canonical_payload_bytes(&snapshot.payload)?;
+    verifying
+        .verify(&bytes, &signature)
+        .map_err(|_| SnapshotError::SignatureMismatch)?;
+
+    if let Some(max_age) = max_age_days {
+        let age = Utc::now() - snapshot.payload.exported_at;
+        if age.num_days() > max_age {
+            return Err(SnapshotError::Stale {
+                exported_at: snapshot.payload.exported_at,
+                max_age_days: max_age,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn test_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn sample_payload() -> SnapshotPayload {
+        SnapshotPayload {
+            schema_version: SNAPSHOT_SCHEMA_VERSION.to_string(),
+            exported_at: Utc::now(),
+            registry_url: Some("https://registry.example".into()),
+            contract: SnapshotContract {
+                id: "11111111-1111-1111-1111-111111111111".into(),
+                contract_id: "CAAAA".into(),
+                name: "token".into(),
+                network: "testnet".into(),
+                wasm_hash: "deadbeef".into(),
+                description: Some("a token".into()),
+                category: None,
+                publisher_id: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            },
+            verification: SnapshotVerification {
+                is_verified: true,
+                status: Some("verified".into()),
+                verified_at: Some(Utc::now()),
+            },
+            dependency_scan: Some(serde_json::json!({"findings": [], "scanned": true})),
+            deprecation: None,
+            lineage: vec![LineageLink {
+                contract_id: "CBBBB".into(),
+                name: Some("token-v2".into()),
+                status: "active".into(),
+                deprecated_at: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn round_trip_export_then_verify() {
+        let key = test_key(1);
+        let snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+
+        // Through serialized form, as a file on disk would be.
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let parsed: ContractSnapshot = serde_json::from_str(&json).unwrap();
+
+        assert!(verify_snapshot(&parsed, None, None).is_ok());
+    }
+
+    #[test]
+    fn round_trip_survives_key_reordering() {
+        // A verifier that re-serializes with different key order must still
+        // reach the same canonical bytes.
+        let key = test_key(1);
+        let snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+
+        let value: Value = serde_json::to_value(&snapshot).unwrap();
+        let shuffled = serde_json::to_string(&value).unwrap();
+        let parsed: ContractSnapshot = serde_json::from_str(&shuffled).unwrap();
+
+        assert!(verify_snapshot(&parsed, None, None).is_ok());
+    }
+
+    #[test]
+    fn tampered_field_is_detected() {
+        let key = test_key(1);
+        let mut snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+
+        snapshot.payload.verification.is_verified = false;
+
+        assert_eq!(
+            verify_snapshot(&snapshot, None, None).unwrap_err(),
+            SnapshotError::SignatureMismatch
+        );
+    }
+
+    #[test]
+    fn tampered_nested_field_is_detected() {
+        let key = test_key(1);
+        let mut snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+
+        snapshot.payload.contract.wasm_hash = "cafebabe".into();
+
+        assert_eq!(
+            verify_snapshot(&snapshot, None, None).unwrap_err(),
+            SnapshotError::SignatureMismatch
+        );
+    }
+
+    #[test]
+    fn tampered_lineage_is_detected() {
+        let key = test_key(1);
+        let mut snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+
+        snapshot.payload.lineage.clear();
+
+        assert_eq!(
+            verify_snapshot(&snapshot, None, None).unwrap_err(),
+            SnapshotError::SignatureMismatch
+        );
+    }
+
+    #[test]
+    fn tampered_json_text_is_detected() {
+        // Editing the file directly, the way an auditor's adversary would.
+        let key = test_key(1);
+        let snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+        let json = serde_json::to_string(&snapshot).unwrap();
+
+        let edited = json.replace("\"is_verified\":true", "\"is_verified\":false");
+        assert_ne!(edited, json, "test fixture must actually change");
+
+        let parsed: ContractSnapshot = serde_json::from_str(&edited).unwrap();
+        assert_eq!(
+            verify_snapshot(&parsed, None, None).unwrap_err(),
+            SnapshotError::SignatureMismatch
+        );
+    }
+
+    #[test]
+    fn resigning_with_another_key_is_caught_by_fingerprint_pinning() {
+        // The attack the embedded public key alone does not stop: modify the
+        // payload, re-sign with your own key, ship the matching public key.
+        let registry = test_key(1);
+        let attacker = test_key(9);
+
+        let genuine = sign_snapshot(sample_payload(), &registry).unwrap();
+        let expected = genuine.signature.key_fingerprint.clone();
+
+        let mut forged_payload = sample_payload();
+        forged_payload.verification.is_verified = false;
+        let forged = sign_snapshot(forged_payload, &attacker).unwrap();
+
+        // Internally consistent, so an unpinned check passes.
+        assert!(verify_snapshot(&forged, None, None).is_ok());
+
+        // Pinning the registry's fingerprint rejects it.
+        match verify_snapshot(&forged, Some(&expected), None) {
+            Err(SnapshotError::UntrustedKey { .. }) => {}
+            other => panic!("expected UntrustedKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn correct_fingerprint_is_accepted() {
+        let key = test_key(1);
+        let snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+        let fp = snapshot.signature.key_fingerprint.clone();
+
+        assert!(verify_snapshot(&snapshot, Some(&fp), None).is_ok());
+        // Case-insensitive, since users paste fingerprints by hand.
+        assert!(verify_snapshot(&snapshot, Some(&fp.to_uppercase()), None).is_ok());
+    }
+
+    #[test]
+    fn stale_snapshot_is_rejected_within_tolerance() {
+        let key = test_key(1);
+        let mut payload = sample_payload();
+        payload.exported_at = Utc::now() - chrono::Duration::days(40);
+        let snapshot = sign_snapshot(payload, &key).unwrap();
+
+        assert!(verify_snapshot(&snapshot, None, Some(90)).is_ok());
+        match verify_snapshot(&snapshot, None, Some(30)) {
+            Err(SnapshotError::Stale { .. }) => {}
+            other => panic!("expected Stale, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn freshness_boundary_is_inclusive() {
+        // Exactly at the limit is still fresh; only strictly older is stale.
+        let key = test_key(1);
+        let mut payload = sample_payload();
+        payload.exported_at = Utc::now() - chrono::Duration::days(30);
+        let snapshot = sign_snapshot(payload, &key).unwrap();
+
+        assert!(verify_snapshot(&snapshot, None, Some(30)).is_ok());
+    }
+
+    #[test]
+    fn schema_version_mismatch_is_rejected() {
+        let key = test_key(1);
+        let mut snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+        snapshot.payload.schema_version = "999.0".into();
+
+        match verify_snapshot(&snapshot, None, None) {
+            Err(SnapshotError::UnsupportedSchema(v)) => assert_eq!(v, "999.0"),
+            other => panic!("expected UnsupportedSchema, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_signature_is_rejected_not_panicking() {
+        let key = test_key(1);
+        let mut snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+        snapshot.signature.signature = "not-base64!!".into();
+
+        match verify_snapshot(&snapshot, None, None) {
+            Err(SnapshotError::MalformedSignature(_)) => {}
+            other => panic!("expected MalformedSignature, got {other:?}"),
+        }
+
+        snapshot.signature.signature = BASE64.encode([0u8; 10]);
+        match verify_snapshot(&snapshot, None, None) {
+            Err(SnapshotError::MalformedSignature(_)) => {}
+            other => panic!("expected MalformedSignature, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_public_key_is_rejected_not_panicking() {
+        let key = test_key(1);
+        let mut snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+        snapshot.signature.public_key = BASE64.encode([0u8; 5]);
+
+        match verify_snapshot(&snapshot, None, None) {
+            Err(SnapshotError::MalformedKey(_)) => {}
+            other => panic!("expected MalformedKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn canonical_bytes_have_sorted_keys() {
+        let bytes = canonical_payload_bytes(&sample_payload()).unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+
+        let contract = text.find("\"contract\"").unwrap();
+        let exported = text.find("\"exported_at\"").unwrap();
+        let schema = text.find("\"schema_version\"").unwrap();
+        assert!(contract < exported && exported < schema, "keys must be sorted: {text}");
+    }
+}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3277,6 +3277,7 @@ dependencies = [
  "anyhow",
  "base64",
  "chrono",
+ "ed25519-dalek",
  "hex",
  "once_cell",
  "opentelemetry",

--- a/cli/src/contract_snapshot.rs
+++ b/cli/src/contract_snapshot.rs
@@ -1,0 +1,343 @@
+//! contract_snapshot.rs — `soroban-registry contract snapshot` / `verify-snapshot` (#1116)
+//!
+//! Produces a portable, signed record of a contract's lifecycle state — metadata,
+//! verification status, dependency scan findings, deprecation state and successor
+//! lineage — as a single JSON file, and verifies such a file offline.
+//!
+//! Verification performs no network calls, so an exported snapshot can be audited
+//! in an air-gapped environment. The document shape, canonical form and signature
+//! checks come from `shared::snapshot`, so the CLI validates exactly the bytes the
+//! registry signed rather than a reimplementation of them.
+
+use anyhow::{bail, Context, Result};
+use colored::Colorize;
+use serde::Deserialize;
+use shared::snapshot::{verify_snapshot, ContractSnapshot, SnapshotError};
+use std::path::Path;
+
+use crate::net::RequestBuilderExt;
+
+/// Registry signing identity, as published by `GET /api/registry/signing-key`.
+#[derive(Debug, Deserialize)]
+struct RegistrySigningKey {
+    key_fingerprint: String,
+}
+
+// ── export ───────────────────────────────────────────────────────────────────
+
+/// `soroban-registry contract snapshot <ID> --output <FILE>`
+pub async fn run_export(
+    api_url: &str,
+    contract_id: &str,
+    output: &str,
+    json_output: bool,
+) -> Result<()> {
+    let url = format!(
+        "{}/api/contracts/{}/snapshot",
+        api_url.trim_end_matches('/'),
+        contract_id
+    );
+
+    let response = crate::net::client()
+        .get(&url)
+        .send_with_retry()
+        .await
+        .with_context(|| format!("failed to reach the registry at {url}"))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .context("failed to read the registry response body")?;
+
+    if !status.is_success() {
+        if status.as_u16() == 503 {
+            bail!(
+                "the registry cannot sign snapshots: REGISTRY_SIGNING_KEY is not configured \
+                 on the server ({status})"
+            );
+        }
+        bail!("registry returned {status}: {body}");
+    }
+
+    // Parse before writing so a malformed response is not persisted as if it
+    // were a valid snapshot.
+    let snapshot: ContractSnapshot = serde_json::from_str(&body)
+        .context("registry returned a response that is not a valid contract snapshot")?;
+
+    // Confirm the registry signed what it sent us. Catches a misconfigured or
+    // truncated response at export time rather than at audit time.
+    verify_snapshot(&snapshot, None, None)
+        .map_err(|e| anyhow::anyhow!("the registry returned a snapshot that fails its own signature check: {e}"))?;
+
+    let pretty = serde_json::to_string_pretty(&snapshot)
+        .context("failed to serialize the snapshot for writing")?;
+    std::fs::write(output, pretty.as_bytes())
+        .with_context(|| format!("failed to write snapshot to {output}"))?;
+
+    if json_output {
+        println!(
+            "{}",
+            serde_json::json!({
+                "output": output,
+                "contract_id": snapshot.payload.contract.contract_id,
+                "exported_at": snapshot.payload.exported_at,
+                "key_fingerprint": snapshot.signature.key_fingerprint,
+                "lineage_depth": snapshot.payload.lineage.len(),
+            })
+        );
+    } else {
+        println!("{} {}", "Snapshot written to".green(), output.bold());
+        println!("  contract:    {}", snapshot.payload.contract.contract_id);
+        println!("  name:        {}", snapshot.payload.contract.name);
+        println!("  network:     {}", snapshot.payload.contract.network);
+        println!("  exported at: {}", snapshot.payload.exported_at);
+        println!("  signed by:   {}", snapshot.signature.key_fingerprint);
+        println!();
+        println!(
+            "{}",
+            "Pin this fingerprint out of band. Verifying without --expect-key only proves the"
+                .dimmed()
+        );
+        println!(
+            "{}",
+            "bundle is self-consistent, not that this registry produced it.".dimmed()
+        );
+    }
+
+    Ok(())
+}
+
+// ── verify ───────────────────────────────────────────────────────────────────
+
+/// `soroban-registry contract verify-snapshot <FILE>`
+///
+/// Offline by default. `--fetch-key` is the one path that touches the network,
+/// and is opt-in precisely because the point of the command is to work without it.
+pub async fn run_verify(
+    api_url: &str,
+    file: &str,
+    expect_key: Option<&str>,
+    max_age_days: Option<i64>,
+    fetch_key: bool,
+    json_output: bool,
+) -> Result<()> {
+    let path = Path::new(file);
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read snapshot file {file}"))?;
+
+    let snapshot: ContractSnapshot = serde_json::from_str(&raw)
+        .with_context(|| format!("{file} is not a valid contract snapshot document"))?;
+
+    // Resolve the fingerprint to pin against, in order of trust.
+    let expected: Option<String> = match (expect_key, fetch_key) {
+        (Some(fp), _) => Some(fp.trim().to_string()),
+        (None, true) => Some(fetch_registry_fingerprint(api_url).await?),
+        (None, false) => None,
+    };
+
+    let result = verify_snapshot(&snapshot, expected.as_deref(), max_age_days);
+
+    match result {
+        Ok(()) => {
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "valid": true,
+                        "pinned": expected.is_some(),
+                        "contract_id": snapshot.payload.contract.contract_id,
+                        "exported_at": snapshot.payload.exported_at,
+                        "key_fingerprint": snapshot.signature.key_fingerprint,
+                    })
+                );
+            } else {
+                println!("{}", "Snapshot signature is valid.".green().bold());
+                println!("  contract:    {}", snapshot.payload.contract.contract_id);
+                println!("  name:        {}", snapshot.payload.contract.name);
+                println!("  network:     {}", snapshot.payload.contract.network);
+                println!("  verified:    {}", snapshot.payload.verification.is_verified);
+                println!("  exported at: {}", snapshot.payload.exported_at);
+                println!("  signed by:   {}", snapshot.signature.key_fingerprint);
+
+                if expected.is_some() {
+                    println!("  key:         {}", "pinned and matched".green());
+                } else {
+                    println!(
+                        "  key:         {}",
+                        "NOT pinned - authenticity unproven".yellow()
+                    );
+                    println!();
+                    println!(
+                        "{}",
+                        "Re-run with --expect-key <fingerprint> to confirm this snapshot came from"
+                            .dimmed()
+                    );
+                    println!("{}", "the registry you trust.".dimmed());
+                }
+            }
+            Ok(())
+        }
+        Err(err) => {
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "valid": false,
+                        "reason": err.to_string(),
+                        "kind": error_kind(&err),
+                    })
+                );
+            } else {
+                println!("{} {}", "Snapshot verification FAILED:".red().bold(), err);
+            }
+            // Non-zero exit so this is usable as a CI/compliance gate.
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Stable machine-readable discriminant for `--json` consumers.
+fn error_kind(err: &SnapshotError) -> &'static str {
+    match err {
+        SnapshotError::UnsupportedSchema(_) => "unsupported_schema",
+        SnapshotError::UnsupportedAlgorithm(_) => "unsupported_algorithm",
+        SnapshotError::MalformedKey(_) => "malformed_key",
+        SnapshotError::MalformedSignature(_) => "malformed_signature",
+        SnapshotError::SignatureMismatch => "signature_mismatch",
+        SnapshotError::UntrustedKey { .. } => "untrusted_key",
+        SnapshotError::Stale { .. } => "stale",
+        SnapshotError::Serialization(_) => "serialization",
+    }
+}
+
+async fn fetch_registry_fingerprint(api_url: &str) -> Result<String> {
+    let url = format!("{}/api/registry/signing-key", api_url.trim_end_matches('/'));
+
+    let response = crate::net::client()
+        .get(&url)
+        .send_with_retry()
+        .await
+        .with_context(|| format!("failed to fetch the registry signing key from {url}"))?;
+
+    if !response.status().is_success() {
+        bail!(
+            "registry returned {} when asked for its signing key",
+            response.status()
+        );
+    }
+
+    let key: RegistrySigningKey = response
+        .json()
+        .await
+        .context("registry signing-key response was not in the expected form")?;
+
+    Ok(key.key_fingerprint)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::snapshot::{
+        sign_snapshot, LineageLink, SnapshotContract, SnapshotPayload, SnapshotVerification,
+        SNAPSHOT_SCHEMA_VERSION,
+    };
+
+    use chrono::Utc;
+    use ed25519_dalek::SigningKey;
+
+    fn payload() -> SnapshotPayload {
+        SnapshotPayload {
+            schema_version: SNAPSHOT_SCHEMA_VERSION.to_string(),
+            exported_at: Utc::now(),
+            registry_url: None,
+            contract: SnapshotContract {
+                id: "11111111-1111-1111-1111-111111111111".into(),
+                contract_id: "CTEST".into(),
+                name: "token".into(),
+                network: "testnet".into(),
+                wasm_hash: "deadbeef".into(),
+                description: None,
+                category: None,
+                publisher_id: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            },
+            verification: SnapshotVerification {
+                is_verified: true,
+                status: Some("verified".into()),
+                verified_at: Some(Utc::now()),
+            },
+            dependency_scan: None,
+            deprecation: None,
+            lineage: vec![LineageLink {
+                contract_id: "CNEXT".into(),
+                name: None,
+                status: "active".into(),
+                deprecated_at: None,
+            }],
+        }
+    }
+
+    /// Round-trip through an actual file, the way the two commands are used.
+    #[test]
+    fn export_file_round_trips_through_verify() {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let snapshot = sign_snapshot(payload(), &key).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.json");
+        std::fs::write(&path, serde_json::to_string_pretty(&snapshot).unwrap()).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let parsed: ContractSnapshot = serde_json::from_str(&raw).unwrap();
+
+        assert!(verify_snapshot(&parsed, None, None).is_ok());
+        assert!(
+            verify_snapshot(&parsed, Some(&parsed.signature.key_fingerprint), None).is_ok()
+        );
+    }
+
+    /// Editing the file on disk must be caught.
+    #[test]
+    fn tampered_file_fails_verification() {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let snapshot = sign_snapshot(payload(), &key).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.json");
+        std::fs::write(&path, serde_json::to_string_pretty(&snapshot).unwrap()).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let tampered = raw.replace("\"name\": \"token\"", "\"name\": \"not-token\"");
+        assert_ne!(tampered, raw, "fixture must actually change the document");
+        std::fs::write(&path, &tampered).unwrap();
+
+        let reread = std::fs::read_to_string(&path).unwrap();
+        let parsed: ContractSnapshot = serde_json::from_str(&reread).unwrap();
+
+        assert_eq!(
+            verify_snapshot(&parsed, None, None).unwrap_err(),
+            SnapshotError::SignatureMismatch
+        );
+    }
+
+    #[test]
+    fn error_kinds_are_stable() {
+        assert_eq!(error_kind(&SnapshotError::SignatureMismatch), "signature_mismatch");
+        assert_eq!(
+            error_kind(&SnapshotError::UntrustedKey {
+                expected: "a".into(),
+                actual: "b".into()
+            }),
+            "untrusted_key"
+        );
+        assert_eq!(
+            error_kind(&SnapshotError::Stale {
+                exported_at: Utc::now(),
+                max_age_days: 30
+            }),
+            "stale"
+        );
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,6 +28,7 @@ mod contract_audit;
 mod contract_dependency;
 mod contract_deploy;
 mod contract_deprecate;
+mod contract_snapshot;
 mod contract_highlight;
 mod contract_interaction;
 mod contract_register;
@@ -1809,6 +1810,55 @@ pub enum KeysCommands {
 /// Sub-commands for the `contract` group (#522)
 #[derive(Debug, Subcommand)]
 pub enum ContractCommands {
+
+    /// Export a signed, offline-verifiable snapshot of a contract (#1116)
+    ///
+    /// Captures metadata, verification status, dependency scan findings,
+    /// deprecation state and successor lineage as of now, signed by the
+    /// registry so it can be audited without a live API.
+    ///
+    /// Usage: soroban-registry contract snapshot <ID> --output <FILE>
+    Snapshot {
+        /// Contract UUID to snapshot
+        id: String,
+
+        /// File to write the signed snapshot to
+        #[arg(long, short = 'o')]
+        output: String,
+
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Verify a previously exported contract snapshot (#1116)
+    ///
+    /// Runs entirely offline unless --fetch-key is passed. Exits non-zero when
+    /// verification fails, so it can gate a compliance pipeline.
+    ///
+    /// Usage: soroban-registry contract verify-snapshot <FILE> [--expect-key <FP>]
+    VerifySnapshot {
+        /// Path to the snapshot file
+        file: String,
+
+        /// Registry key fingerprint to pin against. Without it, a valid result
+        /// proves only that the bundle is self-consistent.
+        #[arg(long)]
+        expect_key: Option<String>,
+
+        /// Fail if the snapshot is older than this many days
+        #[arg(long)]
+        max_age_days: Option<i64>,
+
+        /// Fetch the expected fingerprint from the registry instead of pinning
+        /// it locally. Requires network access.
+        #[arg(long)]
+        fetch_key: bool,
+
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Assess security and operational risks for a contract (#837)
     ///
@@ -4422,6 +4472,30 @@ pub async fn dispatch_command(
                 let fmt = if json { "json" } else { &format };
                 contract_audit::run(&cli.api_url, &lockfile, fix, init, &contracts, fmt).await?;
             }
+            ContractCommands::Snapshot { id, output, json } => {
+                log::debug!("Command: contract snapshot | id={} output={}", id, output);
+                contract_snapshot::run_export(&cli.api_url, &id, &output, json).await?;
+            }
+
+            ContractCommands::VerifySnapshot {
+                file,
+                expect_key,
+                max_age_days,
+                fetch_key,
+                json,
+            } => {
+                log::debug!("Command: contract verify-snapshot | file={}", file);
+                contract_snapshot::run_verify(
+                    &cli.api_url,
+                    &file,
+                    expect_key.as_deref(),
+                    max_age_days,
+                    fetch_key,
+                    json,
+                )
+                .await?;
+            }
+
             ContractCommands::Deprecate {
                 address,
                 reason,


### PR DESCRIPTION
Closes #1116

## What

Adds a portable, verifiable record of a contract's state for compliance, archival and air-gapped review — metadata, verification status, dependency scan findings, deprecation state and successor lineage, as a single JSON document signed by the registry.

```
soroban-registry contract snapshot <ID> --output <FILE>
soroban-registry contract verify-snapshot <FILE> [--expect-key <FINGERPRINT>]
```

Server side: `GET /api/contracts/{id}/snapshot` assembles and signs, `GET /api/registry/signing-key` publishes the public half.

## Naming

`contract export` already exists as the bulk registry backup, and its first positional is an output file — `contract export out.json` today means "write to out.json". Adding `<id>` there would silently change what existing invocations mean, so this is `contract snapshot`.

## Design decisions worth reviewing

**One implementation of the signed bytes.** The document shape, canonical form and verification live in `shared::snapshot`, used by both the registry and the CLI. Two implementations of a canonical form drift, and drift here means valid bundles that fail to verify.

**Explicit key sorting.** The canonical form sorts object keys itself rather than relying on `serde_json::Value`'s map type, whose ordering flips with the `preserve_order` feature that any crate in the dependency graph could enable. A test asserts sorted output and another verifies a re-serialized document still checks out.

**A signature alone does not prove origin.** Embedding the public key makes a bundle self-describing, not self-authenticating: an attacker can alter the payload, re-sign with their own key, embed that key, and verification passes. So `--expect-key` pins the registry's fingerprint, the registry publishes it, and an unpinned check prints `NOT pinned - authenticity unproven`. `resigning_with_another_key_is_caught_by_fingerprint_pinning` builds that exact forgery and confirms pinning rejects what an unpinned check accepts.

**Key read on demand, not held in `AppState`.** A deployment that never exports snapshots needs no key: the two endpoints return 503 and nothing else is affected, instead of the process refusing to boot.

**Lineage traversal is bounded** by depth and a visited set, so a cycle in `replacement_contract_id` cannot hang a request. **The scan section reports recorded findings only** and never triggers a fresh scan — a snapshot records state, it must not mutate it.

## Verification

14 unit tests in `shared` covering round-trip, four tampering vectors, key reordering, malformed key and signature, schema mismatch and freshness bounds — all passing.

Exercised end to end against a live registry with real data, then repeated with the registry process killed:

| Case | Result |
|---|---|
| Export via CLI | signed JSON written |
| Verify offline, key pinned | valid, exit 0 |
| Verify with **registry shut down** | valid, exit 0 |
| Tampered payload | `signature does not match payload`, exit 1 |
| Wrong pinned fingerprint | `signed by an untrusted key`, exit 1 |
| `--json` | stable `valid` / `kind` fields for CI gating |

Verification failures exit non-zero so the command can gate a compliance pipeline.

## Reviewer notes

- **The CLI cannot currently be built on `main`** — 4 pre-existing errors unrelated to this change, filed as #1133. The `publisher doctor` dispatch arm from #1126 references a module, enum and variant that were never merged, and `contract_register.rs` is missing a `PublishRequest` field. I verified this branch by repairing those locally, then reverted the repair so this PR stays scoped; the CLI changes here compile once #1133 lands. The backend half builds and runs on `main` today.
- `cargo test` in `cli/` is separately broken on `main` (`tests/output_format_tests.rs`, `src/commands.rs`), also covered in #1133, so the CLI-level tests added here cannot execute yet. Their coverage is duplicated by the `shared` tests, which do run.
- Snapshots are unauthenticated to read, matching the other public contract endpoints. They expose only data those endpoints already serve.
- Rotating `REGISTRY_SIGNING_KEY` does not invalidate previously exported snapshots, but auditors pinning the old fingerprint will need the new one; `.env.example` says so.