### PR TITLE
SDK/CLI: Add typed semantic contract compatibility checking

### DIFF
--- a/backend/shared/src/contract_compatibility.rs
+++ b/backend/shared/src/contract_compatibility.rs
@@ -1,0 +1,1011 @@
+//! Semantic ABI compatibility engine for Soroban contract specs (#1143).
+//!
+//! Structurally compares two normalized `contractspecv0` specs (see
+//! [`crate::contract_spec`]) and classifies the differences, rather than
+//! diffing raw JSON/WASM bytes. Depends on the entry model produced by the
+//! same parser used for [`crate::interface_fingerprint`] (#1139), so a
+//! function rename, a reordered parameter, or a changed struct field is
+//! detected the same way in both engines.
+//!
+//! The single hard invariant here (called out explicitly in the tracking
+//! issue): an incomplete source spec must never produce a `compatible` or
+//! `breaking` verdict by accident. Any comparison built from a missing or
+//! malformed side short-circuits to [`CompatibilityLevel::Unknown`].
+
+use crate::contract_spec::{ScSpecEntry, ScSpecTypeDef, ScSpecUdtUnionCaseV0};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const ALGORITHM: &str = "soroban-compatibility-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompatibilityLevel {
+    Compatible,
+    PotentiallyBreaking,
+    Breaking,
+    Unknown,
+}
+
+impl CompatibilityLevel {
+    /// Combine two levels, keeping the more severe one. `Unknown` is most
+    /// severe: once any part of the comparison is unknown, the overall
+    /// result must not quietly claim `compatible`.
+    fn severity_rank(self) -> u8 {
+        match self {
+            CompatibilityLevel::Compatible => 0,
+            CompatibilityLevel::PotentiallyBreaking => 1,
+            CompatibilityLevel::Breaking => 2,
+            CompatibilityLevel::Unknown => 3,
+        }
+    }
+
+    fn max(self, other: Self) -> Self {
+        if other.severity_rank() > self.severity_rank() {
+            other
+        } else {
+            self
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeCategory {
+    Function,
+    Type,
+    Event,
+    Error,
+    Network,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Change {
+    pub category: ChangeCategory,
+    pub level: CompatibilityLevel,
+    /// Name of the affected function/type/event/error, or a fixed label
+    /// (e.g. "network") for context-level changes.
+    pub subject: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompatibilityReport {
+    pub algorithm: String,
+    pub overall: CompatibilityLevel,
+    pub changes: Vec<Change>,
+}
+
+impl CompatibilityReport {
+    fn unknown(reason: &str) -> Self {
+        Self {
+            algorithm: ALGORITHM.to_string(),
+            overall: CompatibilityLevel::Unknown,
+            changes: vec![Change {
+                category: ChangeCategory::Function,
+                level: CompatibilityLevel::Unknown,
+                subject: "spec".to_string(),
+                description: reason.to_string(),
+            }],
+        }
+    }
+
+    pub fn has_at_least(&self, level: CompatibilityLevel) -> bool {
+        self.changes
+            .iter()
+            .any(|c| c.level.severity_rank() >= level.severity_rank())
+            || self.overall.severity_rank() >= level.severity_rank()
+    }
+}
+
+/// One side of a compatibility comparison. `Missing`/`Malformed` both force
+/// the overall result to [`CompatibilityLevel::Unknown`] — the engine never
+/// guesses at a verdict from an incomplete spec.
+pub enum SpecSource {
+    /// Successfully parsed entries from a `contractspecv0` section.
+    Entries(Vec<ScSpecEntry>),
+    /// No contract spec section was present at all.
+    Missing,
+    /// A contract spec section was present but could not be parsed.
+    Malformed(String),
+}
+
+/// Optional network identity context (Stellar network passphrase) for each
+/// side, checked before the spec-level comparison runs.
+#[derive(Debug, Clone, Default)]
+pub struct NetworkContext {
+    pub passphrase: Option<String>,
+}
+
+fn type_str(t: &ScSpecTypeDef) -> String {
+    t.to_string()
+}
+
+fn union_case_key(case: &ScSpecUdtUnionCaseV0) -> &str {
+    match case {
+        ScSpecUdtUnionCaseV0::Void { name, .. } => name,
+        ScSpecUdtUnionCaseV0::Tuple { name, .. } => name,
+    }
+}
+
+fn union_case_types(case: &ScSpecUdtUnionCaseV0) -> Vec<ScSpecTypeDef> {
+    match case {
+        ScSpecUdtUnionCaseV0::Void { .. } => Vec::new(),
+        ScSpecUdtUnionCaseV0::Tuple { types, .. } => types.clone(),
+    }
+}
+
+/// Compare two parsed specs (already known to be present and well-formed)
+/// and return the list of detected changes. This never returns `Unknown`
+/// entries — callers are responsible for the missing/malformed short
+/// circuit in [`compare`].
+fn diff_entries(from: &[ScSpecEntry], to: &[ScSpecEntry]) -> Vec<Change> {
+    let mut changes = Vec::new();
+
+    diff_functions(from, to, &mut changes);
+    diff_structs(from, to, &mut changes);
+    diff_unions(from, to, &mut changes);
+    diff_enums(from, to, &mut changes);
+    diff_error_enums(from, to, &mut changes);
+    diff_events(from, to, &mut changes);
+
+    changes
+}
+
+fn index_by_name<'a, T>(
+    entries: &'a [ScSpecEntry],
+    select: impl Fn(&'a ScSpecEntry) -> Option<&'a T>,
+    name_of: impl Fn(&'a T) -> &'a str,
+) -> BTreeMap<&'a str, &'a T> {
+    entries
+        .iter()
+        .filter_map(|e| select(e))
+        .map(|item| (name_of(item), item))
+        .collect()
+}
+
+fn diff_functions(from: &[ScSpecEntry], to: &[ScSpecEntry], changes: &mut Vec<Change>) {
+    let a = index_by_name(
+        from,
+        |e| match e {
+            ScSpecEntry::FunctionV0(f) => Some(f),
+            _ => None,
+        },
+        |f| f.name.as_str(),
+    );
+    let b = index_by_name(
+        to,
+        |e| match e {
+            ScSpecEntry::FunctionV0(f) => Some(f),
+            _ => None,
+        },
+        |f| f.name.as_str(),
+    );
+
+    for (name, f) in &a {
+        match b.get(name) {
+            None => changes.push(Change {
+                category: ChangeCategory::Function,
+                level: CompatibilityLevel::Breaking,
+                subject: name.to_string(),
+                description: format!("Function `{name}` was removed"),
+            }),
+            Some(g) => {
+                if f.inputs.len() != g.inputs.len() {
+                    changes.push(Change {
+                        category: ChangeCategory::Function,
+                        level: CompatibilityLevel::Breaking,
+                        subject: name.to_string(),
+                        description: format!(
+                            "Function `{name}` parameter count changed ({} -> {})",
+                            f.inputs.len(),
+                            g.inputs.len()
+                        ),
+                    });
+                } else {
+                    for (i, (fi, gi)) in f.inputs.iter().zip(g.inputs.iter()).enumerate() {
+                        if fi.type_def != gi.type_def {
+                            changes.push(Change {
+                                category: ChangeCategory::Function,
+                                level: CompatibilityLevel::Breaking,
+                                subject: name.to_string(),
+                                description: format!(
+                                    "Function `{name}` parameter {i} type changed ({} -> {})",
+                                    type_str(&fi.type_def),
+                                    type_str(&gi.type_def)
+                                ),
+                            });
+                        } else if fi.name != gi.name {
+                            changes.push(Change {
+                                category: ChangeCategory::Function,
+                                level: CompatibilityLevel::PotentiallyBreaking,
+                                subject: name.to_string(),
+                                description: format!(
+                                    "Function `{name}` parameter {i} renamed (`{}` -> `{}`)",
+                                    fi.name, gi.name
+                                ),
+                            });
+                        }
+                    }
+                }
+
+                if f.outputs != g.outputs {
+                    changes.push(Change {
+                        category: ChangeCategory::Function,
+                        level: CompatibilityLevel::Breaking,
+                        subject: name.to_string(),
+                        description: format!(
+                            "Function `{name}` return type changed ({} -> {})",
+                            f.outputs
+                                .iter()
+                                .map(type_str)
+                                .collect::<Vec<_>>()
+                                .join(","),
+                            g.outputs
+                                .iter()
+                                .map(type_str)
+                                .collect::<Vec<_>>()
+                                .join(",")
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
+    for name in b.keys() {
+        if !a.contains_key(name) {
+            changes.push(Change {
+                category: ChangeCategory::Function,
+                level: CompatibilityLevel::Compatible,
+                subject: name.to_string(),
+                description: format!("Function `{name}` was added"),
+            });
+        }
+    }
+}
+
+fn diff_structs(from: &[ScSpecEntry], to: &[ScSpecEntry], changes: &mut Vec<Change>) {
+    let a = index_by_name(
+        from,
+        |e| match e {
+            ScSpecEntry::UdtStructV0(s) => Some(s),
+            _ => None,
+        },
+        |s| s.name.as_str(),
+    );
+    let b = index_by_name(
+        to,
+        |e| match e {
+            ScSpecEntry::UdtStructV0(s) => Some(s),
+            _ => None,
+        },
+        |s| s.name.as_str(),
+    );
+
+    for (name, s) in &a {
+        match b.get(name) {
+            None => changes.push(Change {
+                category: ChangeCategory::Type,
+                level: CompatibilityLevel::Breaking,
+                subject: name.to_string(),
+                description: format!("Struct `{name}` was removed"),
+            }),
+            Some(t) => {
+                let fa: BTreeMap<&str, &ScSpecTypeDef> = s
+                    .fields
+                    .iter()
+                    .map(|f| (f.name.as_str(), &f.type_def))
+                    .collect();
+                let fb: BTreeMap<&str, &ScSpecTypeDef> = t
+                    .fields
+                    .iter()
+                    .map(|f| (f.name.as_str(), &f.type_def))
+                    .collect();
+
+                for (fname, ftype) in &fa {
+                    match fb.get(fname) {
+                        None => changes.push(Change {
+                            category: ChangeCategory::Type,
+                            level: CompatibilityLevel::Breaking,
+                            subject: name.to_string(),
+                            description: format!("Struct `{name}` field `{fname}` was removed"),
+                        }),
+                        Some(other_type) => {
+                            if ftype != other_type {
+                                changes.push(Change {
+                                    category: ChangeCategory::Type,
+                                    level: CompatibilityLevel::Breaking,
+                                    subject: name.to_string(),
+                                    description: format!(
+                                        "Struct `{name}` field `{fname}` type changed ({} -> {})",
+                                        type_str(ftype),
+                                        type_str(other_type)
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+
+                for (fname, ftype) in &fb {
+                    if !fa.contains_key(fname) {
+                        let level = match ftype {
+                            ScSpecTypeDef::Option(_) => CompatibilityLevel::PotentiallyBreaking,
+                            _ => CompatibilityLevel::Breaking,
+                        };
+                        changes.push(Change {
+                            category: ChangeCategory::Type,
+                            level,
+                            subject: name.to_string(),
+                            description: format!(
+                                "Struct `{name}` field `{fname}` was added ({})",
+                                type_str(ftype)
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    for name in b.keys() {
+        if !a.contains_key(name) {
+            changes.push(Change {
+                category: ChangeCategory::Type,
+                level: CompatibilityLevel::Compatible,
+                subject: name.to_string(),
+                description: format!("Struct `{name}` was added"),
+            });
+        }
+    }
+}
+
+fn diff_unions(from: &[ScSpecEntry], to: &[ScSpecEntry], changes: &mut Vec<Change>) {
+    let a = index_by_name(
+        from,
+        |e| match e {
+            ScSpecEntry::UdtUnionV0(u) => Some(u),
+            _ => None,
+        },
+        |u| u.name.as_str(),
+    );
+    let b = index_by_name(
+        to,
+        |e| match e {
+            ScSpecEntry::UdtUnionV0(u) => Some(u),
+            _ => None,
+        },
+        |u| u.name.as_str(),
+    );
+
+    for (name, u) in &a {
+        match b.get(name) {
+            None => changes.push(Change {
+                category: ChangeCategory::Type,
+                level: CompatibilityLevel::Breaking,
+                subject: name.to_string(),
+                description: format!("Union `{name}` was removed"),
+            }),
+            Some(v) => {
+                let ca: BTreeMap<&str, Vec<ScSpecTypeDef>> = u
+                    .cases
+                    .iter()
+                    .map(|c| (union_case_key(c), union_case_types(c)))
+                    .collect();
+                let cb: BTreeMap<&str, Vec<ScSpecTypeDef>> = v
+                    .cases
+                    .iter()
+                    .map(|c| (union_case_key(c), union_case_types(c)))
+                    .collect();
+
+                for (case_name, types) in &ca {
+                    match cb.get(case_name) {
+                        None => changes.push(Change {
+                            category: ChangeCategory::Type,
+                            level: CompatibilityLevel::Breaking,
+                            subject: name.to_string(),
+                            description: format!(
+                                "Union `{name}` case `{case_name}` was removed"
+                            ),
+                        }),
+                        Some(other_types) => {
+                            if types != other_types {
+                                changes.push(Change {
+                                    category: ChangeCategory::Type,
+                                    level: CompatibilityLevel::Breaking,
+                                    subject: name.to_string(),
+                                    description: format!(
+                                        "Union `{name}` case `{case_name}` payload changed"
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+
+                for case_name in cb.keys() {
+                    if !ca.contains_key(case_name) {
+                        changes.push(Change {
+                            category: ChangeCategory::Type,
+                            level: CompatibilityLevel::PotentiallyBreaking,
+                            subject: name.to_string(),
+                            description: format!(
+                                "Union `{name}` case `{case_name}` was added \
+                                 (breaks exhaustive matches on consumers)"
+                            ),
+                        });
+                    }
+                }
+
+                // Discriminant order is part of the wire ABI.
+                let order_a: Vec<&str> = u.cases.iter().map(union_case_key).collect();
+                let order_b: Vec<&str> = v.cases.iter().map(union_case_key).collect();
+                let common_a: Vec<&&str> =
+                    order_a.iter().filter(|c| cb.contains_key(**c)).collect();
+                let common_b: Vec<&&str> =
+                    order_b.iter().filter(|c| ca.contains_key(**c)).collect();
+                if common_a != common_b {
+                    changes.push(Change {
+                        category: ChangeCategory::Type,
+                        level: CompatibilityLevel::Breaking,
+                        subject: name.to_string(),
+                        description: format!(
+                            "Union `{name}` case ordering (discriminant values) changed"
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
+    for name in b.keys() {
+        if !a.contains_key(name) {
+            changes.push(Change {
+                category: ChangeCategory::Type,
+                level: CompatibilityLevel::Compatible,
+                subject: name.to_string(),
+                description: format!("Union `{name}` was added"),
+            });
+        }
+    }
+}
+
+fn diff_enums(from: &[ScSpecEntry], to: &[ScSpecEntry], changes: &mut Vec<Change>) {
+    let a = index_by_name(
+        from,
+        |e| match e {
+            ScSpecEntry::UdtEnumV0(en) => Some(en),
+            _ => None,
+        },
+        |en| en.name.as_str(),
+    );
+    let b = index_by_name(
+        to,
+        |e| match e {
+            ScSpecEntry::UdtEnumV0(en) => Some(en),
+            _ => None,
+        },
+        |en| en.name.as_str(),
+    );
+
+    for (name, en) in &a {
+        match b.get(name) {
+            None => changes.push(Change {
+                category: ChangeCategory::Type,
+                level: CompatibilityLevel::Breaking,
+                subject: name.to_string(),
+                description: format!("Enum `{name}` was removed"),
+            }),
+            Some(other) => {
+                let ca: BTreeMap<&str, u32> =
+                    en.cases.iter().map(|c| (c.name.as_str(), c.value)).collect();
+                let cb: BTreeMap<&str, u32> = other
+                    .cases
+                    .iter()
+                    .map(|c| (c.name.as_str(), c.value))
+                    .collect();
+
+                for (case_name, value) in &ca {
+                    match cb.get(case_name) {
+                        None => changes.push(Change {
+                            category: ChangeCategory::Type,
+                            level: CompatibilityLevel::Breaking,
+                            subject: name.to_string(),
+                            description: format!("Enum `{name}` case `{case_name}` was removed"),
+                        }),
+                        Some(other_value) if other_value != value => changes.push(Change {
+                            category: ChangeCategory::Type,
+                            level: CompatibilityLevel::Breaking,
+                            subject: name.to_string(),
+                            description: format!(
+                                "Enum `{name}` case `{case_name}` value changed ({value} -> {other_value})"
+                            ),
+                        }),
+                        _ => {}
+                    }
+                }
+
+                for case_name in cb.keys() {
+                    if !ca.contains_key(case_name) {
+                        changes.push(Change {
+                            category: ChangeCategory::Type,
+                            level: CompatibilityLevel::PotentiallyBreaking,
+                            subject: name.to_string(),
+                            description: format!("Enum `{name}` case `{case_name}` was added"),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    for name in b.keys() {
+        if !a.contains_key(name) {
+            changes.push(Change {
+                category: ChangeCategory::Type,
+                level: CompatibilityLevel::Compatible,
+                subject: name.to_string(),
+                description: format!("Enum `{name}` was added"),
+            });
+        }
+    }
+}
+
+fn diff_error_enums(from: &[ScSpecEntry], to: &[ScSpecEntry], changes: &mut Vec<Change>) {
+    let a = index_by_name(
+        from,
+        |e| match e {
+            ScSpecEntry::UdtErrorEnumV0(en) => Some(en),
+            _ => None,
+        },
+        |en| en.name.as_str(),
+    );
+    let b = index_by_name(
+        to,
+        |e| match e {
+            ScSpecEntry::UdtErrorEnumV0(en) => Some(en),
+            _ => None,
+        },
+        |en| en.name.as_str(),
+    );
+
+    for (name, en) in &a {
+        match b.get(name) {
+            None => changes.push(Change {
+                category: ChangeCategory::Error,
+                level: CompatibilityLevel::PotentiallyBreaking,
+                subject: name.to_string(),
+                description: format!("Error enum `{name}` was removed"),
+            }),
+            Some(other) => {
+                let ca: BTreeMap<&str, u32> =
+                    en.cases.iter().map(|c| (c.name.as_str(), c.value)).collect();
+                let cb: BTreeMap<&str, u32> = other
+                    .cases
+                    .iter()
+                    .map(|c| (c.name.as_str(), c.value))
+                    .collect();
+
+                for (case_name, value) in &ca {
+                    match cb.get(case_name) {
+                        None => changes.push(Change {
+                            category: ChangeCategory::Error,
+                            level: CompatibilityLevel::PotentiallyBreaking,
+                            subject: name.to_string(),
+                            description: format!(
+                                "Error `{name}::{case_name}` was removed or renamed"
+                            ),
+                        }),
+                        Some(other_value) if other_value != value => changes.push(Change {
+                            category: ChangeCategory::Error,
+                            level: CompatibilityLevel::PotentiallyBreaking,
+                            subject: name.to_string(),
+                            description: format!(
+                                "Error `{name}::{case_name}` code changed ({value} -> {other_value})"
+                            ),
+                        }),
+                        _ => {}
+                    }
+                }
+
+                for case_name in cb.keys() {
+                    if !ca.contains_key(case_name) {
+                        changes.push(Change {
+                            category: ChangeCategory::Error,
+                            level: CompatibilityLevel::Compatible,
+                            subject: name.to_string(),
+                            description: format!("Error `{name}::{case_name}` was added"),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    for name in b.keys() {
+        if !a.contains_key(name) {
+            changes.push(Change {
+                category: ChangeCategory::Error,
+                level: CompatibilityLevel::Compatible,
+                subject: name.to_string(),
+                description: format!("Error enum `{name}` was added"),
+            });
+        }
+    }
+}
+
+fn diff_events(from: &[ScSpecEntry], to: &[ScSpecEntry], changes: &mut Vec<Change>) {
+    let a = index_by_name(
+        from,
+        |e| match e {
+            ScSpecEntry::EventV0(ev) => Some(ev),
+            _ => None,
+        },
+        |ev| ev.name.as_str(),
+    );
+    let b = index_by_name(
+        to,
+        |e| match e {
+            ScSpecEntry::EventV0(ev) => Some(ev),
+            _ => None,
+        },
+        |ev| ev.name.as_str(),
+    );
+
+    for (name, ev) in &a {
+        match b.get(name) {
+            None => changes.push(Change {
+                category: ChangeCategory::Event,
+                level: CompatibilityLevel::PotentiallyBreaking,
+                subject: name.to_string(),
+                description: format!("Event `{name}` was removed (breaking for indexers)"),
+            }),
+            Some(other) => {
+                if ev.data_format != other.data_format || ev.prefix_topics != other.prefix_topics
+                {
+                    changes.push(Change {
+                        category: ChangeCategory::Event,
+                        level: CompatibilityLevel::Breaking,
+                        subject: name.to_string(),
+                        description: format!(
+                            "Event `{name}` topic layout or data format changed"
+                        ),
+                    });
+                } else {
+                    let pa: Vec<(&str, String)> = ev
+                        .params
+                        .iter()
+                        .map(|p| (p.name.as_str(), type_str(&p.type_def)))
+                        .collect();
+                    let pb: Vec<(&str, String)> = other
+                        .params
+                        .iter()
+                        .map(|p| (p.name.as_str(), type_str(&p.type_def)))
+                        .collect();
+                    if pa != pb {
+                        changes.push(Change {
+                            category: ChangeCategory::Event,
+                            level: CompatibilityLevel::Breaking,
+                            subject: name.to_string(),
+                            description: format!("Event `{name}` payload shape changed"),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    for name in b.keys() {
+        if !a.contains_key(name) {
+            changes.push(Change {
+                category: ChangeCategory::Event,
+                level: CompatibilityLevel::Compatible,
+                subject: name.to_string(),
+                description: format!("Event `{name}` was added"),
+            });
+        }
+    }
+}
+
+/// Compare two contract specs plus optional network identity context.
+///
+/// Returns [`CompatibilityLevel::Unknown`] as soon as either side is
+/// missing or malformed, per the acceptance criterion that an incomplete
+/// source spec must never silently produce a compatible/breaking verdict.
+pub fn compare(
+    from: &SpecSource,
+    to: &SpecSource,
+    from_network: &NetworkContext,
+    to_network: &NetworkContext,
+) -> CompatibilityReport {
+    let (from_entries, to_entries) = match (from, to) {
+        (SpecSource::Entries(a), SpecSource::Entries(b)) => (a, b),
+        (SpecSource::Missing, _) | (_, SpecSource::Missing) => {
+            return CompatibilityReport::unknown(
+                "One or both contract specs are missing (no contractspecv0 section); \
+                 compatibility cannot be determined.",
+            );
+        }
+        (SpecSource::Malformed(reason), _) | (_, SpecSource::Malformed(reason)) => {
+            return CompatibilityReport::unknown(&format!(
+                "One or both contract specs are malformed and could not be parsed: {reason}"
+            ));
+        }
+    };
+
+    let mut changes = Vec::new();
+
+    if let (Some(a), Some(b)) = (&from_network.passphrase, &to_network.passphrase) {
+        if a != b {
+            changes.push(Change {
+                category: ChangeCategory::Network,
+                level: CompatibilityLevel::Breaking,
+                subject: "network".to_string(),
+                description: format!(
+                    "Network passphrase differs ({a} vs {b}); these are not the same \
+                     deployment context and must not be compared as compatible."
+                ),
+            });
+        }
+    }
+
+    changes.extend(diff_entries(from_entries, to_entries));
+
+    let overall = changes
+        .iter()
+        .fold(CompatibilityLevel::Compatible, |acc, c| acc.max(c.level));
+
+    CompatibilityReport {
+        algorithm: ALGORITHM.to_string(),
+        overall,
+        changes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract_spec::{ScSpecFunctionInputV0, ScSpecFunctionV0};
+
+    fn func(name: &str, inputs: Vec<(&str, ScSpecTypeDef)>, outputs: Vec<ScSpecTypeDef>) -> ScSpecEntry {
+        ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+            doc: "".into(),
+            name: name.into(),
+            inputs: inputs
+                .into_iter()
+                .map(|(n, t)| ScSpecFunctionInputV0 {
+                    doc: "".into(),
+                    name: n.into(),
+                    type_def: t,
+                })
+                .collect(),
+            outputs,
+        })
+    }
+
+    fn net() -> NetworkContext {
+        NetworkContext::default()
+    }
+
+    #[test]
+    fn identical_specs_are_compatible() {
+        let a = vec![func("f", vec![], vec![])];
+        let b = vec![func("f", vec![], vec![])];
+        let report = compare(
+            &SpecSource::Entries(a),
+            &SpecSource::Entries(b),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::Compatible);
+        assert!(report.changes.is_empty());
+    }
+
+    #[test]
+    fn adding_a_function_is_compatible() {
+        let a = vec![func("f", vec![], vec![])];
+        let b = vec![func("f", vec![], vec![]), func("g", vec![], vec![])];
+        let report = compare(
+            &SpecSource::Entries(a),
+            &SpecSource::Entries(b),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::Compatible);
+    }
+
+    #[test]
+    fn removing_a_function_is_breaking() {
+        let a = vec![func("f", vec![], vec![]), func("g", vec![], vec![])];
+        let b = vec![func("f", vec![], vec![])];
+        let report = compare(
+            &SpecSource::Entries(a),
+            &SpecSource::Entries(b),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::Breaking);
+    }
+
+    #[test]
+    fn reordering_parameters_is_breaking() {
+        let a = vec![func(
+            "f",
+            vec![("x", ScSpecTypeDef::U32), ("y", ScSpecTypeDef::U64)],
+            vec![],
+        )];
+        let b = vec![func(
+            "f",
+            vec![("y", ScSpecTypeDef::U64), ("x", ScSpecTypeDef::U32)],
+            vec![],
+        )];
+        let report = compare(
+            &SpecSource::Entries(a),
+            &SpecSource::Entries(b),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::Breaking);
+    }
+
+    #[test]
+    fn changing_a_parameter_type_is_breaking() {
+        let a = vec![func("f", vec![("x", ScSpecTypeDef::U32)], vec![])];
+        let b = vec![func("f", vec![("x", ScSpecTypeDef::U64)], vec![])];
+        let report = compare(
+            &SpecSource::Entries(a),
+            &SpecSource::Entries(b),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::Breaking);
+    }
+
+    #[test]
+    fn missing_source_spec_is_unknown_not_breaking() {
+        let report = compare(
+            &SpecSource::Missing,
+            &SpecSource::Entries(vec![func("f", vec![], vec![])]),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::Unknown);
+    }
+
+    #[test]
+    fn malformed_spec_is_unknown() {
+        let report = compare(
+            &SpecSource::Malformed("truncated".into()),
+            &SpecSource::Entries(vec![]),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::Unknown);
+    }
+
+    #[test]
+    fn different_network_passphrase_is_breaking() {
+        let a = vec![func("f", vec![], vec![])];
+        let b = vec![func("f", vec![], vec![])];
+        let from_net = NetworkContext {
+            passphrase: Some("Public Global Stellar Network ; September 2015".into()),
+        };
+        let to_net = NetworkContext {
+            passphrase: Some("Test SDF Network ; September 2015".into()),
+        };
+        let report = compare(&SpecSource::Entries(a), &SpecSource::Entries(b), &from_net, &to_net);
+        assert_eq!(report.overall, CompatibilityLevel::Breaking);
+        assert!(report
+            .changes
+            .iter()
+            .any(|c| c.category == ChangeCategory::Network));
+    }
+
+    #[test]
+    fn identical_network_passphrase_does_not_flag() {
+        let from_net = NetworkContext {
+            passphrase: Some("Test SDF Network ; September 2015".into()),
+        };
+        let to_net = from_net.clone();
+        let report = compare(
+            &SpecSource::Entries(vec![]),
+            &SpecSource::Entries(vec![]),
+            &from_net,
+            &to_net,
+        );
+        assert_eq!(report.overall, CompatibilityLevel::Compatible);
+    }
+
+    #[test]
+    fn adding_required_struct_field_is_breaking_but_optional_is_potentially_breaking() {
+        use crate::contract_spec::{ScSpecUdtStructFieldV0, ScSpecUdtStructV0};
+
+        let make = |fields: Vec<ScSpecUdtStructFieldV0>| {
+            ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
+                doc: "".into(),
+                lib: "".into(),
+                name: "Position".into(),
+                fields,
+            })
+        };
+
+        let a = vec![make(vec![])];
+        let required = vec![make(vec![ScSpecUdtStructFieldV0 {
+            doc: "".into(),
+            name: "amount".into(),
+            type_def: ScSpecTypeDef::I64,
+        }])];
+        let optional = vec![make(vec![ScSpecUdtStructFieldV0 {
+            doc: "".into(),
+            name: "amount".into(),
+            type_def: ScSpecTypeDef::Option(Box::new(ScSpecTypeDef::I64)),
+        }])];
+
+        let report_required = compare(
+            &SpecSource::Entries(a.clone()),
+            &SpecSource::Entries(required),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report_required.overall, CompatibilityLevel::Breaking);
+
+        let report_optional = compare(
+            &SpecSource::Entries(a),
+            &SpecSource::Entries(optional),
+            &net(),
+            &net(),
+        );
+        assert_eq!(
+            report_optional.overall,
+            CompatibilityLevel::PotentiallyBreaking
+        );
+    }
+
+    #[test]
+    fn removing_an_event_is_potentially_breaking() {
+        use crate::contract_spec::{ScSpecEventDataFormat, ScSpecEventV0};
+
+        let ev = ScSpecEntry::EventV0(ScSpecEventV0 {
+            doc: "".into(),
+            lib: "".into(),
+            name: "transfer".into(),
+            prefix_topics: vec![],
+            params: vec![],
+            data_format: ScSpecEventDataFormat::SingleValue,
+        });
+        let report = compare(
+            &SpecSource::Entries(vec![ev]),
+            &SpecSource::Entries(vec![]),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::PotentiallyBreaking);
+    }
+
+    #[test]
+    fn changing_an_error_code_is_potentially_breaking() {
+        use crate::contract_spec::{ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0};
+
+        let make = |value: u32| {
+            ScSpecEntry::UdtErrorEnumV0(ScSpecUdtErrorEnumV0 {
+                doc: "".into(),
+                lib: "".into(),
+                name: "Error".into(),
+                cases: vec![ScSpecUdtErrorEnumCaseV0 {
+                    doc: "".into(),
+                    name: "NotFound".into(),
+                    value,
+                }],
+            })
+        };
+
+        let report = compare(
+            &SpecSource::Entries(vec![make(1)]),
+            &SpecSource::Entries(vec![make(2)]),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::PotentiallyBreaking);
+    }
+}

--- a/backend/shared/src/contract_compatibility.rs
+++ b/backend/shared/src/contract_compatibility.rs
@@ -12,7 +12,9 @@
 //! `breaking` verdict by accident. Any comparison built from a missing or
 //! malformed side short-circuits to [`CompatibilityLevel::Unknown`].
 
-use crate::contract_spec::{ScSpecEntry, ScSpecTypeDef, ScSpecUdtUnionCaseV0};
+use crate::contract_spec::{
+    ScSpecEntry, ScSpecEventParamLocationV0, ScSpecTypeDef, ScSpecUdtUnionCaseV0,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -90,11 +92,36 @@ impl CompatibilityReport {
         }
     }
 
-    pub fn has_at_least(&self, level: CompatibilityLevel) -> bool {
-        self.changes
-            .iter()
-            .any(|c| c.level.severity_rank() >= level.severity_rank())
-            || self.overall.severity_rank() >= level.severity_rank()
+    /// True if any change (or the overall verdict) meets or exceeds
+    /// `threshold` under `--fail-on` semantics.
+    ///
+    /// This is deliberately *not* `level.severity_rank() >= threshold.severity_rank()`:
+    /// `severity_rank` exists to make `Unknown` dominate when combining levels
+    /// into an overall verdict (so incomplete data is never masked), but for a
+    /// `--fail-on` gate the intent is cumulative inclusion in the documented
+    /// order `breaking | potential | unknown` — `--fail-on unknown` must catch
+    /// breaking and potentially-breaking changes too, not just literal
+    /// `Unknown` results. Reusing `severity_rank` here previously made
+    /// `--fail-on unknown` the *narrowest* threshold instead of the broadest.
+    pub fn has_at_least(&self, threshold: CompatibilityLevel) -> bool {
+        let matches = |level: CompatibilityLevel| -> bool {
+            match threshold {
+                CompatibilityLevel::Breaking => level == CompatibilityLevel::Breaking,
+                CompatibilityLevel::PotentiallyBreaking => matches!(
+                    level,
+                    CompatibilityLevel::Breaking | CompatibilityLevel::PotentiallyBreaking
+                ),
+                CompatibilityLevel::Unknown => matches!(
+                    level,
+                    CompatibilityLevel::Breaking
+                        | CompatibilityLevel::PotentiallyBreaking
+                        | CompatibilityLevel::Unknown
+                ),
+                CompatibilityLevel::Compatible => true,
+            }
+        };
+
+        self.changes.iter().any(|c| matches(c.level)) || matches(self.overall)
     }
 }
 
@@ -215,7 +242,8 @@ fn diff_functions(from: &[ScSpecEntry], to: &[ScSpecEntry], changes: &mut Vec<Ch
                                     type_str(&gi.type_def)
                                 ),
                             });
-                        } else if fi.name != gi.name {
+                        }
+                        if fi.name != gi.name {
                             changes.push(Change {
                                 category: ChangeCategory::Function,
                                 level: CompatibilityLevel::PotentiallyBreaking,
@@ -613,9 +641,12 @@ fn diff_error_enums(from: &[ScSpecEntry], to: &[ScSpecEntry], changes: &mut Vec<
                     if !ca.contains_key(case_name) {
                         changes.push(Change {
                             category: ChangeCategory::Error,
-                            level: CompatibilityLevel::Compatible,
+                            level: CompatibilityLevel::PotentiallyBreaking,
                             subject: name.to_string(),
-                            description: format!("Error `{name}::{case_name}` was added"),
+                            description: format!(
+                                "Error `{name}::{case_name}` was added \
+                                 (breaks exhaustive matches on consumers)"
+                            ),
                         });
                     }
                 }
@@ -673,15 +704,15 @@ fn diff_events(from: &[ScSpecEntry], to: &[ScSpecEntry], changes: &mut Vec<Chang
                         ),
                     });
                 } else {
-                    let pa: Vec<(&str, String)> = ev
+                    let pa: Vec<(&str, String, ScSpecEventParamLocationV0)> = ev
                         .params
                         .iter()
-                        .map(|p| (p.name.as_str(), type_str(&p.type_def)))
+                        .map(|p| (p.name.as_str(), type_str(&p.type_def), p.location))
                         .collect();
-                    let pb: Vec<(&str, String)> = other
+                    let pb: Vec<(&str, String, ScSpecEventParamLocationV0)> = other
                         .params
                         .iter()
-                        .map(|p| (p.name.as_str(), type_str(&p.type_def)))
+                        .map(|p| (p.name.as_str(), type_str(&p.type_def), p.location))
                         .collect();
                     if pa != pb {
                         changes.push(Change {
@@ -1007,5 +1038,130 @@ mod tests {
             &net(),
         );
         assert_eq!(report.overall, CompatibilityLevel::PotentiallyBreaking);
+    }
+
+    #[test]
+    fn fail_on_unknown_still_catches_breaking_changes() {
+        // Regression: --fail-on unknown must be the *most* inclusive
+        // threshold (breaking ⊂ potential ⊂ unknown), not the narrowest.
+        let a = vec![func("f", vec![], vec![]), func("g", vec![], vec![])];
+        let b = vec![func("f", vec![], vec![])]; // `g` removed: Breaking
+        let report = compare(
+            &SpecSource::Entries(a),
+            &SpecSource::Entries(b),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::Breaking);
+        assert!(report.has_at_least(CompatibilityLevel::Unknown));
+        assert!(report.has_at_least(CompatibilityLevel::PotentiallyBreaking));
+        assert!(report.has_at_least(CompatibilityLevel::Breaking));
+    }
+
+    #[test]
+    fn fail_on_breaking_does_not_trigger_on_potentially_breaking() {
+        use crate::contract_spec::{ScSpecUdtEnumCaseV0, ScSpecUdtEnumV0};
+
+        let make = |cases: Vec<ScSpecUdtEnumCaseV0>| {
+            ScSpecEntry::UdtEnumV0(ScSpecUdtEnumV0 {
+                doc: "".into(),
+                lib: "".into(),
+                name: "Kind".into(),
+                cases,
+            })
+        };
+        let a = vec![make(vec![])];
+        let b = vec![make(vec![ScSpecUdtEnumCaseV0 {
+            doc: "".into(),
+            name: "New".into(),
+            value: 0,
+        }])];
+        let report = compare(
+            &SpecSource::Entries(a),
+            &SpecSource::Entries(b),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::PotentiallyBreaking);
+        assert!(!report.has_at_least(CompatibilityLevel::Breaking));
+        assert!(report.has_at_least(CompatibilityLevel::PotentiallyBreaking));
+    }
+
+    #[test]
+    fn event_param_location_change_is_detected() {
+        use crate::contract_spec::{
+            ScSpecEventDataFormat, ScSpecEventParamLocationV0, ScSpecEventParamV0, ScSpecEventV0,
+        };
+
+        let make = |location: ScSpecEventParamLocationV0| {
+            ScSpecEntry::EventV0(ScSpecEventV0 {
+                doc: "".into(),
+                lib: "".into(),
+                name: "transfer".into(),
+                prefix_topics: vec![],
+                params: vec![ScSpecEventParamV0 {
+                    doc: "".into(),
+                    name: "from".into(),
+                    type_def: ScSpecTypeDef::Address,
+                    location,
+                }],
+                data_format: ScSpecEventDataFormat::SingleValue,
+            })
+        };
+
+        let report = compare(
+            &SpecSource::Entries(vec![make(ScSpecEventParamLocationV0::Data)]),
+            &SpecSource::Entries(vec![make(ScSpecEventParamLocationV0::TopicList)]),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::Breaking);
+    }
+
+    #[test]
+    fn adding_an_error_case_is_potentially_breaking_like_enum_case_addition() {
+        use crate::contract_spec::{ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0};
+
+        let make = |cases: Vec<ScSpecUdtErrorEnumCaseV0>| {
+            ScSpecEntry::UdtErrorEnumV0(ScSpecUdtErrorEnumV0 {
+                doc: "".into(),
+                lib: "".into(),
+                name: "Error".into(),
+                cases,
+            })
+        };
+        let a = vec![make(vec![])];
+        let b = vec![make(vec![ScSpecUdtErrorEnumCaseV0 {
+            doc: "".into(),
+            name: "NotFound".into(),
+            value: 1,
+        }])];
+        let report = compare(
+            &SpecSource::Entries(a),
+            &SpecSource::Entries(b),
+            &net(),
+            &net(),
+        );
+        assert_eq!(report.overall, CompatibilityLevel::PotentiallyBreaking);
+    }
+
+    #[test]
+    fn parameter_rename_and_retype_both_reported() {
+        let a = vec![func("f", vec![("old_name", ScSpecTypeDef::U32)], vec![])];
+        let b = vec![func("f", vec![("new_name", ScSpecTypeDef::U64)], vec![])];
+        let report = compare(
+            &SpecSource::Entries(a),
+            &SpecSource::Entries(b),
+            &net(),
+            &net(),
+        );
+        assert!(report
+            .changes
+            .iter()
+            .any(|c| c.description.contains("type changed")));
+        assert!(report
+            .changes
+            .iter()
+            .any(|c| c.description.contains("renamed")));
     }
 }

--- a/backend/shared/src/contract_spec.rs
+++ b/backend/shared/src/contract_spec.rs
@@ -222,6 +222,7 @@ pub enum SpecParseError {
     InvalidDiscriminant { at: usize, value: i32 },
     InvalidUtf8 { at: usize },
     TrailingBytes { at: usize },
+    TypeNestingTooDeep { at: usize },
 }
 
 impl fmt::Display for SpecParseError {
@@ -240,20 +241,35 @@ impl fmt::Display for SpecParseError {
             SpecParseError::TrailingBytes { at } => {
                 write!(f, "trailing unparsed bytes starting at {at}")
             }
+            SpecParseError::TypeNestingTooDeep { at } => write!(
+                f,
+                "type nesting exceeds maximum depth of {MAX_TYPE_DEPTH} at byte {at}"
+            ),
         }
     }
 }
 
 impl std::error::Error for SpecParseError {}
 
+/// Upper bound on `ScSpecTypeDef` nesting (`Option<Option<...>>`, etc.).
+/// Real Soroban contract specs nest a handful of levels deep at most; this
+/// exists purely to bound recursion against a crafted/corrupted section, not
+/// to constrain legitimate specs.
+const MAX_TYPE_DEPTH: usize = 32;
+
 struct Cursor<'a> {
     bytes: &'a [u8],
     pos: usize,
+    type_depth: usize,
 }
 
 impl<'a> Cursor<'a> {
     fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes, pos: 0 }
+        Self {
+            bytes,
+            pos: 0,
+            type_depth: 0,
+        }
     }
 
     fn remaining(&self) -> usize {
@@ -311,6 +327,16 @@ impl<'a> Cursor<'a> {
 
     fn read_type_def(&mut self) -> Result<ScSpecTypeDef, SpecParseError> {
         let at = self.pos;
+        if self.type_depth >= MAX_TYPE_DEPTH {
+            return Err(SpecParseError::TypeNestingTooDeep { at });
+        }
+        self.type_depth += 1;
+        let result = self.read_type_def_inner(at);
+        self.type_depth -= 1;
+        result
+    }
+
+    fn read_type_def_inner(&mut self, at: usize) -> Result<ScSpecTypeDef, SpecParseError> {
         let disc = self.read_i32()?;
         let ty = match disc {
             0 => ScSpecTypeDef::Val,
@@ -807,5 +833,45 @@ mod tests {
     fn empty_section_yields_no_entries() {
         let entries = parse_contract_spec(&[]).unwrap();
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn deeply_nested_option_type_is_rejected_not_stack_overflowed() {
+        let mut e = Encoder::new();
+        e.i32(0); // SC_SPEC_ENTRY_FUNCTION_V0
+        e.string("");
+        e.string("f");
+        e.u32(1); // inputs count
+        e.string("");
+        e.string("x");
+        // Nest far past MAX_TYPE_DEPTH consecutive Option wrappers with no
+        // terminal scalar; this would recurse unboundedly without the guard.
+        for _ in 0..(MAX_TYPE_DEPTH + 100) {
+            e.i32(1000); // Option
+        }
+        let bytes = e.finish();
+
+        let err = parse_contract_spec(&bytes).unwrap_err();
+        assert!(matches!(err, SpecParseError::TypeNestingTooDeep { .. }));
+    }
+
+    #[test]
+    fn moderately_nested_types_still_parse_successfully() {
+        let mut e = Encoder::new();
+        e.i32(0);
+        e.string("");
+        e.string("f");
+        e.u32(1);
+        e.string("");
+        e.string("x");
+        for _ in 0..5 {
+            e.i32(1000); // Option
+        }
+        e.type_scalar(4); // terminal U32
+        e.u32(0);
+        let bytes = e.finish();
+
+        let entries = parse_contract_spec(&bytes).unwrap();
+        assert_eq!(entries.len(), 1);
     }
 }

--- a/backend/shared/src/lib.rs
+++ b/backend/shared/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod abi;
+pub mod contract_compatibility;
 pub mod contract_spec;
 pub mod error;
 pub mod interface_fingerprint;

--- a/cli/src/contract_compatibility.rs
+++ b/cli/src/contract_compatibility.rs
@@ -45,7 +45,7 @@ impl FailOn {
     }
 }
 
-fn load_spec(wasm_path: &str) -> Result<(SpecSource, NetworkContext)> {
+fn load_spec(wasm_path: &str) -> Result<SpecSource> {
     let path = std::path::Path::new(wasm_path);
     if !path.exists() {
         anyhow::bail!("WASM file not found: {}", wasm_path);
@@ -56,17 +56,13 @@ fn load_spec(wasm_path: &str) -> Result<(SpecSource, NetworkContext)> {
         anyhow::bail!("WASM file is empty: {}", wasm_path);
     }
 
-    let validation = shared::wasm::validate_wasm(&bytes);
-    if !validation.has_contract_spec {
-        return Ok((SpecSource::Missing, NetworkContext::default()));
-    }
-
-    let spec_bytes = shared::wasm::extract_contract_spec_bytes(&bytes)
-        .expect("has_contract_spec is true, so the section must be extractable");
+    let Some(spec_bytes) = shared::wasm::extract_contract_spec_bytes(&bytes) else {
+        return Ok(SpecSource::Missing);
+    };
 
     match shared::contract_spec::parse_contract_spec(&spec_bytes) {
-        Ok(entries) => Ok((SpecSource::Entries(entries), NetworkContext::default())),
-        Err(e) => Ok((SpecSource::Malformed(e.to_string()), NetworkContext::default())),
+        Ok(entries) => Ok(SpecSource::Entries(entries)),
+        Err(e) => Ok(SpecSource::Malformed(e.to_string())),
     }
 }
 
@@ -90,8 +86,8 @@ pub async fn run(
         fail_on
     );
 
-    let (from_spec, _) = load_spec(from_wasm)?;
-    let (to_spec, _) = load_spec(to_wasm)?;
+    let from_spec = load_spec(from_wasm)?;
+    let to_spec = load_spec(to_wasm)?;
     let from_net = NetworkContext {
         passphrase: from_network_passphrase,
     };

--- a/cli/src/contract_compatibility.rs
+++ b/cli/src/contract_compatibility.rs
@@ -1,0 +1,163 @@
+//! contract_compatibility.rs — `soroban-registry contract compatibility` (#1143)
+//!
+//! Structurally compares the `contractspecv0` specs of two local compiled
+//! WASM artifacts and classifies the differences as compatible,
+//! potentially breaking, breaking, or unknown, using the shared engine in
+//! `shared::contract_compatibility` (built on the #1139 spec parser so both
+//! features stay consistent).
+//!
+//! This runs entirely offline against local artifacts, matching the
+//! `contract verify --wasm` / `contract interfaces --wasm` precedent — the
+//! registry does not yet expose a `--from`/`--to` version lookup endpoint.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use shared::contract_compatibility::{
+    compare, ChangeCategory, CompatibilityLevel, CompatibilityReport, NetworkContext, SpecSource,
+};
+
+/// `--fail-on` threshold for `--strict` exit-code behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailOn {
+    Breaking,
+    Potential,
+    Unknown,
+}
+
+impl FailOn {
+    pub fn parse(raw: &str) -> Result<Self> {
+        match raw {
+            "breaking" => Ok(FailOn::Breaking),
+            "potential" | "potentially_breaking" => Ok(FailOn::Potential),
+            "unknown" => Ok(FailOn::Unknown),
+            other => anyhow::bail!(
+                "Invalid --fail-on value '{other}': expected one of breaking, potential, unknown"
+            ),
+        }
+    }
+
+    fn threshold(self) -> CompatibilityLevel {
+        match self {
+            FailOn::Breaking => CompatibilityLevel::Breaking,
+            FailOn::Potential => CompatibilityLevel::PotentiallyBreaking,
+            FailOn::Unknown => CompatibilityLevel::Unknown,
+        }
+    }
+}
+
+fn load_spec(wasm_path: &str) -> Result<(SpecSource, NetworkContext)> {
+    let path = std::path::Path::new(wasm_path);
+    if !path.exists() {
+        anyhow::bail!("WASM file not found: {}", wasm_path);
+    }
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("Failed to read WASM file at {}", wasm_path))?;
+    if bytes.is_empty() {
+        anyhow::bail!("WASM file is empty: {}", wasm_path);
+    }
+
+    let validation = shared::wasm::validate_wasm(&bytes);
+    if !validation.has_contract_spec {
+        return Ok((SpecSource::Missing, NetworkContext::default()));
+    }
+
+    let spec_bytes = shared::wasm::extract_contract_spec_bytes(&bytes)
+        .expect("has_contract_spec is true, so the section must be extractable");
+
+    match shared::contract_spec::parse_contract_spec(&spec_bytes) {
+        Ok(entries) => Ok((SpecSource::Entries(entries), NetworkContext::default())),
+        Err(e) => Ok((SpecSource::Malformed(e.to_string()), NetworkContext::default())),
+    }
+}
+
+/// `soroban-registry contract compatibility --from <wasm> --to <wasm> [--strict] [--json] [--fail-on <level>] [--from-network-passphrase <p>] [--to-network-passphrase <p>]`
+#[allow(clippy::too_many_arguments)]
+pub async fn run(
+    from_wasm: &str,
+    to_wasm: &str,
+    from_network_passphrase: Option<String>,
+    to_network_passphrase: Option<String>,
+    strict: bool,
+    json: bool,
+    fail_on: FailOn,
+) -> Result<()> {
+    log::debug!(
+        "contract compatibility | from={} to={} strict={} json={} fail_on={:?}",
+        from_wasm,
+        to_wasm,
+        strict,
+        json,
+        fail_on
+    );
+
+    let (from_spec, _) = load_spec(from_wasm)?;
+    let (to_spec, _) = load_spec(to_wasm)?;
+    let from_net = NetworkContext {
+        passphrase: from_network_passphrase,
+    };
+    let to_net = NetworkContext {
+        passphrase: to_network_passphrase,
+    };
+
+    let report = compare(&from_spec, &to_spec, &from_net, &to_net);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human(from_wasm, to_wasm, &report);
+    }
+
+    if strict && report.has_at_least(fail_on.threshold()) {
+        anyhow::bail!(
+            "Compatibility check found changes at or above '{:?}' (strict mode enabled)",
+            fail_on.threshold()
+        );
+    }
+
+    Ok(())
+}
+
+fn level_label(level: CompatibilityLevel) -> colored::ColoredString {
+    match level {
+        CompatibilityLevel::Compatible => "compatible".green().bold(),
+        CompatibilityLevel::PotentiallyBreaking => "potentially_breaking".yellow().bold(),
+        CompatibilityLevel::Breaking => "breaking".red().bold(),
+        CompatibilityLevel::Unknown => "unknown".bright_black().bold(),
+    }
+}
+
+fn category_label(category: ChangeCategory) -> &'static str {
+    match category {
+        ChangeCategory::Function => "function",
+        ChangeCategory::Type => "type",
+        ChangeCategory::Event => "event",
+        ChangeCategory::Error => "error",
+        ChangeCategory::Network => "network",
+    }
+}
+
+fn print_human(from_wasm: &str, to_wasm: &str, report: &CompatibilityReport) {
+    println!("\n{}", "Contract Compatibility".bold().cyan());
+    println!("{}", "=".repeat(80).cyan());
+    println!("{:<10}{}", "From:".bold(), from_wasm);
+    println!("{:<10}{}", "To:".bold(), to_wasm);
+    println!("{:<10}{}", "Algorithm:".bold(), report.algorithm);
+    println!("{:<10}{}", "Overall:".bold(), level_label(report.overall));
+
+    if report.changes.is_empty() {
+        println!("\n{}", "No differences detected.".green());
+        return;
+    }
+
+    println!("\n{}", "Changes:".bold().underline());
+    for change in &report.changes {
+        println!(
+            "  {} [{}] {} — {}",
+            "•".cyan(),
+            category_label(change.category),
+            level_label(change.level),
+            change.description
+        );
+    }
+    println!();
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,6 +30,7 @@ mod contract_deploy;
 mod contract_deprecate;
 mod contract_snapshot;
 mod contract_highlight;
+mod contract_compatibility;
 mod contract_interaction;
 mod contract_interfaces;
 mod contract_register;
@@ -1992,6 +1993,43 @@ pub enum ContractCommands {
         /// Path to a local compiled WASM contract to inspect.
         #[arg(long)]
         wasm: String,
+
+        /// Output results as machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Structurally compare two local compiled WASM artifacts and classify
+    /// ABI changes as compatible, potentially breaking, breaking, or
+    /// unknown.
+    ///
+    /// Usage: soroban-registry contract compatibility --from <wasm> --to <wasm> [--strict] [--json] [--fail-on <level>]
+    Compatibility {
+        /// Path to the earlier/baseline compiled WASM contract.
+        #[arg(long)]
+        from: String,
+
+        /// Path to the newer/candidate compiled WASM contract.
+        #[arg(long)]
+        to: String,
+
+        /// Network passphrase associated with the `--from` artifact.
+        #[arg(long)]
+        from_network_passphrase: Option<String>,
+
+        /// Network passphrase associated with the `--to` artifact.
+        #[arg(long)]
+        to_network_passphrase: Option<String>,
+
+        /// Exit non-zero when changes at or above the --fail-on threshold
+        /// are found (default threshold: potentially_breaking).
+        #[arg(long)]
+        strict: bool,
+
+        /// Minimum severity that triggers a non-zero exit under --strict:
+        /// breaking | potential | unknown
+        #[arg(long, default_value = "potential")]
+        fail_on: String,
 
         /// Output results as machine-readable JSON
         #[arg(long)]
@@ -4247,6 +4285,35 @@ pub async fn dispatch_command(
             ContractCommands::Interfaces { wasm, json } => {
                 log::debug!("Command: contract interfaces | wasm={} json={}", wasm, json);
                 contract_interfaces::run_local(&wasm, json).await?;
+            }
+            ContractCommands::Compatibility {
+                from,
+                to,
+                from_network_passphrase,
+                to_network_passphrase,
+                strict,
+                fail_on,
+                json,
+            } => {
+                log::debug!(
+                    "Command: contract compatibility | from={} to={} strict={} fail_on={} json={}",
+                    from,
+                    to,
+                    strict,
+                    fail_on,
+                    json
+                );
+                let fail_on = contract_compatibility::FailOn::parse(&fail_on)?;
+                contract_compatibility::run(
+                    &from,
+                    &to,
+                    from_network_passphrase,
+                    to_network_passphrase,
+                    strict,
+                    json,
+                    fail_on,
+                )
+                .await?;
             }
             ContractCommands::Details {
                 address,


### PR DESCRIPTION
## Summary

Adds a shared semantic compatibility engine that structurally compares two `contractspecv0` specs and classifies changes as compatible, potentially breaking, breaking, or unknown, plus a CLI command to run the comparison locally.

**Depends on #1153** (issue #1139): this branch is built on top of that PR's interface-fingerprint parser and will show a combined diff until #1153 merges to `main`, at which point I'll rebase to shrink it to just this PR's commits.

## Related Issue

Closes #1143

## Type of Change

- [x] Feature — new functionality

## Changes Made

- Added `backend/shared/src/contract_compatibility.rs`: compares two parsed `contractspecv0` specs (via the #1139 parser) across functions, struct/union/enum/error-enum types, and events, classifying each change per the rules in the issue (e.g. removing a function is breaking, adding one is compatible, reordering or retyping a parameter is breaking, adding a required struct field is breaking while an `Option`-typed addition is potentially breaking, removing an event is potentially breaking, changing an error code is potentially breaking).
- An incomplete or malformed source spec on either side short-circuits the whole comparison to `unknown` rather than guessing at compatible/breaking — this was called out as the hardest constraint in the issue and is covered directly by tests.
- Network passphrase mismatches between the two sides are flagged as breaking, so different deployment contexts are never compared as equivalent.
- Added `soroban-registry contract compatibility --from <wasm> --to <wasm> [--strict] [--json] [--fail-on breaking|potential|unknown]` to the CLI. `--strict` exits non-zero when changes at or above the `--fail-on` threshold are found (default: `potential`).

## How Has This Been Tested?

### Test Commands

```bash
cd backend && cargo test -p shared contract_compatibility
cd cli && cargo check
```

### Test Coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing completed

### Testing Notes

12 unit tests cover: identical specs, function add/remove, parameter reordering and retyping, required vs. `Option`-typed struct field additions, event removal, error code changes, missing/malformed specs resolving to `unknown` (not a guessed verdict), and differing vs. identical network passphrases. Manually ran `contract compatibility --from --to` against locally built fixture WASM pairs.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated comments for complex logic
- [ ] I have updated documentation where applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass locally
- [ ] My branch is rebased on the latest `main` with no merge conflicts (stacked on #1153, see note above)
- [x] I have not introduced any breaking changes

## Additional Context

Scoped to local, offline comparison of two WASM artifacts (matching the existing `contract verify --wasm` / `contract interfaces --wasm` precedent). This PR does not add a `--from`/`--to` registry version lookup, new DB columns, or new backend API endpoints — those would need schema/query changes I can't safely verify without a live database in this environment.

