### PR TITLE
Backend: Add stable contract interface fingerprints for runtime compatibility checks

### DIFF
--- a/backend/shared/src/contract_spec.rs
+++ b/backend/shared/src/contract_spec.rs
@@ -1,0 +1,823 @@
+//! Decoder for the Soroban `contractspecv0` custom WASM section.
+//!
+//! The section is a concatenation of XDR-encoded `SCSpecEntry` values (no
+//! outer length prefix — entries are read back to back until the byte slice
+//! is exhausted). This module implements a minimal, dependency-free XDR
+//! reader for exactly the subset of the Soroban contract-spec XDR schema
+//! needed to enumerate functions, user-defined types, events and errors:
+//! this crate intentionally avoids pulling in `stellar-xdr` so that
+//! `backend/shared` stays usable from every workspace member without adding
+//! a new dependency.
+//!
+//! Reference: `Stellar-contract-spec.x` (`SCSpecEntry`, `SCSpecTypeDef`).
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A single decoded entry from a `contractspecv0` section.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ScSpecEntry {
+    FunctionV0(ScSpecFunctionV0),
+    UdtStructV0(ScSpecUdtStructV0),
+    UdtUnionV0(ScSpecUdtUnionV0),
+    UdtEnumV0(ScSpecUdtEnumV0),
+    UdtErrorEnumV0(ScSpecUdtErrorEnumV0),
+    EventV0(ScSpecEventV0),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecFunctionV0 {
+    pub doc: String,
+    pub name: String,
+    pub inputs: Vec<ScSpecFunctionInputV0>,
+    pub outputs: Vec<ScSpecTypeDef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecFunctionInputV0 {
+    pub doc: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_def: ScSpecTypeDef,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecUdtStructFieldV0 {
+    pub doc: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_def: ScSpecTypeDef,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecUdtStructV0 {
+    pub doc: String,
+    pub lib: String,
+    pub name: String,
+    pub fields: Vec<ScSpecUdtStructFieldV0>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ScSpecUdtUnionCaseV0 {
+    Void { doc: String, name: String },
+    Tuple {
+        doc: String,
+        name: String,
+        types: Vec<ScSpecTypeDef>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecUdtUnionV0 {
+    pub doc: String,
+    pub lib: String,
+    pub name: String,
+    pub cases: Vec<ScSpecUdtUnionCaseV0>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecUdtEnumCaseV0 {
+    pub doc: String,
+    pub name: String,
+    pub value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecUdtEnumV0 {
+    pub doc: String,
+    pub lib: String,
+    pub name: String,
+    pub cases: Vec<ScSpecUdtEnumCaseV0>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecUdtErrorEnumCaseV0 {
+    pub doc: String,
+    pub name: String,
+    pub value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecUdtErrorEnumV0 {
+    pub doc: String,
+    pub lib: String,
+    pub name: String,
+    pub cases: Vec<ScSpecUdtErrorEnumCaseV0>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum ScSpecEventParamLocationV0 {
+    Data,
+    TopicList,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecEventParamV0 {
+    pub doc: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_def: ScSpecTypeDef,
+    pub location: ScSpecEventParamLocationV0,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum ScSpecEventDataFormat {
+    SingleValue,
+    Vec,
+    Map,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScSpecEventV0 {
+    pub doc: String,
+    pub lib: String,
+    pub name: String,
+    pub prefix_topics: Vec<String>,
+    pub params: Vec<ScSpecEventParamV0>,
+    pub data_format: ScSpecEventDataFormat,
+}
+
+/// A structural Soroban contract-spec type reference.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ScSpecTypeDef {
+    Val,
+    Bool,
+    Void,
+    Error,
+    U32,
+    I32,
+    U64,
+    I64,
+    Timepoint,
+    Duration,
+    U128,
+    I128,
+    U256,
+    I256,
+    Bytes,
+    String,
+    Symbol,
+    Address,
+    MuxedAddress,
+    Option(Box<ScSpecTypeDef>),
+    Result {
+        ok: Box<ScSpecTypeDef>,
+        error: Box<ScSpecTypeDef>,
+    },
+    Vec(Box<ScSpecTypeDef>),
+    Map {
+        key: Box<ScSpecTypeDef>,
+        value: Box<ScSpecTypeDef>,
+    },
+    Tuple(Vec<ScSpecTypeDef>),
+    BytesN(u32),
+    Udt(String),
+}
+
+impl fmt::Display for ScSpecTypeDef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ScSpecTypeDef::Val => write!(f, "Val"),
+            ScSpecTypeDef::Bool => write!(f, "bool"),
+            ScSpecTypeDef::Void => write!(f, "void"),
+            ScSpecTypeDef::Error => write!(f, "error"),
+            ScSpecTypeDef::U32 => write!(f, "u32"),
+            ScSpecTypeDef::I32 => write!(f, "i32"),
+            ScSpecTypeDef::U64 => write!(f, "u64"),
+            ScSpecTypeDef::I64 => write!(f, "i64"),
+            ScSpecTypeDef::Timepoint => write!(f, "timepoint"),
+            ScSpecTypeDef::Duration => write!(f, "duration"),
+            ScSpecTypeDef::U128 => write!(f, "u128"),
+            ScSpecTypeDef::I128 => write!(f, "i128"),
+            ScSpecTypeDef::U256 => write!(f, "u256"),
+            ScSpecTypeDef::I256 => write!(f, "i256"),
+            ScSpecTypeDef::Bytes => write!(f, "bytes"),
+            ScSpecTypeDef::String => write!(f, "string"),
+            ScSpecTypeDef::Symbol => write!(f, "symbol"),
+            ScSpecTypeDef::Address => write!(f, "address"),
+            ScSpecTypeDef::MuxedAddress => write!(f, "muxed_address"),
+            ScSpecTypeDef::Option(inner) => write!(f, "option<{}>", inner),
+            ScSpecTypeDef::Result { ok, error } => write!(f, "result<{}, {}>", ok, error),
+            ScSpecTypeDef::Vec(inner) => write!(f, "vec<{}>", inner),
+            ScSpecTypeDef::Map { key, value } => write!(f, "map<{}, {}>", key, value),
+            ScSpecTypeDef::Tuple(items) => {
+                write!(f, "tuple<")?;
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", item)?;
+                }
+                write!(f, ">")
+            }
+            ScSpecTypeDef::BytesN(n) => write!(f, "bytes{}", n),
+            ScSpecTypeDef::Udt(name) => write!(f, "{}", name),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SpecParseError {
+    UnexpectedEof { at: usize },
+    InvalidDiscriminant { at: usize, value: i32 },
+    InvalidUtf8 { at: usize },
+    TrailingBytes { at: usize },
+}
+
+impl fmt::Display for SpecParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SpecParseError::UnexpectedEof { at } => {
+                write!(f, "unexpected end of contractspecv0 section at byte {at}")
+            }
+            SpecParseError::InvalidDiscriminant { at, value } => write!(
+                f,
+                "unrecognized XDR discriminant {value} at byte {at}"
+            ),
+            SpecParseError::InvalidUtf8 { at } => {
+                write!(f, "invalid UTF-8 string at byte {at}")
+            }
+            SpecParseError::TrailingBytes { at } => {
+                write!(f, "trailing unparsed bytes starting at {at}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SpecParseError {}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len() - self.pos
+    }
+
+    fn read_u32(&mut self) -> Result<u32, SpecParseError> {
+        if self.remaining() < 4 {
+            return Err(SpecParseError::UnexpectedEof { at: self.pos });
+        }
+        let v = u32::from_be_bytes(self.bytes[self.pos..self.pos + 4].try_into().unwrap());
+        self.pos += 4;
+        Ok(v)
+    }
+
+    fn read_i32(&mut self) -> Result<i32, SpecParseError> {
+        Ok(self.read_u32()? as i32)
+    }
+
+    fn read_bool(&mut self) -> Result<bool, SpecParseError> {
+        Ok(self.read_u32()? != 0)
+    }
+
+    /// XDR variable-length opaque/string: u32 length, bytes, zero-padded to a
+    /// 4-byte boundary.
+    fn read_var_bytes(&mut self) -> Result<&'a [u8], SpecParseError> {
+        let len = self.read_u32()? as usize;
+        if self.remaining() < len {
+            return Err(SpecParseError::UnexpectedEof { at: self.pos });
+        }
+        let start = self.pos;
+        let data = &self.bytes[start..start + len];
+        self.pos += len;
+        let padding = (4 - (len % 4)) % 4;
+        if self.remaining() < padding {
+            return Err(SpecParseError::UnexpectedEof { at: self.pos });
+        }
+        self.pos += padding;
+        Ok(data)
+    }
+
+    fn read_string(&mut self) -> Result<String, SpecParseError> {
+        let at = self.pos;
+        let bytes = self.read_var_bytes()?;
+        String::from_utf8(bytes.to_vec()).map_err(|_| SpecParseError::InvalidUtf8 { at })
+    }
+
+    fn read_vec<T>(
+        &mut self,
+        mut read_item: impl FnMut(&mut Self) -> Result<T, SpecParseError>,
+    ) -> Result<Vec<T>, SpecParseError> {
+        let count = self.read_u32()? as usize;
+        let mut items = Vec::with_capacity(count.min(1024));
+        for _ in 0..count {
+            items.push(read_item(self)?);
+        }
+        Ok(items)
+    }
+
+    fn read_type_def(&mut self) -> Result<ScSpecTypeDef, SpecParseError> {
+        let at = self.pos;
+        let disc = self.read_i32()?;
+        let ty = match disc {
+            0 => ScSpecTypeDef::Val,
+            1 => ScSpecTypeDef::Bool,
+            2 => ScSpecTypeDef::Void,
+            3 => ScSpecTypeDef::Error,
+            4 => ScSpecTypeDef::U32,
+            5 => ScSpecTypeDef::I32,
+            6 => ScSpecTypeDef::U64,
+            7 => ScSpecTypeDef::I64,
+            8 => ScSpecTypeDef::Timepoint,
+            9 => ScSpecTypeDef::Duration,
+            10 => ScSpecTypeDef::U128,
+            11 => ScSpecTypeDef::I128,
+            12 => ScSpecTypeDef::U256,
+            13 => ScSpecTypeDef::I256,
+            14 => ScSpecTypeDef::Bytes,
+            16 => ScSpecTypeDef::String,
+            17 => ScSpecTypeDef::Symbol,
+            19 => ScSpecTypeDef::Address,
+            20 => ScSpecTypeDef::MuxedAddress,
+            1000 => ScSpecTypeDef::Option(Box::new(self.read_type_def()?)),
+            1001 => {
+                let ok = Box::new(self.read_type_def()?);
+                let error = Box::new(self.read_type_def()?);
+                ScSpecTypeDef::Result { ok, error }
+            }
+            1002 => ScSpecTypeDef::Vec(Box::new(self.read_type_def()?)),
+            1004 => {
+                let key = Box::new(self.read_type_def()?);
+                let value = Box::new(self.read_type_def()?);
+                ScSpecTypeDef::Map { key, value }
+            }
+            1005 => {
+                let items = self.read_vec(|c| c.read_type_def())?;
+                ScSpecTypeDef::Tuple(items)
+            }
+            1006 => ScSpecTypeDef::BytesN(self.read_u32()?),
+            2000 => ScSpecTypeDef::Udt(self.read_string()?),
+            other => {
+                return Err(SpecParseError::InvalidDiscriminant { at, value: other });
+            }
+        };
+        Ok(ty)
+    }
+
+    fn read_function_input(&mut self) -> Result<ScSpecFunctionInputV0, SpecParseError> {
+        let doc = self.read_string()?;
+        let name = self.read_string()?;
+        let type_def = self.read_type_def()?;
+        Ok(ScSpecFunctionInputV0 {
+            doc,
+            name,
+            type_def,
+        })
+    }
+
+    fn read_function(&mut self) -> Result<ScSpecFunctionV0, SpecParseError> {
+        let doc = self.read_string()?;
+        let name = self.read_string()?;
+        let inputs = self.read_vec(|c| c.read_function_input())?;
+        let outputs = self.read_vec(|c| c.read_type_def())?;
+        Ok(ScSpecFunctionV0 {
+            doc,
+            name,
+            inputs,
+            outputs,
+        })
+    }
+
+    fn read_struct(&mut self) -> Result<ScSpecUdtStructV0, SpecParseError> {
+        let doc = self.read_string()?;
+        let lib = self.read_string()?;
+        let name = self.read_string()?;
+        let fields = self.read_vec(|c| {
+            let doc = c.read_string()?;
+            let name = c.read_string()?;
+            let type_def = c.read_type_def()?;
+            Ok(ScSpecUdtStructFieldV0 {
+                doc,
+                name,
+                type_def,
+            })
+        })?;
+        Ok(ScSpecUdtStructV0 {
+            doc,
+            lib,
+            name,
+            fields,
+        })
+    }
+
+    fn read_union(&mut self) -> Result<ScSpecUdtUnionV0, SpecParseError> {
+        let doc = self.read_string()?;
+        let lib = self.read_string()?;
+        let name = self.read_string()?;
+        let cases = self.read_vec(|c| {
+            let at = c.pos;
+            let kind = c.read_i32()?;
+            match kind {
+                0 => {
+                    let doc = c.read_string()?;
+                    let name = c.read_string()?;
+                    Ok(ScSpecUdtUnionCaseV0::Void { doc, name })
+                }
+                1 => {
+                    let doc = c.read_string()?;
+                    let name = c.read_string()?;
+                    let types = c.read_vec(|c2| c2.read_type_def())?;
+                    Ok(ScSpecUdtUnionCaseV0::Tuple { doc, name, types })
+                }
+                other => Err(SpecParseError::InvalidDiscriminant { at, value: other }),
+            }
+        })?;
+        Ok(ScSpecUdtUnionV0 {
+            doc,
+            lib,
+            name,
+            cases,
+        })
+    }
+
+    fn read_enum(&mut self) -> Result<ScSpecUdtEnumV0, SpecParseError> {
+        let doc = self.read_string()?;
+        let lib = self.read_string()?;
+        let name = self.read_string()?;
+        let cases = self.read_vec(|c| {
+            let doc = c.read_string()?;
+            let name = c.read_string()?;
+            let value = c.read_u32()?;
+            Ok(ScSpecUdtEnumCaseV0 { doc, name, value })
+        })?;
+        Ok(ScSpecUdtEnumV0 {
+            doc,
+            lib,
+            name,
+            cases,
+        })
+    }
+
+    fn read_error_enum(&mut self) -> Result<ScSpecUdtErrorEnumV0, SpecParseError> {
+        let doc = self.read_string()?;
+        let lib = self.read_string()?;
+        let name = self.read_string()?;
+        let cases = self.read_vec(|c| {
+            let doc = c.read_string()?;
+            let name = c.read_string()?;
+            let value = c.read_u32()?;
+            Ok(ScSpecUdtErrorEnumCaseV0 { doc, name, value })
+        })?;
+        Ok(ScSpecUdtErrorEnumV0 {
+            doc,
+            lib,
+            name,
+            cases,
+        })
+    }
+
+    fn read_event(&mut self) -> Result<ScSpecEventV0, SpecParseError> {
+        let doc = self.read_string()?;
+        let lib = self.read_string()?;
+        let name = self.read_string()?;
+        let prefix_topics = self.read_vec(|c| c.read_string())?;
+        let params = self.read_vec(|c| {
+            let doc = c.read_string()?;
+            let name = c.read_string()?;
+            let type_def = c.read_type_def()?;
+            let at = c.pos;
+            let location = match c.read_i32()? {
+                0 => ScSpecEventParamLocationV0::Data,
+                1 => ScSpecEventParamLocationV0::TopicList,
+                other => return Err(SpecParseError::InvalidDiscriminant { at, value: other }),
+            };
+            Ok(ScSpecEventParamV0 {
+                doc,
+                name,
+                type_def,
+                location,
+            })
+        })?;
+        let at = self.pos;
+        let data_format = match self.read_i32()? {
+            0 => ScSpecEventDataFormat::SingleValue,
+            1 => ScSpecEventDataFormat::Vec,
+            2 => ScSpecEventDataFormat::Map,
+            other => return Err(SpecParseError::InvalidDiscriminant { at, value: other }),
+        };
+        Ok(ScSpecEventV0 {
+            doc,
+            lib,
+            name,
+            prefix_topics,
+            params,
+            data_format,
+        })
+    }
+
+    fn read_entry(&mut self) -> Result<ScSpecEntry, SpecParseError> {
+        let at = self.pos;
+        let kind = self.read_i32()?;
+        match kind {
+            0 => Ok(ScSpecEntry::FunctionV0(self.read_function()?)),
+            1 => Ok(ScSpecEntry::UdtStructV0(self.read_struct()?)),
+            2 => Ok(ScSpecEntry::UdtUnionV0(self.read_union()?)),
+            3 => Ok(ScSpecEntry::UdtEnumV0(self.read_enum()?)),
+            4 => Ok(ScSpecEntry::UdtErrorEnumV0(self.read_error_enum()?)),
+            5 => Ok(ScSpecEntry::EventV0(self.read_event()?)),
+            other => Err(SpecParseError::InvalidDiscriminant { at, value: other }),
+        }
+    }
+}
+
+// `read_bool` is part of the XDR primitive set this module supports even
+// though no currently-decoded entry uses it; keep it exercised so it does
+// not bit-rot silently.
+#[allow(dead_code)]
+fn _assert_read_bool_used(c: &mut Cursor) -> Result<bool, SpecParseError> {
+    c.read_bool()
+}
+
+/// Parse the raw bytes of a `contractspecv0` custom section into its
+/// sequence of entries. Returns a typed [`SpecParseError`] rather than
+/// panicking on malformed input.
+pub fn parse_contract_spec(bytes: &[u8]) -> Result<Vec<ScSpecEntry>, SpecParseError> {
+    let mut cursor = Cursor::new(bytes);
+    let mut entries = Vec::new();
+    while cursor.remaining() > 0 {
+        entries.push(cursor.read_entry()?);
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Encoder {
+        buf: Vec<u8>,
+    }
+
+    impl Encoder {
+        fn new() -> Self {
+            Self { buf: Vec::new() }
+        }
+
+        fn u32(&mut self, v: u32) -> &mut Self {
+            self.buf.extend_from_slice(&v.to_be_bytes());
+            self
+        }
+
+        fn i32(&mut self, v: i32) -> &mut Self {
+            self.u32(v as u32)
+        }
+
+        fn string(&mut self, s: &str) -> &mut Self {
+            self.u32(s.len() as u32);
+            self.buf.extend_from_slice(s.as_bytes());
+            let padding = (4 - (s.len() % 4)) % 4;
+            self.buf.extend(std::iter::repeat(0u8).take(padding));
+            self
+        }
+
+        fn type_scalar(&mut self, disc: i32) -> &mut Self {
+            self.i32(disc)
+        }
+
+        fn finish(self) -> Vec<u8> {
+            self.buf
+        }
+    }
+
+    #[test]
+    fn decodes_function_with_scalar_types() {
+        let mut e = Encoder::new();
+        e.i32(0); // SC_SPEC_ENTRY_FUNCTION_V0
+        e.string(""); // doc
+        e.string("transfer"); // name
+        e.u32(2); // inputs count
+        e.string("");
+        e.string("to");
+        e.type_scalar(19); // Address
+        e.string("");
+        e.string("amount");
+        e.type_scalar(6); // U64
+        e.u32(1); // outputs count
+        e.type_scalar(1); // Bool
+        let bytes = e.finish();
+
+        let entries = parse_contract_spec(&bytes).unwrap();
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            ScSpecEntry::FunctionV0(f) => {
+                assert_eq!(f.name, "transfer");
+                assert_eq!(f.inputs.len(), 2);
+                assert_eq!(f.inputs[0].name, "to");
+                assert_eq!(f.inputs[0].type_def, ScSpecTypeDef::Address);
+                assert_eq!(f.inputs[1].type_def, ScSpecTypeDef::U64);
+                assert_eq!(f.outputs, vec![ScSpecTypeDef::Bool]);
+            }
+            other => panic!("expected function, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_nested_option_vec_type() {
+        let mut e = Encoder::new();
+        e.i32(0);
+        e.string("");
+        e.string("f");
+        e.u32(1);
+        e.string("");
+        e.string("x");
+        e.i32(1000); // Option
+        e.i32(1002); // Vec
+        e.type_scalar(4); // U32
+        e.u32(0); // outputs count
+        let bytes = e.finish();
+
+        let entries = parse_contract_spec(&bytes).unwrap();
+        match &entries[0] {
+            ScSpecEntry::FunctionV0(f) => {
+                assert_eq!(
+                    f.inputs[0].type_def,
+                    ScSpecTypeDef::Option(Box::new(ScSpecTypeDef::Vec(Box::new(
+                        ScSpecTypeDef::U32
+                    ))))
+                );
+            }
+            other => panic!("expected function, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_struct_with_fields() {
+        let mut e = Encoder::new();
+        e.i32(1); // SC_SPEC_ENTRY_UDT_STRUCT_V0
+        e.string("");
+        e.string(""); // lib
+        e.string("Position");
+        e.u32(1); // fields count
+        e.string("");
+        e.string("amount");
+        e.type_scalar(7); // I64
+        let bytes = e.finish();
+
+        let entries = parse_contract_spec(&bytes).unwrap();
+        match &entries[0] {
+            ScSpecEntry::UdtStructV0(s) => {
+                assert_eq!(s.name, "Position");
+                assert_eq!(s.fields.len(), 1);
+                assert_eq!(s.fields[0].name, "amount");
+                assert_eq!(s.fields[0].type_def, ScSpecTypeDef::I64);
+            }
+            other => panic!("expected struct, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_union_void_and_tuple_cases() {
+        let mut e = Encoder::new();
+        e.i32(2); // SC_SPEC_ENTRY_UDT_UNION_V0
+        e.string("");
+        e.string("");
+        e.string("Status");
+        e.u32(2); // cases
+        e.i32(0); // void case
+        e.string("");
+        e.string("Idle");
+        e.i32(1); // tuple case
+        e.string("");
+        e.string("Running");
+        e.u32(1);
+        e.type_scalar(4); // U32
+        let bytes = e.finish();
+
+        let entries = parse_contract_spec(&bytes).unwrap();
+        match &entries[0] {
+            ScSpecEntry::UdtUnionV0(u) => {
+                assert_eq!(u.cases.len(), 2);
+                assert_eq!(
+                    u.cases[0],
+                    ScSpecUdtUnionCaseV0::Void {
+                        doc: "".into(),
+                        name: "Idle".into()
+                    }
+                );
+                assert_eq!(
+                    u.cases[1],
+                    ScSpecUdtUnionCaseV0::Tuple {
+                        doc: "".into(),
+                        name: "Running".into(),
+                        types: vec![ScSpecTypeDef::U32]
+                    }
+                );
+            }
+            other => panic!("expected union, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_enum_and_error_enum() {
+        let mut e = Encoder::new();
+        e.i32(3); // SC_SPEC_ENTRY_UDT_ENUM_V0
+        e.string("");
+        e.string("");
+        e.string("Kind");
+        e.u32(1);
+        e.string("");
+        e.string("A");
+        e.u32(0);
+
+        e.i32(4); // SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0
+        e.string("");
+        e.string("");
+        e.string("Error");
+        e.u32(1);
+        e.string("");
+        e.string("NotFound");
+        e.u32(1);
+        let bytes = e.finish();
+
+        let entries = parse_contract_spec(&bytes).unwrap();
+        assert_eq!(entries.len(), 2);
+        match &entries[0] {
+            ScSpecEntry::UdtEnumV0(en) => assert_eq!(en.cases[0].value, 0),
+            other => panic!("expected enum, got {other:?}"),
+        }
+        match &entries[1] {
+            ScSpecEntry::UdtErrorEnumV0(en) => {
+                assert_eq!(en.cases[0].name, "NotFound");
+                assert_eq!(en.cases[0].value, 1);
+            }
+            other => panic!("expected error enum, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_event() {
+        let mut e = Encoder::new();
+        e.i32(5); // SC_SPEC_ENTRY_EVENT_V0
+        e.string("");
+        e.string("");
+        e.string("transfer");
+        e.u32(1); // prefix_topics
+        e.string("transfer");
+        e.u32(1); // params
+        e.string("");
+        e.string("amount");
+        e.type_scalar(6); // U64
+        e.i32(0); // Data location
+        e.i32(0); // SingleValue
+        let bytes = e.finish();
+
+        let entries = parse_contract_spec(&bytes).unwrap();
+        match &entries[0] {
+            ScSpecEntry::EventV0(ev) => {
+                assert_eq!(ev.name, "transfer");
+                assert_eq!(ev.prefix_topics, vec!["transfer".to_string()]);
+                assert_eq!(ev.params[0].location, ScSpecEventParamLocationV0::Data);
+                assert_eq!(ev.data_format, ScSpecEventDataFormat::SingleValue);
+            }
+            other => panic!("expected event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multiple_entries_back_to_back() {
+        let mut e = Encoder::new();
+        e.i32(0);
+        e.string("");
+        e.string("f1");
+        e.u32(0);
+        e.u32(0);
+        e.i32(0);
+        e.string("");
+        e.string("f2");
+        e.u32(0);
+        e.u32(0);
+        let bytes = e.finish();
+
+        let entries = parse_contract_spec(&bytes).unwrap();
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn rejects_truncated_input() {
+        let bytes = vec![0u8, 0, 0]; // 3 bytes, not enough for a u32 discriminant
+        let err = parse_contract_spec(&bytes).unwrap_err();
+        assert!(matches!(err, SpecParseError::UnexpectedEof { .. }));
+    }
+
+    #[test]
+    fn rejects_unknown_entry_kind() {
+        let mut e = Encoder::new();
+        e.i32(99);
+        let bytes = e.finish();
+        let err = parse_contract_spec(&bytes).unwrap_err();
+        assert!(matches!(err, SpecParseError::InvalidDiscriminant { .. }));
+    }
+
+    #[test]
+    fn empty_section_yields_no_entries() {
+        let entries = parse_contract_spec(&[]).unwrap();
+        assert!(entries.is_empty());
+    }
+}

--- a/backend/shared/src/contract_spec.rs
+++ b/backend/shared/src/contract_spec.rs
@@ -273,10 +273,6 @@ impl<'a> Cursor<'a> {
         Ok(self.read_u32()? as i32)
     }
 
-    fn read_bool(&mut self) -> Result<bool, SpecParseError> {
-        Ok(self.read_u32()? != 0)
-    }
-
     /// XDR variable-length opaque/string: u32 length, bytes, zero-padded to a
     /// 4-byte boundary.
     fn read_var_bytes(&mut self) -> Result<&'a [u8], SpecParseError> {
@@ -525,14 +521,6 @@ impl<'a> Cursor<'a> {
             other => Err(SpecParseError::InvalidDiscriminant { at, value: other }),
         }
     }
-}
-
-// `read_bool` is part of the XDR primitive set this module supports even
-// though no currently-decoded entry uses it; keep it exercised so it does
-// not bit-rot silently.
-#[allow(dead_code)]
-fn _assert_read_bool_used(c: &mut Cursor) -> Result<bool, SpecParseError> {
-    c.read_bool()
 }
 
 /// Parse the raw bytes of a `contractspecv0` custom section into its

--- a/backend/shared/src/interface_fingerprint.rs
+++ b/backend/shared/src/interface_fingerprint.rs
@@ -17,6 +17,7 @@ use crate::contract_spec::{
     ScSpecUdtUnionCaseV0,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use sha2::{Digest, Sha256};
 
 pub const ALGORITHM: &str = "soroban-interface-v1";
@@ -78,11 +79,16 @@ fn canonical_union_case(case: &ScSpecUdtUnionCaseV0) -> String {
     }
 }
 
-/// Build the canonical signature and derived fingerprint for a single spec
-/// entry. Returns `None` for entry variants that carry no independent
-/// identity (there are none today, but this keeps the mapping total and
-/// future-proof).
-fn fingerprint_entry(entry: &ScSpecEntry) -> (EntryKind, String, String) {
+/// Build the human-readable signature, and the structured (collision-safe)
+/// hash input, for a single spec entry.
+///
+/// The hash input is a `serde_json::Value` rather than a hand-joined
+/// string: joining fields with plain delimiters (e.g. `,`/`:`) is not safe
+/// because a name or UDT type reference could itself contain those
+/// characters, letting two structurally different entries serialize to the
+/// same joined string. JSON's own escaping and structural nesting rules out
+/// that collision regardless of what the individual strings contain.
+fn fingerprint_entry(entry: &ScSpecEntry) -> (EntryKind, String, String, serde_json::Value) {
     match entry {
         ScSpecEntry::FunctionV0(f) => {
             let inputs: Vec<String> = f
@@ -97,7 +103,12 @@ fn fingerprint_entry(entry: &ScSpecEntry) -> (EntryKind, String, String) {
                 inputs.join(","),
                 outputs.join(",")
             );
-            (EntryKind::Function, f.name.clone(), sig)
+            let hash_input = json!({
+                "fn": f.name,
+                "in": f.inputs.iter().map(|i| json!([i.name, canonical_type(&i.type_def)])).collect::<Vec<_>>(),
+                "out": outputs,
+            });
+            (EntryKind::Function, f.name.clone(), sig, hash_input)
         }
         ScSpecEntry::UdtStructV0(s) => {
             let fields: Vec<String> = s
@@ -106,37 +117,58 @@ fn fingerprint_entry(entry: &ScSpecEntry) -> (EntryKind, String, String) {
                 .map(|field| format!("{}:{}", field.name, canonical_type(&field.type_def)))
                 .collect();
             let sig = format!("struct {} {{{}}}", s.name, fields.join(","));
-            (EntryKind::Type, s.name.clone(), sig)
+            let hash_input = json!({
+                "struct": s.name,
+                "fields": s.fields.iter().map(|field| json!([field.name, canonical_type(&field.type_def)])).collect::<Vec<_>>(),
+            });
+            (EntryKind::Type, s.name.clone(), sig, hash_input)
         }
         ScSpecEntry::UdtUnionV0(u) => {
-            let mut cases: Vec<String> = u.cases.iter().map(canonical_union_case).collect();
+            let cases: Vec<String> = u.cases.iter().map(canonical_union_case).collect();
+            let sig = format!("union {} {{{}}}", u.name, cases.join(","));
             // Union case order is part of the wire ABI (it is the
             // discriminant), so it is preserved rather than sorted.
-            let _ = &mut cases;
-            let sig = format!("union {} {{{}}}", u.name, cases.join(","));
-            (EntryKind::Type, u.name.clone(), sig)
+            let hash_input = json!({
+                "union": u.name,
+                "cases": u.cases.iter().map(|case| match case {
+                    ScSpecUdtUnionCaseV0::Void { name, .. } => json!(["void", name, []]),
+                    ScSpecUdtUnionCaseV0::Tuple { name, types, .. } => {
+                        let types: Vec<String> = types.iter().map(canonical_type).collect();
+                        json!(["tuple", name, types])
+                    }
+                }).collect::<Vec<_>>(),
+            });
+            (EntryKind::Type, u.name.clone(), sig, hash_input)
         }
         ScSpecEntry::UdtEnumV0(e) => {
             let mut cases: Vec<(u32, &str)> =
                 e.cases.iter().map(|c| (c.value, c.name.as_str())).collect();
             cases.sort_by_key(|(v, _)| *v);
-            let cases: Vec<String> = cases
-                .into_iter()
+            let sig_cases: Vec<String> = cases
+                .iter()
                 .map(|(v, name)| format!("{name}={v}"))
                 .collect();
-            let sig = format!("enum {} {{{}}}", e.name, cases.join(","));
-            (EntryKind::Type, e.name.clone(), sig)
+            let sig = format!("enum {} {{{}}}", e.name, sig_cases.join(","));
+            let hash_input = json!({
+                "enum": e.name,
+                "cases": cases.iter().map(|(v, name)| json!([name, v])).collect::<Vec<_>>(),
+            });
+            (EntryKind::Type, e.name.clone(), sig, hash_input)
         }
         ScSpecEntry::UdtErrorEnumV0(e) => {
             let mut cases: Vec<(u32, &str)> =
                 e.cases.iter().map(|c| (c.value, c.name.as_str())).collect();
             cases.sort_by_key(|(v, _)| *v);
-            let cases: Vec<String> = cases
-                .into_iter()
+            let sig_cases: Vec<String> = cases
+                .iter()
                 .map(|(v, name)| format!("{name}={v}"))
                 .collect();
-            let sig = format!("error {} {{{}}}", e.name, cases.join(","));
-            (EntryKind::Error, e.name.clone(), sig)
+            let sig = format!("error {} {{{}}}", e.name, sig_cases.join(","));
+            let hash_input = json!({
+                "error": e.name,
+                "cases": cases.iter().map(|(v, name)| json!([name, v])).collect::<Vec<_>>(),
+            });
+            (EntryKind::Error, e.name.clone(), sig, hash_input)
         }
         ScSpecEntry::EventV0(ev) => {
             let params: Vec<String> = ev
@@ -163,7 +195,19 @@ fn fingerprint_entry(entry: &ScSpecEntry) -> (EntryKind, String, String) {
                 params.join(","),
                 format_tag
             );
-            (EntryKind::Event, ev.name.clone(), sig)
+            let hash_input = json!({
+                "event": ev.name,
+                "topics": ev.prefix_topics,
+                "params": ev.params.iter().map(|p| {
+                    let loc = match p.location {
+                        ScSpecEventParamLocationV0::Data => "data",
+                        ScSpecEventParamLocationV0::TopicList => "topic",
+                    };
+                    json!([p.name, canonical_type(&p.type_def), loc])
+                }).collect::<Vec<_>>(),
+                "format": format_tag,
+            });
+            (EntryKind::Event, ev.name.clone(), sig, hash_input)
         }
     }
 }
@@ -181,8 +225,10 @@ pub fn fingerprint_spec(entries: &[ScSpecEntry]) -> InterfaceFingerprint {
     let mut errors = Vec::new();
 
     for entry in entries {
-        let (kind, name, signature) = fingerprint_entry(entry);
-        let fingerprint = sha256_hex(&format!("{ALGORITHM}:{kind:?}:{signature}"));
+        let (kind, name, signature, hash_input) = fingerprint_entry(entry);
+        let hash_input_str =
+            serde_json::to_string(&hash_input).expect("json::Value serialization cannot fail");
+        let fingerprint = sha256_hex(&format!("{ALGORITHM}:{kind:?}:{hash_input_str}"));
         let item = EntryFingerprint {
             kind,
             name,
@@ -311,6 +357,28 @@ mod tests {
         assert_ne!(
             fingerprint_spec(&[a]).functions[0].fingerprint,
             fingerprint_spec(&[b]).functions[0].fingerprint
+        );
+    }
+
+    #[test]
+    fn delimiter_confusable_functions_do_not_collide() {
+        // Two inputs "a:u32" + "b:u64" naively joined with ',' produce the
+        // same string as one input named "a" whose UDT type name is
+        // "u32,b:u64" naively joined with ':'. The structured JSON hash
+        // input must keep these distinguishable.
+        let two_inputs = func(
+            "f",
+            vec![("a", ScSpecTypeDef::U32), ("b", ScSpecTypeDef::U64)],
+            vec![],
+        );
+        let one_input = func(
+            "f",
+            vec![("a", ScSpecTypeDef::Udt("u32,b:u64".to_string()))],
+            vec![],
+        );
+        assert_ne!(
+            fingerprint_spec(&[two_inputs]).functions[0].fingerprint,
+            fingerprint_spec(&[one_input]).functions[0].fingerprint
         );
     }
 

--- a/backend/shared/src/interface_fingerprint.rs
+++ b/backend/shared/src/interface_fingerprint.rs
@@ -1,0 +1,325 @@
+//! Deterministic interface fingerprints for Soroban contracts.
+//!
+//! Derives stable, versioned identifiers from a parsed `contractspecv0`
+//! (see [`crate::contract_spec`]) by normalizing away non-semantic data
+//! (doc comments, library names, and any incidental entry ordering) before
+//! hashing. Two specs that differ only in those respects must produce
+//! identical fingerprints; any change to a callable ABI, type, event, or
+//! error surface must change the relevant fingerprint.
+//!
+//! Algorithm identifier: `soroban-interface-v1`. Bump the version string
+//! (and add a new module, e.g. `v2`) rather than silently changing this
+//! logic in place — old fingerprints must never be reinterpreted under a
+//! new algorithm.
+
+use crate::contract_spec::{
+    ScSpecEntry, ScSpecEventDataFormat, ScSpecEventParamLocationV0, ScSpecTypeDef,
+    ScSpecUdtUnionCaseV0,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const ALGORITHM: &str = "soroban-interface-v1";
+
+/// The kind of entry a fingerprint was derived from, used to group and sort
+/// entries deterministically. Distinct kinds are also mixed into the entry
+/// fingerprint so that a struct and a function with the same name never
+/// collide.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EntryKind {
+    Function,
+    Type,
+    Event,
+    Error,
+}
+
+/// A single named, fingerprinted entry (function, type, event, or error).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntryFingerprint {
+    pub kind: EntryKind,
+    pub name: String,
+    /// sha256 of the canonical signature, hex-encoded.
+    pub fingerprint: String,
+    /// Canonicalized human-readable signature (also the hash preimage).
+    pub signature: String,
+}
+
+/// The full interface fingerprint for a contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterfaceFingerprint {
+    pub algorithm: String,
+    pub interface_id: String,
+    pub functions: Vec<EntryFingerprint>,
+    pub types: Vec<EntryFingerprint>,
+    pub events: Vec<EntryFingerprint>,
+    pub errors: Vec<EntryFingerprint>,
+}
+
+fn sha256_hex(input: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Canonical (semantic-only) rendering of a type reference. Never includes
+/// doc strings; only names and structural shape.
+fn canonical_type(t: &ScSpecTypeDef) -> String {
+    t.to_string()
+}
+
+fn canonical_union_case(case: &ScSpecUdtUnionCaseV0) -> String {
+    match case {
+        ScSpecUdtUnionCaseV0::Void { name, .. } => format!("{name}()"),
+        ScSpecUdtUnionCaseV0::Tuple { name, types, .. } => {
+            let types: Vec<String> = types.iter().map(canonical_type).collect();
+            format!("{name}({})", types.join(","))
+        }
+    }
+}
+
+/// Build the canonical signature and derived fingerprint for a single spec
+/// entry. Returns `None` for entry variants that carry no independent
+/// identity (there are none today, but this keeps the mapping total and
+/// future-proof).
+fn fingerprint_entry(entry: &ScSpecEntry) -> (EntryKind, String, String) {
+    match entry {
+        ScSpecEntry::FunctionV0(f) => {
+            let inputs: Vec<String> = f
+                .inputs
+                .iter()
+                .map(|i| format!("{}:{}", i.name, canonical_type(&i.type_def)))
+                .collect();
+            let outputs: Vec<String> = f.outputs.iter().map(canonical_type).collect();
+            let sig = format!(
+                "fn {}({}) -> ({})",
+                f.name,
+                inputs.join(","),
+                outputs.join(",")
+            );
+            (EntryKind::Function, f.name.clone(), sig)
+        }
+        ScSpecEntry::UdtStructV0(s) => {
+            let fields: Vec<String> = s
+                .fields
+                .iter()
+                .map(|field| format!("{}:{}", field.name, canonical_type(&field.type_def)))
+                .collect();
+            let sig = format!("struct {} {{{}}}", s.name, fields.join(","));
+            (EntryKind::Type, s.name.clone(), sig)
+        }
+        ScSpecEntry::UdtUnionV0(u) => {
+            let mut cases: Vec<String> = u.cases.iter().map(canonical_union_case).collect();
+            // Union case order is part of the wire ABI (it is the
+            // discriminant), so it is preserved rather than sorted.
+            let _ = &mut cases;
+            let sig = format!("union {} {{{}}}", u.name, cases.join(","));
+            (EntryKind::Type, u.name.clone(), sig)
+        }
+        ScSpecEntry::UdtEnumV0(e) => {
+            let mut cases: Vec<(u32, &str)> =
+                e.cases.iter().map(|c| (c.value, c.name.as_str())).collect();
+            cases.sort_by_key(|(v, _)| *v);
+            let cases: Vec<String> = cases
+                .into_iter()
+                .map(|(v, name)| format!("{name}={v}"))
+                .collect();
+            let sig = format!("enum {} {{{}}}", e.name, cases.join(","));
+            (EntryKind::Type, e.name.clone(), sig)
+        }
+        ScSpecEntry::UdtErrorEnumV0(e) => {
+            let mut cases: Vec<(u32, &str)> =
+                e.cases.iter().map(|c| (c.value, c.name.as_str())).collect();
+            cases.sort_by_key(|(v, _)| *v);
+            let cases: Vec<String> = cases
+                .into_iter()
+                .map(|(v, name)| format!("{name}={v}"))
+                .collect();
+            let sig = format!("error {} {{{}}}", e.name, cases.join(","));
+            (EntryKind::Error, e.name.clone(), sig)
+        }
+        ScSpecEntry::EventV0(ev) => {
+            let params: Vec<String> = ev
+                .params
+                .iter()
+                .map(|p| {
+                    let loc = match p.location {
+                        ScSpecEventParamLocationV0::Data => "data",
+                        ScSpecEventParamLocationV0::TopicList => "topic",
+                    };
+                    format!("{}:{}@{}", p.name, canonical_type(&p.type_def), loc)
+                })
+                .collect();
+            let format_tag = match ev.data_format {
+                ScSpecEventDataFormat::SingleValue => "single",
+                ScSpecEventDataFormat::Vec => "vec",
+                ScSpecEventDataFormat::Map => "map",
+            };
+            let topics = ev.prefix_topics.join(",");
+            let sig = format!(
+                "event {} topics=[{}] params=({}) format={}",
+                ev.name,
+                topics,
+                params.join(","),
+                format_tag
+            );
+            (EntryKind::Event, ev.name.clone(), sig)
+        }
+    }
+}
+
+/// Derive the full [`InterfaceFingerprint`] from a parsed contract spec.
+///
+/// Entries are grouped by kind and sorted by name so that the original
+/// physical ordering of entries inside the WASM section never affects the
+/// result. Union case order is preserved within a union's own signature
+/// because it is part of that union's wire ABI.
+pub fn fingerprint_spec(entries: &[ScSpecEntry]) -> InterfaceFingerprint {
+    let mut functions = Vec::new();
+    let mut types = Vec::new();
+    let mut events = Vec::new();
+    let mut errors = Vec::new();
+
+    for entry in entries {
+        let (kind, name, signature) = fingerprint_entry(entry);
+        let fingerprint = sha256_hex(&format!("{ALGORITHM}:{kind:?}:{signature}"));
+        let item = EntryFingerprint {
+            kind,
+            name,
+            fingerprint,
+            signature,
+        };
+        match kind {
+            EntryKind::Function => functions.push(item),
+            EntryKind::Type => types.push(item),
+            EntryKind::Event => events.push(item),
+            EntryKind::Error => errors.push(item),
+        }
+    }
+
+    for group in [&mut functions, &mut types, &mut events, &mut errors] {
+        group.sort_by(|a, b| a.name.cmp(&b.name));
+    }
+
+    let mut canonical_all: Vec<&EntryFingerprint> = functions
+        .iter()
+        .chain(types.iter())
+        .chain(events.iter())
+        .chain(errors.iter())
+        .collect();
+    canonical_all.sort_by(|a, b| (a.kind, &a.name).cmp(&(b.kind, &b.name)));
+
+    let joined = canonical_all
+        .iter()
+        .map(|e| e.fingerprint.as_str())
+        .collect::<Vec<_>>()
+        .join("|");
+    let interface_id = sha256_hex(&format!("{ALGORITHM}:contract:{joined}"));
+
+    InterfaceFingerprint {
+        algorithm: ALGORITHM.to_string(),
+        interface_id,
+        functions,
+        types,
+        events,
+        errors,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract_spec::{ScSpecFunctionInputV0, ScSpecFunctionV0};
+
+    fn func(name: &str, inputs: Vec<(&str, ScSpecTypeDef)>, outputs: Vec<ScSpecTypeDef>) -> ScSpecEntry {
+        ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+            doc: "some doc".into(),
+            name: name.into(),
+            inputs: inputs
+                .into_iter()
+                .map(|(n, t)| ScSpecFunctionInputV0 {
+                    doc: "input doc".into(),
+                    name: n.into(),
+                    type_def: t,
+                })
+                .collect(),
+            outputs,
+        })
+    }
+
+    #[test]
+    fn identical_specs_produce_identical_fingerprints() {
+        let a = vec![func("transfer", vec![("to", ScSpecTypeDef::Address)], vec![ScSpecTypeDef::Bool])];
+        let b = vec![func("transfer", vec![("to", ScSpecTypeDef::Address)], vec![ScSpecTypeDef::Bool])];
+        assert_eq!(fingerprint_spec(&a).interface_id, fingerprint_spec(&b).interface_id);
+    }
+
+    #[test]
+    fn doc_changes_do_not_affect_fingerprint() {
+        let mut a = func("transfer", vec![], vec![]);
+        let mut b = a.clone();
+        if let ScSpecEntry::FunctionV0(f) = &mut a {
+            f.doc = "Docs A".into();
+        }
+        if let ScSpecEntry::FunctionV0(f) = &mut b {
+            f.doc = "Totally different docs".into();
+        }
+        assert_eq!(
+            fingerprint_spec(&[a]).interface_id,
+            fingerprint_spec(&[b]).interface_id
+        );
+    }
+
+    #[test]
+    fn entry_order_does_not_affect_interface_id() {
+        let f1 = func("a", vec![], vec![]);
+        let f2 = func("b", vec![], vec![]);
+        let id1 = fingerprint_spec(&[f1.clone(), f2.clone()]).interface_id;
+        let id2 = fingerprint_spec(&[f2, f1]).interface_id;
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn removing_a_function_changes_the_interface_id() {
+        let a = vec![func("a", vec![], vec![]), func("b", vec![], vec![])];
+        let b = vec![func("a", vec![], vec![])];
+        assert_ne!(fingerprint_spec(&a).interface_id, fingerprint_spec(&b).interface_id);
+    }
+
+    #[test]
+    fn changing_a_parameter_type_changes_the_function_fingerprint() {
+        let a = func("f", vec![("x", ScSpecTypeDef::U32)], vec![]);
+        let b = func("f", vec![("x", ScSpecTypeDef::U64)], vec![]);
+        let fa = fingerprint_spec(&[a]);
+        let fb = fingerprint_spec(&[b]);
+        assert_ne!(fa.functions[0].fingerprint, fb.functions[0].fingerprint);
+        assert_ne!(fa.interface_id, fb.interface_id);
+    }
+
+    #[test]
+    fn reordering_parameters_changes_the_function_fingerprint() {
+        let a = func(
+            "f",
+            vec![("x", ScSpecTypeDef::U32), ("y", ScSpecTypeDef::U32)],
+            vec![],
+        );
+        let b = func(
+            "f",
+            vec![("y", ScSpecTypeDef::U32), ("x", ScSpecTypeDef::U32)],
+            vec![],
+        );
+        assert_ne!(
+            fingerprint_spec(&[a]).functions[0].fingerprint,
+            fingerprint_spec(&[b]).functions[0].fingerprint
+        );
+    }
+
+    #[test]
+    fn empty_spec_has_a_stable_interface_id() {
+        let fp = fingerprint_spec(&[]);
+        assert_eq!(fp.algorithm, ALGORITHM);
+        assert!(fp.functions.is_empty());
+        // Even with no entries, the id is deterministic for the empty set.
+        assert_eq!(fp.interface_id, fingerprint_spec(&[]).interface_id);
+    }
+}

--- a/backend/shared/src/lib.rs
+++ b/backend/shared/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod abi;
 pub mod contract_spec;
 pub mod error;
+pub mod interface_fingerprint;
 pub mod logging;
 pub mod models;
 pub mod pagination;

--- a/backend/shared/src/lib.rs
+++ b/backend/shared/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod abi;
+pub mod contract_spec;
 pub mod error;
 pub mod logging;
 pub mod models;

--- a/backend/shared/src/wasm.rs
+++ b/backend/shared/src/wasm.rs
@@ -41,6 +41,26 @@ impl WasmValidationResult {
     }
 }
 
+/// Extract the raw bytes of the `contractspecv0` custom section, if present.
+/// Concatenates the payloads of every section with that name, matching how
+/// Soroban's toolchain may split them, before use with
+/// [`crate::contract_spec::parse_contract_spec`].
+pub fn extract_contract_spec_bytes(wasm_bytes: &[u8]) -> Option<Vec<u8>> {
+    let parser = Parser::new(0);
+    let mut out: Option<Vec<u8>> = None;
+
+    for payload in parser.parse_all(wasm_bytes) {
+        if let Ok(wasmparser::Payload::CustomSection(c)) = payload {
+            if c.name() == CONTRACT_SPEC_SECTION {
+                out.get_or_insert_with(Vec::new)
+                    .extend_from_slice(c.data());
+            }
+        }
+    }
+
+    out
+}
+
 /// Parse and structurally validate a WASM byte slice.
 ///
 /// Returns a populated [`WasmValidationResult`] even on failure; inspect
@@ -151,12 +171,18 @@ mod tests {
     ];
 
     /// Append a custom section with `name` and empty payload to `wasm`.
-    fn with_custom_section(mut wasm: Vec<u8>, name: &str) -> Vec<u8> {
+    fn with_custom_section(wasm: Vec<u8>, name: &str) -> Vec<u8> {
+        with_custom_section_payload(wasm, name, &[])
+    }
+
+    /// Append a custom section with `name` and the given payload to `wasm`.
+    fn with_custom_section_payload(mut wasm: Vec<u8>, name: &str, payload: &[u8]) -> Vec<u8> {
         let mut body = Vec::new();
         body.push(name.len() as u8); // name length (LEB128, fits in one byte here)
         body.extend_from_slice(name.as_bytes());
+        body.extend_from_slice(payload);
         wasm.push(0x00); // custom section id
-        wasm.push(body.len() as u8); // section size
+        wasm.push(body.len() as u8); // section size (fits in one byte for test fixtures)
         wasm.extend_from_slice(&body);
         wasm
     }
@@ -208,5 +234,19 @@ mod tests {
         let wasm = with_custom_section(MINIMAL_WASM.to_vec(), CONTRACT_ENV_META_SECTION);
         let result = validate_wasm(&wasm);
         assert!(result.has_env_meta);
+    }
+
+    #[test]
+    fn extracts_contract_spec_payload_bytes() {
+        let payload = [1u8, 2, 3, 4];
+        let wasm =
+            with_custom_section_payload(MINIMAL_WASM.to_vec(), CONTRACT_SPEC_SECTION, &payload);
+        let extracted = extract_contract_spec_bytes(&wasm).expect("section should be found");
+        assert_eq!(extracted, payload);
+    }
+
+    #[test]
+    fn extract_returns_none_when_section_absent() {
+        assert!(extract_contract_spec_bytes(MINIMAL_WASM).is_none());
     }
 }

--- a/cli/src/contract_interfaces.rs
+++ b/cli/src/contract_interfaces.rs
@@ -31,17 +31,13 @@ pub async fn run_local(wasm_path: &str, json: bool) -> Result<()> {
         anyhow::bail!("WASM file is empty: {}", wasm_path);
     }
 
-    let validation = shared::wasm::validate_wasm(&bytes);
-    if !validation.has_contract_spec {
-        anyhow::bail!(
+    let spec_bytes = shared::wasm::extract_contract_spec_bytes(&bytes).ok_or_else(|| {
+        anyhow::anyhow!(
             "No {} section found: this WASM does not embed a Soroban contract spec, \
              so no interface fingerprint can be derived.",
             shared::wasm::CONTRACT_SPEC_SECTION
-        );
-    }
-
-    let spec_bytes = shared::wasm::extract_contract_spec_bytes(&bytes)
-        .expect("has_contract_spec is true, so the section must be extractable");
+        )
+    })?;
 
     let entries = shared::contract_spec::parse_contract_spec(&spec_bytes).map_err(|e| {
         anyhow::anyhow!(

--- a/cli/src/contract_interfaces.rs
+++ b/cli/src/contract_interfaces.rs
@@ -1,0 +1,98 @@
+//! contract_interfaces.rs — `soroban-registry contract interfaces --wasm <path>` (#1139)
+//!
+//! Derives the deterministic `soroban-interface-v1` fingerprint for a local
+//! compiled contract WASM artifact and displays its functions, types,
+//! events and errors alongside their per-entry and contract-level
+//! fingerprints.
+//!
+//! This runs entirely offline against a local artifact — it does not
+//! require a registry lookup, since the registry does not yet expose
+//! interface fingerprints through its API.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use shared::interface_fingerprint::{fingerprint_spec, EntryKind, InterfaceFingerprint};
+
+/// `soroban-registry contract interfaces --wasm <path> [--json]`
+pub async fn run_local(wasm_path: &str, json: bool) -> Result<()> {
+    log::debug!("contract interfaces (local) | wasm={} json={}", wasm_path, json);
+
+    let path = std::path::Path::new(wasm_path);
+    if !path.exists() {
+        anyhow::bail!(
+            "WASM file not found: {}\n  → Pass the path to a compiled contract, e.g. \
+             target/wasm32-unknown-unknown/release/<contract>.wasm",
+            wasm_path
+        );
+    }
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("Failed to read WASM file at {}", wasm_path))?;
+    if bytes.is_empty() {
+        anyhow::bail!("WASM file is empty: {}", wasm_path);
+    }
+
+    let validation = shared::wasm::validate_wasm(&bytes);
+    if !validation.has_contract_spec {
+        anyhow::bail!(
+            "No {} section found: this WASM does not embed a Soroban contract spec, \
+             so no interface fingerprint can be derived.",
+            shared::wasm::CONTRACT_SPEC_SECTION
+        );
+    }
+
+    let spec_bytes = shared::wasm::extract_contract_spec_bytes(&bytes)
+        .expect("has_contract_spec is true, so the section must be extractable");
+
+    let entries = shared::contract_spec::parse_contract_spec(&spec_bytes).map_err(|e| {
+        anyhow::anyhow!(
+            "Malformed {} section, cannot derive an interface fingerprint: {e}",
+            shared::wasm::CONTRACT_SPEC_SECTION
+        )
+    })?;
+
+    let fp = fingerprint_spec(&entries);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&fp)?);
+        return Ok(());
+    }
+
+    print_human(wasm_path, &fp);
+    Ok(())
+}
+
+fn print_human(wasm_path: &str, fp: &InterfaceFingerprint) {
+    println!("\n{}", "Contract Interface".bold().cyan());
+    println!("{}", "=".repeat(80).cyan());
+    println!("{:<14}{}", "File:".bold(), wasm_path);
+    println!("{:<14}{}", "Algorithm:".bold(), fp.algorithm);
+    println!(
+        "{:<14}{}",
+        "Interface ID:".bold(),
+        fp.interface_id.bright_black()
+    );
+
+    print_group("Functions", EntryKind::Function, &fp.functions);
+    print_group("Types", EntryKind::Type, &fp.types);
+    print_group("Events", EntryKind::Event, &fp.events);
+    print_group("Errors", EntryKind::Error, &fp.errors);
+
+    println!();
+}
+
+fn print_group(
+    label: &str,
+    _kind: EntryKind,
+    entries: &[shared::interface_fingerprint::EntryFingerprint],
+) {
+    println!("\n{} ({})", label.bold().underline(), entries.len());
+    if entries.is_empty() {
+        println!("  {}", "(none)".dimmed());
+        return;
+    }
+    for entry in entries {
+        println!("  {} {}", "•".cyan(), entry.name.bold());
+        println!("      {}", entry.signature.bright_black());
+        println!("      {} {}", "fingerprint:".dimmed(), entry.fingerprint.dimmed());
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,6 +31,7 @@ mod contract_deprecate;
 mod contract_snapshot;
 mod contract_highlight;
 mod contract_interaction;
+mod contract_interfaces;
 mod contract_register;
 mod contract_risk;
 mod contract_update;
@@ -1980,6 +1981,21 @@ pub enum ContractCommands {
         /// Skip cache and always fetch fresh data from registry
         #[arg(long)]
         no_cache: bool,
+    },
+
+    /// Derive and display a contract's deterministic interface fingerprint
+    /// (functions, types, events, errors) from a local compiled WASM
+    /// artifact.
+    ///
+    /// Usage: soroban-registry contract interfaces --wasm <path> [--json]
+    Interfaces {
+        /// Path to a local compiled WASM contract to inspect.
+        #[arg(long)]
+        wasm: String,
+
+        /// Output results as machine-readable JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Display detailed information about a contract
@@ -4227,6 +4243,10 @@ pub async fn dispatch_command(
                         );
                     }
                 }
+            }
+            ContractCommands::Interfaces { wasm, json } => {
+                log::debug!("Command: contract interfaces | wasm={} json={}", wasm, json);
+                contract_interfaces::run_local(&wasm, json).await?;
             }
             ContractCommands::Details {
                 address,


### PR DESCRIPTION
## Summary

Adds a deterministic, versioned interface-fingerprint system for Soroban contracts, derived from the embedded `contractspecv0` WASM section, plus a CLI command to inspect it locally.

## Related Issue

Closes #1139

## Type of Change

- [x] Feature — new functionality

## Changes Made

- Added a dependency-free XDR decoder for the `contractspecv0` custom WASM section (`backend/shared/src/contract_spec.rs`), covering functions, struct/union/enum/error-enum UDTs, events, and the full nested type system (option, result, vec, map, tuple, bytesN, UDT references).
- Added `extract_contract_spec_bytes` to `backend/shared/src/wasm.rs` to pull the raw section payload out of a WASM module (previously only presence was detected).
- Added the `soroban-interface-v1` fingerprint engine (`backend/shared/src/interface_fingerprint.rs`): normalizes parsed entries (stripping doc comments, library names, and physical ordering) and derives per-entry fingerprints plus a single contract-level `interface_id`.
- Added `soroban-registry contract interfaces --wasm <path> [--json]` to the CLI, displaying functions, types, events, and errors with their fingerprints.

## How Has This Been Tested?

### Test Commands

```bash
cd backend && cargo test -p shared contract_spec
cd backend && cargo test -p shared interface_fingerprint
cd cli && cargo check
```

### Test Coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing completed

### Testing Notes

Unit tests cover: decoding every entry kind (function, struct, union, enum, error-enum, event) with nested type shapes, truncated/malformed input, identical specs producing identical fingerprints, doc-only changes not affecting the fingerprint, entry reordering not affecting the interface ID, and any real signature/type/parameter-order change producing a different fingerprint. Manually ran `contract interfaces --wasm` against locally built fixture WASM.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated comments for complex logic
- [ ] I have updated documentation where applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass locally
- [x] My branch is rebased on the latest `main` with no merge conflicts
- [x] I have not introduced any breaking changes

## Additional Context

Algorithm identity is versioned as `soroban-interface-v1` and embedded in every fingerprint response, so a future algorithm change never silently reinterprets old fingerprints as compatible with new ones.
