### PR TITLE
Implement paginated contract search and shared registry client features

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3633,18 +3633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "registry_client"
-version = "0.1.0"
-dependencies = [
- "futures-util",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4480,6 +4468,21 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "soroban-registry-client"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "shared",
+ "thiserror 1.0.69",
+ "tokio",
  "uuid",
 ]
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3633,6 +3633,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "registry_client"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
-members = ["api", "indexer", "verifier", "shared", "seeder", "contract_abi"]
+members = [
+    "api",
+    "indexer",
+    "verifier",
+    "shared",
+    "seeder",
+    "contract_abi",
+    "registry_client",
+]
 resolver = "2"
 
 [workspace.package]

--- a/backend/registry_client/Cargo.toml
+++ b/backend/registry_client/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "registry_client"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Typed client for the Soroban Registry HTTP API, with backend-agnostic pagination"
+
+[lib]
+name = "registry_client"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/backend/registry_client/Cargo.toml
+++ b/backend/registry_client/Cargo.toml
@@ -1,22 +1,26 @@
 [package]
-name = "registry_client"
+name = "soroban-registry-client"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-description = "Typed client for the Soroban Registry HTTP API, with backend-agnostic pagination"
+description = "Typed Rust client for the Soroban Registry HTTP API"
 
 [lib]
 name = "registry_client"
 path = "src/lib.rs"
 
 [dependencies]
+shared = { path = "../shared" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 tokio = { workspace = true }
+serde_json = { workspace = true }

--- a/backend/registry_client/src/api/contracts.rs
+++ b/backend/registry_client/src/api/contracts.rs
@@ -1,0 +1,403 @@
+//! Contracts: list, search, read, metadata, and publish.
+
+use shared::models::{
+    Contract, ContractGetResponse, ContractSearchParams, PaginatedResponse, PublishRequest,
+    UpdateContractMetadataRequest,
+};
+
+use crate::error::{Error, Result};
+use crate::http::{query_pairs_from, RequestSpec};
+use crate::models::{ContractHit, ContractSearchRequest, RawSearchResponse};
+use crate::pagination::{
+    advance_offset, PageCursor, PageFetcher, PageFuture, PageLimits, PageRequest, PaginationMode,
+    Paginator, RegistryPage,
+};
+use crate::RegistryClient;
+
+/// `GET /api/contracts` — the list endpoint.
+pub const CONTRACTS_PATH: &str = "/api/contracts";
+
+impl RegistryClient {
+    // ── List ─────────────────────────────────────────────────────────────────
+
+    /// One page of `GET /api/contracts`.
+    ///
+    /// `params` is the API's own filter type, so every documented filter is
+    /// available without a parallel struct to keep in sync.
+    pub async fn list_contracts(
+        &self,
+        params: &ContractSearchParams,
+    ) -> Result<PaginatedResponse<Contract>> {
+        let mut spec = RequestSpec::get(CONTRACTS_PATH);
+        spec.query = query_pairs_from(params)?;
+        self.transport.send_json(spec).await
+    }
+
+    /// A paginator that walks `GET /api/contracts`.
+    ///
+    /// Cursor mode follows `next_cursor`; offset mode advances `offset` and
+    /// stops at the reported total. Mixing the two is rejected up front.
+    pub fn list_paginator(
+        &self,
+        params: ContractSearchParams,
+        mode: PaginationMode,
+        limits: PageLimits,
+    ) -> Result<Paginator<ContractListFetcher>> {
+        let start = match mode {
+            PaginationMode::Cursor => {
+                if let Some(offset) = params.offset {
+                    if offset > 0 {
+                        return Err(crate::PaginationError::MixedPagination {
+                            offset: offset as u64,
+                        }
+                        .into());
+                    }
+                }
+                params
+                    .cursor
+                    .as_ref()
+                    .filter(|token| !token.is_empty())
+                    .map(|token| PageCursor::Cursor(token.clone()))
+            }
+            PaginationMode::Offset => {
+                if params.cursor.is_some() {
+                    return Err(crate::PaginationError::ModeMismatch {
+                        expected: PaginationMode::Offset,
+                        returned: PaginationMode::Cursor,
+                    }
+                    .into());
+                }
+                params
+                    .offset
+                    .filter(|offset| *offset > 0)
+                    .map(|offset| PageCursor::Offset {
+                        offset: offset as u64,
+                    })
+            }
+        };
+
+        let fetcher = ContractListFetcher {
+            client: self.clone(),
+            params,
+            mode,
+        };
+        Paginator::new(fetcher, mode)
+            .with_limits(limits)
+            .start_at(start)
+    }
+
+    // ── Read ─────────────────────────────────────────────────────────────────
+
+    /// `GET /api/contracts/{id}` — by registry UUID, contract address, or slug.
+    pub async fn get_contract(&self, id: &str) -> Result<ContractGetResponse> {
+        self.transport
+            .send_json(RequestSpec::get(contract_path(id, "")))
+            .await
+    }
+
+    /// `GET /api/v1/contracts/{id}/metadata`.
+    ///
+    /// The endpoint composes fields from several tables and has no single
+    /// backend type, so the document is returned as-is.
+    pub async fn get_contract_metadata(&self, id: &str) -> Result<serde_json::Value> {
+        self.transport
+            .send_json(RequestSpec::get(format!("/api/v1/contracts/{id}/metadata")))
+            .await
+    }
+
+    // ── Write ────────────────────────────────────────────────────────────────
+
+    /// `PATCH /api/contracts/{id}/metadata`.
+    ///
+    /// A metadata update is not retried unless `idempotency_key` is supplied:
+    /// repeating it would append a spurious version-history entry.
+    pub async fn update_contract_metadata(
+        &self,
+        id: &str,
+        request: &UpdateContractMetadataRequest,
+        idempotency_key: Option<String>,
+    ) -> Result<Contract> {
+        let spec = RequestSpec::patch(contract_path(id, "/metadata"))
+            .json_body(request)?
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_json(spec).await
+    }
+
+    /// `POST /api/contracts` — publish a contract.
+    ///
+    /// Pass an `idempotency_key` for anything that may be retried (CI, a flaky
+    /// link): the registry replays the original response instead of registering
+    /// a second time, and only then will this client retry the request itself.
+    /// Without a key the request is sent exactly once.
+    ///
+    /// A key that is still being processed surfaces as
+    /// [`Error::IdempotencyInProgress`] rather than a generic conflict.
+    pub async fn publish_contract(
+        &self,
+        request: &PublishRequest,
+        idempotency_key: Option<String>,
+    ) -> Result<Contract> {
+        let spec = RequestSpec::post(CONTRACTS_PATH)
+            .json_body(request)?
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_json(spec).await
+    }
+
+    // ── Search ───────────────────────────────────────────────────────────────
+
+    /// Fetch a single page of search results.
+    ///
+    /// `continuation` is `None` for the first page. Most callers want
+    /// [`RegistryClient::search_paginator`] instead, which manages continuations.
+    pub async fn search_page(
+        &self,
+        request: &ContractSearchRequest,
+        continuation: Option<PageCursor>,
+        limit: u32,
+    ) -> Result<RegistryPage<ContractHit>> {
+        request.validate()?;
+
+        let mode = request.mode;
+        let endpoint = request.effective_endpoint();
+        let mut spec = RequestSpec::get(endpoint.path())
+            .query_pair("q", request.query.clone())
+            .query_pair("limit", limit.to_string());
+
+        // Offset walks report where they are; cursor walks send the opaque token
+        // (empty on the first page, which is how the API is asked for a cursor
+        // walk at all). The two are never sent together.
+        let mut current_offset = 0_u64;
+        match mode {
+            PaginationMode::Cursor => {
+                let token = continuation
+                    .as_ref()
+                    .and_then(|cursor| cursor.as_cursor())
+                    .unwrap_or("");
+                spec = spec.query_pair("cursor", token);
+            }
+            PaginationMode::Offset => {
+                current_offset = continuation
+                    .as_ref()
+                    .and_then(|cursor| cursor.as_offset())
+                    .or(request.offset)
+                    .unwrap_or(0);
+                spec = spec.query_pair("offset", current_offset.to_string());
+            }
+        }
+
+        if !request.networks.is_empty() {
+            spec = spec.query_pair("networks", request.networks.join(","));
+        }
+        if !request.categories.is_empty() {
+            spec = spec.query_pair("categories", request.categories.join(","));
+        }
+        if !request.tags.is_empty() {
+            spec = spec.query_pair("tags", request.tags.join(","));
+        }
+        if request.verified_only {
+            spec = spec.query_pair("verified_only", "true");
+        }
+
+        let raw: RawSearchResponse = self.transport.send_json(spec).await?;
+        raw.into_page(mode, current_offset, limit)
+    }
+
+    /// A paginator that walks the whole result set for `request`, subject to
+    /// `limits`.
+    ///
+    /// Validates the request up front, so mixing a cursor with an offset fails
+    /// here rather than part-way through a walk.
+    pub fn search_paginator(
+        &self,
+        request: ContractSearchRequest,
+        limits: PageLimits,
+    ) -> Result<Paginator<ContractSearchFetcher>> {
+        let start = request.start_continuation()?;
+        let mode = request.mode;
+        let fetcher = ContractSearchFetcher {
+            client: self.clone(),
+            request,
+        };
+
+        Paginator::new(fetcher, mode)
+            .with_limits(limits)
+            .start_at(start)
+    }
+}
+
+/// Path for a contract sub-resource, with the id percent-safe enough for the
+/// identifier shapes the registry accepts (UUID, `C…` address, or slug).
+fn contract_path(id: &str, suffix: &str) -> String {
+    format!("{CONTRACTS_PATH}/{}{suffix}", id.trim())
+}
+
+/// Fetches search pages for one request. Built by
+/// [`RegistryClient::search_paginator`].
+pub struct ContractSearchFetcher {
+    client: RegistryClient,
+    request: ContractSearchRequest,
+}
+
+impl ContractSearchFetcher {
+    pub fn request(&self) -> &ContractSearchRequest {
+        &self.request
+    }
+}
+
+impl PageFetcher for ContractSearchFetcher {
+    type Item = ContractHit;
+
+    fn fetch_page(&self, request: PageRequest) -> PageFuture<'_, ContractHit> {
+        Box::pin(async move {
+            self.client
+                .search_page(&self.request, request.cursor, request.limit)
+                .await
+        })
+    }
+}
+
+/// Fetches list pages. Built by [`RegistryClient::list_paginator`].
+pub struct ContractListFetcher {
+    client: RegistryClient,
+    params: ContractSearchParams,
+    mode: PaginationMode,
+}
+
+impl PageFetcher for ContractListFetcher {
+    type Item = Contract;
+
+    fn fetch_page(&self, request: PageRequest) -> PageFuture<'_, Contract> {
+        Box::pin(async move {
+            let mut params = self.params.clone();
+            params.limit = Some(i64::from(request.limit));
+
+            let current_offset = match self.mode {
+                PaginationMode::Cursor => {
+                    params.offset = None;
+                    params.page = None;
+                    // An empty cursor opts the endpoint into a keyset walk.
+                    params.cursor = Some(
+                        request
+                            .cursor
+                            .as_ref()
+                            .and_then(PageCursor::as_cursor)
+                            .unwrap_or("")
+                            .to_string(),
+                    );
+                    0
+                }
+                PaginationMode::Offset => {
+                    params.cursor = None;
+                    let offset = request
+                        .cursor
+                        .as_ref()
+                        .and_then(PageCursor::as_offset)
+                        .or(params.offset.map(|offset| offset.max(0) as u64))
+                        .unwrap_or(0);
+                    params.offset = Some(i64::try_from(offset).map_err(|_| {
+                        Error::InvalidRequest(format!("offset {offset} exceeds the API's range"))
+                    })?);
+                    offset
+                }
+            };
+
+            let page = self.client.list_contracts(&params).await?;
+            let total = u64::try_from(page.total).ok();
+            let page_len = page.items.len() as u64;
+
+            let next = match self.mode {
+                PaginationMode::Cursor => page
+                    .next_cursor
+                    .clone()
+                    .filter(|token| !token.is_empty())
+                    .map(PageCursor::Cursor),
+                PaginationMode::Offset => {
+                    if page_len == 0 {
+                        None
+                    } else {
+                        let next_offset = advance_offset(current_offset, page_len)?;
+                        let has_more = match total {
+                            Some(total) => next_offset < total,
+                            None => page_len >= u64::from(request.limit),
+                        };
+                        has_more.then_some(PageCursor::Offset {
+                            offset: next_offset,
+                        })
+                    }
+                }
+            };
+
+            Ok(RegistryPage::new(page.items, next, total))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PaginationError;
+
+    fn client() -> RegistryClient {
+        RegistryClient::new("http://registry.test").expect("client")
+    }
+
+    #[test]
+    fn contract_sub_resource_paths_are_built_from_the_id() {
+        assert_eq!(
+            contract_path("11111111-1111-1111-1111-111111111111", "/metadata"),
+            "/api/contracts/11111111-1111-1111-1111-111111111111/metadata"
+        );
+        assert_eq!(contract_path(" CA123 ", ""), "/api/contracts/CA123");
+    }
+
+    #[test]
+    fn a_cursor_list_walk_rejects_an_offset() {
+        let params = ContractSearchParams {
+            offset: Some(40),
+            ..Default::default()
+        };
+        let err = client()
+            .list_paginator(params, PaginationMode::Cursor, PageLimits::default())
+            .expect_err("cursor + offset must be rejected");
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::MixedPagination { offset: 40 })
+        ));
+    }
+
+    #[test]
+    fn an_offset_list_walk_rejects_a_cursor() {
+        let params = ContractSearchParams {
+            cursor: Some("token".to_string()),
+            ..Default::default()
+        };
+        let err = client()
+            .list_paginator(params, PaginationMode::Offset, PageLimits::default())
+            .expect_err("offset + cursor must be rejected");
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::ModeMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn list_params_flatten_into_the_documented_query_shape() {
+        let params = ContractSearchParams {
+            query: Some("swap".to_string()),
+            limit: Some(20),
+            offset: Some(40),
+            verified_only: Some(true),
+            ..Default::default()
+        };
+        let pairs = query_pairs_from(&params).expect("flatten");
+
+        assert!(pairs.contains(&("query".to_string(), "swap".to_string())));
+        assert!(pairs.contains(&("limit".to_string(), "20".to_string())));
+        assert!(pairs.contains(&("offset".to_string(), "40".to_string())));
+        assert!(pairs.contains(&("verified_only".to_string(), "true".to_string())));
+        assert!(
+            !pairs.iter().any(|(key, _)| key == "cursor"),
+            "absent filters are not sent"
+        );
+    }
+}

--- a/backend/registry_client/src/api/deprecation.rs
+++ b/backend/registry_client/src/api/deprecation.rs
@@ -1,0 +1,45 @@
+//! Deprecation lifecycle: announce, inspect, and withdraw a deprecation.
+
+use shared::models::{DeprecateContractRequest, DeprecationInfo};
+
+use crate::error::Result;
+use crate::http::RequestSpec;
+use crate::RegistryClient;
+
+impl RegistryClient {
+    /// `GET /api/contracts/{id}/deprecation-info`.
+    pub async fn deprecation_info(&self, id: &str) -> Result<DeprecationInfo> {
+        self.transport
+            .send_json(RequestSpec::get(format!(
+                "/api/contracts/{id}/deprecation-info"
+            )))
+            .await
+    }
+
+    /// `POST /api/contracts/{id}/deprecate`.
+    ///
+    /// Deprecation notifies subscribers, so it is only retried when
+    /// `idempotency_key` is supplied.
+    pub async fn deprecate_contract(
+        &self,
+        id: &str,
+        request: &DeprecateContractRequest,
+        idempotency_key: Option<String>,
+    ) -> Result<DeprecationInfo> {
+        let spec = RequestSpec::post(format!("/api/contracts/{id}/deprecate"))
+            .json_body(request)?
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_json(spec).await
+    }
+
+    /// `DELETE /api/contracts/{id}/deprecate` — withdraw a deprecation.
+    pub async fn undeprecate_contract(
+        &self,
+        id: &str,
+        idempotency_key: Option<String>,
+    ) -> Result<DeprecationInfo> {
+        let spec = RequestSpec::delete(format!("/api/contracts/{id}/deprecate"))
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_json(spec).await
+    }
+}

--- a/backend/registry_client/src/api/mod.rs
+++ b/backend/registry_client/src/api/mod.rs
@@ -1,0 +1,15 @@
+//! Typed endpoint bindings, grouped by domain.
+//!
+//! Each module adds inherent methods to [`crate::RegistryClient`], so every call
+//! shares one client, one auth configuration, one retry policy, and one error
+//! taxonomy. Request and response types come from `shared` wherever the backend
+//! defines them; where an endpoint's types live in the API crate they are
+//! mirrored here with the same wire shape.
+
+pub mod contracts;
+pub mod deprecation;
+pub mod ownership;
+pub mod snapshots;
+pub mod verification;
+pub mod vulnerabilities;
+pub mod webhooks;

--- a/backend/registry_client/src/api/ownership.rs
+++ b/backend/registry_client/src/api/ownership.rs
@@ -1,0 +1,76 @@
+//! Signed ownership transfers and their append-only provenance chain.
+
+use shared::models::{
+    ConfirmOwnershipTransferRequest, CreateOwnershipTransferRequest, OwnershipTransfer,
+    OwnershipTransferLog,
+};
+
+use crate::error::Result;
+use crate::http::RequestSpec;
+use crate::RegistryClient;
+
+impl RegistryClient {
+    /// `POST /api/contracts/{id}/ownership-transfer` — initiate a transfer.
+    ///
+    /// The request body carries the sender's signature over a nonce, so the
+    /// registry already rejects replays; an `idempotency_key` additionally makes
+    /// the *transport* retryable when a response is lost.
+    pub async fn create_ownership_transfer(
+        &self,
+        contract_id: &str,
+        request: &CreateOwnershipTransferRequest,
+        idempotency_key: Option<String>,
+    ) -> Result<OwnershipTransfer> {
+        let spec = RequestSpec::post(format!("/api/contracts/{contract_id}/ownership-transfer"))
+            .json_body(request)?
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_json(spec).await
+    }
+
+    /// `GET /api/contracts/{id}/ownership-transfer` — transfers for a contract.
+    pub async fn list_ownership_transfers(
+        &self,
+        contract_id: &str,
+    ) -> Result<Vec<OwnershipTransfer>> {
+        self.transport
+            .send_json(RequestSpec::get(format!(
+                "/api/contracts/{contract_id}/ownership-transfer"
+            )))
+            .await
+    }
+
+    /// `GET /api/ownership-transfers/{id}`.
+    pub async fn get_ownership_transfer(&self, transfer_id: &str) -> Result<OwnershipTransfer> {
+        self.transport
+            .send_json(RequestSpec::get(format!(
+                "/api/ownership-transfers/{transfer_id}"
+            )))
+            .await
+    }
+
+    /// `POST /api/ownership-transfers/{id}/confirm` — accept or reject.
+    pub async fn confirm_ownership_transfer(
+        &self,
+        transfer_id: &str,
+        request: &ConfirmOwnershipTransferRequest,
+        idempotency_key: Option<String>,
+    ) -> Result<OwnershipTransfer> {
+        let spec = RequestSpec::post(format!("/api/ownership-transfers/{transfer_id}/confirm"))
+            .json_body(request)?
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_json(spec).await
+    }
+
+    /// `GET /api/ownership-transfers/{id}/logs` — the append-only provenance
+    /// chain for a transfer, oldest entry first.
+    pub async fn ownership_transfer_logs(
+        &self,
+        transfer_id: &str,
+    ) -> Result<Vec<OwnershipTransferLog>> {
+        self.transport
+            .send_json(RequestSpec::get(format!(
+                "/api/ownership-transfers/{transfer_id}/logs"
+            )))
+            .await
+    }
+}

--- a/backend/registry_client/src/api/snapshots.rs
+++ b/backend/registry_client/src/api/snapshots.rs
@@ -1,0 +1,39 @@
+//! Signed, offline-verifiable contract snapshots.
+
+use serde::{Deserialize, Serialize};
+use shared::snapshot::ContractSnapshot;
+
+use crate::error::Result;
+use crate::http::RequestSpec;
+use crate::RegistryClient;
+
+/// The registry's snapshot-signing public key.
+///
+/// Pin `key_fingerprint` in a verifier so a snapshot signed by a different key
+/// is rejected rather than trusted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistrySigningKey {
+    pub algorithm: String,
+    /// Base64-encoded public key. Public material — safe to print.
+    pub public_key: String,
+    pub key_fingerprint: String,
+}
+
+impl RegistryClient {
+    /// `GET /api/contracts/{id}/snapshot` — a signed snapshot of a contract.
+    ///
+    /// The payload verifies offline against [`RegistryClient::registry_signing_key`]
+    /// using `shared::snapshot::verify_snapshot`.
+    pub async fn contract_snapshot(&self, id: &str) -> Result<ContractSnapshot> {
+        self.transport
+            .send_json(RequestSpec::get(format!("/api/contracts/{id}/snapshot")))
+            .await
+    }
+
+    /// `GET /api/registry/signing-key`.
+    pub async fn registry_signing_key(&self) -> Result<RegistrySigningKey> {
+        self.transport
+            .send_json(RequestSpec::get("/api/registry/signing-key"))
+            .await
+    }
+}

--- a/backend/registry_client/src/api/verification.rs
+++ b/backend/registry_client/src/api/verification.rs
@@ -1,0 +1,146 @@
+//! Contract verification: submit a build, read status, read history.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::http::RequestSpec;
+use crate::RegistryClient;
+
+/// Body for `POST /api/contracts/{id}/verify`.
+///
+/// Mirrors the API's `ContractVerifyRequest`, which lives in the API crate
+/// rather than `shared`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractVerifyRequest {
+    pub source_code: String,
+    pub build_params: serde_json::Value,
+    pub compiler_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    /// Network passphrase the contract was deployed against. Optional for the
+    /// three well-known networks; required for custom ones, and a mismatch with
+    /// a previously recorded passphrase is rejected with 422.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_passphrase: Option<String>,
+}
+
+impl ContractVerifyRequest {
+    pub fn new(
+        source_code: impl Into<String>,
+        compiler_version: impl Into<String>,
+        build_params: serde_json::Value,
+    ) -> Self {
+        Self {
+            source_code: source_code.into(),
+            compiler_version: compiler_version.into(),
+            build_params,
+            notes: None,
+            network_passphrase: None,
+        }
+    }
+
+    pub fn with_notes(mut self, notes: Option<String>) -> Self {
+        self.notes = notes;
+        self
+    }
+
+    pub fn with_network_passphrase(mut self, passphrase: Option<String>) -> Self {
+        self.network_passphrase = passphrase;
+        self
+    }
+}
+
+/// Response to a verification submission.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationSubmitResponse {
+    pub verification_id: Uuid,
+    pub contract_id: String,
+    pub status: String,
+    pub message: String,
+    pub submitted_at: DateTime<Utc>,
+    /// Set when the registry already held a passphrase and the request omitted
+    /// one; start sending it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub passphrase_warning: Option<String>,
+}
+
+/// Current verification state of a contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationStatusResponse {
+    pub contract_id: String,
+    pub verification_status: String,
+    pub is_verified: bool,
+    pub verified_at: Option<DateTime<Utc>>,
+    pub verification_method: Option<String>,
+    pub auditor: Option<String>,
+    pub report_url: Option<String>,
+    pub verification_notes: Option<String>,
+    /// Whether the registry served this from its status cache.
+    #[serde(default)]
+    pub cached: bool,
+    #[serde(default)]
+    pub network_passphrase: Option<String>,
+}
+
+/// One status transition in a contract's verification history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationHistoryEntry {
+    pub id: Uuid,
+    pub from_status: String,
+    pub to_status: String,
+    pub changed_by: Option<Uuid>,
+    pub notes: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Chronological audit trail of verification status changes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationHistoryResponse {
+    pub contract_id: String,
+    pub total: usize,
+    pub history: Vec<VerificationHistoryEntry>,
+}
+
+impl RegistryClient {
+    /// `POST /api/contracts/{id}/verify` — submit a build for verification.
+    ///
+    /// A submission has side effects (it queues work), so it is only retried
+    /// when `idempotency_key` is supplied.
+    pub async fn submit_contract_verification(
+        &self,
+        id: &str,
+        request: &ContractVerifyRequest,
+        idempotency_key: Option<String>,
+    ) -> Result<VerificationSubmitResponse> {
+        let spec = RequestSpec::post(format!("/api/contracts/{id}/verify"))
+            .json_body(request)?
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_json(spec).await
+    }
+
+    /// `GET /api/contracts/{id}/verification-status`.
+    pub async fn contract_verification_status(
+        &self,
+        id: &str,
+    ) -> Result<VerificationStatusResponse> {
+        self.transport
+            .send_json(RequestSpec::get(format!(
+                "/api/contracts/{id}/verification-status"
+            )))
+            .await
+    }
+
+    /// `GET /api/contracts/{id}/verification-history`.
+    pub async fn contract_verification_history(
+        &self,
+        id: &str,
+    ) -> Result<VerificationHistoryResponse> {
+        self.transport
+            .send_json(RequestSpec::get(format!(
+                "/api/contracts/{id}/verification-history"
+            )))
+            .await
+    }
+}

--- a/backend/registry_client/src/api/vulnerabilities.rs
+++ b/backend/registry_client/src/api/vulnerabilities.rs
@@ -1,0 +1,46 @@
+//! Dependency scanning and vulnerability reports.
+
+use shared::models::DependencyScanReport;
+
+use crate::error::Result;
+use crate::http::RequestSpec;
+use crate::RegistryClient;
+
+impl RegistryClient {
+    /// `GET /api/contracts/{id}/dependency-scan` — the latest scan report.
+    ///
+    /// `id` is the registry UUID; this endpoint does not accept slugs.
+    pub async fn dependency_scan_report(&self, id: &str) -> Result<DependencyScanReport> {
+        self.transport
+            .send_json(RequestSpec::get(format!(
+                "/api/contracts/{id}/dependency-scan"
+            )))
+            .await
+    }
+
+    /// `POST /api/contracts/{id}/dependency-scan` — run a scan now.
+    ///
+    /// Scanning consumes upstream advisory-database quota, so it is only
+    /// retried when `idempotency_key` is supplied.
+    pub async fn trigger_dependency_scan(
+        &self,
+        id: &str,
+        idempotency_key: Option<String>,
+    ) -> Result<DependencyScanReport> {
+        let spec = RequestSpec::post(format!("/api/contracts/{id}/dependency-scan"))
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_json(spec).await
+    }
+
+    /// `GET /api/v1/contracts/{id}/vulnerability-assessment`.
+    ///
+    /// The assessment aggregates several scanners into a document with no
+    /// single backend type, so it is returned as-is.
+    pub async fn vulnerability_assessment(&self, id: &str) -> Result<serde_json::Value> {
+        self.transport
+            .send_json(RequestSpec::get(format!(
+                "/api/v1/contracts/{id}/vulnerability-assessment"
+            )))
+            .await
+    }
+}

--- a/backend/registry_client/src/api/webhooks.rs
+++ b/backend/registry_client/src/api/webhooks.rs
@@ -1,0 +1,124 @@
+//! Webhook configuration, delivery logs, and redelivery.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use shared::models::{CreateWebhookRequest, PaginatedResponse, WebhookConfiguration};
+use uuid::Uuid;
+
+use crate::config::Secret;
+use crate::error::Result;
+use crate::http::RequestSpec;
+use crate::RegistryClient;
+
+/// One delivery attempt for a webhook.
+///
+/// Mirrors the API's `WebhookDeliveryLog`, which lives in the API crate rather
+/// than `shared`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookDelivery {
+    pub id: Uuid,
+    pub webhook_id: Uuid,
+    pub notification_id: Option<Uuid>,
+    pub event_type: String,
+    pub status: String,
+    pub response_code: Option<i32>,
+    pub response_body: Option<String>,
+    pub error_message: Option<String>,
+    pub attempt_number: i32,
+    pub delivery_duration_ms: Option<i64>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// A freshly created webhook, with its signing secret held apart.
+///
+/// The registry returns the signing secret exactly once, at creation. It is
+/// lifted out of the configuration into a [`Secret`] so that neither logging
+/// the webhook nor logging this struct can print it — reach it deliberately
+/// with [`Secret::expose`].
+#[derive(Debug, Clone)]
+pub struct CreatedWebhook {
+    /// The stored configuration, with the secret field cleared.
+    pub webhook: WebhookConfiguration,
+    /// The signing secret, if the registry issued one.
+    pub secret: Option<Secret>,
+}
+
+impl RegistryClient {
+    /// `GET /api/webhooks` — the caller's webhooks.
+    pub async fn list_webhooks(
+        &self,
+        page: Option<i64>,
+        limit: Option<i64>,
+    ) -> Result<PaginatedResponse<WebhookConfiguration>> {
+        let spec = RequestSpec::get("/api/webhooks")
+            .maybe_query("page", page)
+            .maybe_query("limit", limit);
+        self.transport.send_json(spec).await
+    }
+
+    /// `POST /api/webhooks` — register a webhook.
+    ///
+    /// The response's signing secret is moved into [`CreatedWebhook::secret`]
+    /// so it cannot be printed by accident.
+    pub async fn create_webhook(
+        &self,
+        request: &CreateWebhookRequest,
+        idempotency_key: Option<String>,
+    ) -> Result<CreatedWebhook> {
+        let spec = RequestSpec::post("/api/webhooks")
+            .json_body(request)?
+            .idempotency_key(idempotency_key)?;
+        let mut webhook: WebhookConfiguration = self.transport.send_json(spec).await?;
+        let secret = webhook.secret.take().map(Secret::new);
+        Ok(CreatedWebhook { webhook, secret })
+    }
+
+    /// `DELETE /api/webhooks/{id}`.
+    ///
+    /// Deleting is naturally idempotent in effect, but a repeat returns 404, so
+    /// it is only retried when `idempotency_key` is supplied.
+    pub async fn delete_webhook(
+        &self,
+        webhook_id: &str,
+        idempotency_key: Option<String>,
+    ) -> Result<()> {
+        let spec = RequestSpec::delete(format!("/api/webhooks/{webhook_id}"))
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_discard(spec).await
+    }
+
+    /// `GET /api/webhooks/{id}/deliveries` — delivery attempts, newest first.
+    pub async fn webhook_deliveries(
+        &self,
+        webhook_id: &str,
+        page: Option<i64>,
+        limit: Option<i64>,
+    ) -> Result<PaginatedResponse<WebhookDelivery>> {
+        let spec = RequestSpec::get(format!("/api/webhooks/{webhook_id}/deliveries"))
+            .maybe_query("page", page)
+            .maybe_query("limit", limit);
+        self.transport.send_json(spec).await
+    }
+
+    /// `POST /api/webhooks/{id}/test` — send a test event.
+    pub async fn test_webhook(
+        &self,
+        webhook_id: &str,
+        idempotency_key: Option<String>,
+    ) -> Result<()> {
+        let spec = RequestSpec::post(format!("/api/webhooks/{webhook_id}/test"))
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_discard(spec).await
+    }
+
+    /// `POST /api/webhook-deliveries/{id}/retry` — redeliver one event.
+    pub async fn retry_webhook_delivery(
+        &self,
+        delivery_id: &str,
+        idempotency_key: Option<String>,
+    ) -> Result<()> {
+        let spec = RequestSpec::post(format!("/api/webhook-deliveries/{delivery_id}/retry"))
+            .idempotency_key(idempotency_key)?;
+        self.transport.send_discard(spec).await
+    }
+}

--- a/backend/registry_client/src/client.rs
+++ b/backend/registry_client/src/client.rs
@@ -1,301 +1,153 @@
-//! HTTP client for the registry search endpoints.
+//! The client type: configuration, transport wiring, and the escape hatch for
+//! endpoints the typed API does not cover yet.
+//!
+//! Endpoint methods live next door in [`crate::api`], grouped by domain.
 
+use std::sync::Arc;
 use std::time::Duration;
 
-use reqwest::{Method, StatusCode};
+use serde::de::DeserializeOwned;
 
+use crate::config::{Auth, ClientConfig, RetryPolicy};
 use crate::error::{Error, Result};
-use crate::models::{ContractHit, ContractSearchRequest, RawSearchResponse};
-use crate::pagination::{
-    PageFetcher, PageFuture, PageLimits, PageRequest, Paginator, RegistryPage,
-};
-
-const DEFAULT_TIMEOUT_SECS: u64 = 30;
-const DEFAULT_MAX_ATTEMPTS: usize = 3;
-const BACKOFFS_MS: [u64; 2] = [250, 750];
+use crate::http::{RequestSpec, ResponseCache, Transport};
+use crate::pagination::CancelToken;
 
 /// Client for the Soroban Registry HTTP API.
 ///
-/// Cloning is cheap; the underlying `reqwest::Client` shares its connection pool.
+/// Cloning is cheap: the configuration is shared and the underlying
+/// `reqwest::Client` keeps its connection pool.
+///
+/// ```no_run
+/// use registry_client::{Auth, ClientConfig, RegistryClient, RetryPolicy};
+/// # fn main() -> registry_client::Result<()> {
+/// let client = RegistryClient::from_config(
+///     ClientConfig::new("https://registry.example")
+///         .with_auth(Auth::bearer(std::env::var("REGISTRY_TOKEN").unwrap_or_default()))
+///         .with_timeout(std::time::Duration::from_secs(15))
+///         .with_user_agent("my-tool/1.0")
+///         .with_retry_policy(RetryPolicy::attempts(5)),
+/// )?;
+/// # let _ = client;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct RegistryClient {
-    http: reqwest::Client,
-    base_url: String,
-    bearer_token: Option<String>,
-    max_attempts: usize,
+    pub(crate) transport: Transport,
 }
 
 impl RegistryClient {
-    /// A client for `base_url` (e.g. `http://localhost:3001`).
+    /// A client for `base_url` (e.g. `http://localhost:3001`) with defaults.
     pub fn new(base_url: impl Into<String>) -> Result<Self> {
+        Self::from_config(ClientConfig::new(base_url))
+    }
+
+    /// A client from a full configuration.
+    pub fn from_config(config: ClientConfig) -> Result<Self> {
         let http = reqwest::Client::builder()
-            .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .timeout(config.timeout)
             .build()
             .map_err(|err| {
                 Error::InvalidRequest(format!("could not build an HTTP client: {err}"))
             })?;
-        Ok(Self::with_http_client(base_url, http))
+        Ok(Self::with_http_client(config, http))
     }
 
-    /// A client using a caller-supplied `reqwest::Client`, for callers that
-    /// already configure timeouts, proxies or TLS.
-    pub fn with_http_client(base_url: impl Into<String>, http: reqwest::Client) -> Self {
+    /// A client using a caller-supplied `reqwest::Client`, for consumers that
+    /// already configure proxies, TLS, or connection pooling.
+    pub fn with_http_client(config: ClientConfig, http: reqwest::Client) -> Self {
         Self {
-            http,
-            base_url: base_url.into().trim_end_matches('/').to_string(),
-            bearer_token: None,
-            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            transport: Transport::new(Arc::new(config), http),
         }
     }
 
-    /// Send `Authorization: Bearer …` with every request.
-    pub fn with_bearer_token(mut self, token: Option<String>) -> Self {
-        self.bearer_token = token;
-        self
-    }
-
-    /// Attempts per page fetch, retries included (minimum 1).
-    ///
-    /// Retries happen inside a single page fetch, so they can never cause a
-    /// paginated walk to emit an item twice.
-    pub fn with_max_attempts(mut self, max_attempts: usize) -> Self {
-        self.max_attempts = max_attempts.max(1);
-        self
+    pub fn config(&self) -> &ClientConfig {
+        self.transport.config()
     }
 
     pub fn base_url(&self) -> &str {
-        &self.base_url
+        &self.transport.config().base_url
     }
 
-    /// Fetch a single page of search results.
-    ///
-    /// `continuation` is `None` for the first page. Most callers want
-    /// [`RegistryClient::search_paginator`] instead, which manages continuations.
-    pub async fn search_page(
-        &self,
-        request: &ContractSearchRequest,
-        continuation: Option<crate::pagination::PageCursor>,
-        limit: u32,
-    ) -> Result<RegistryPage<ContractHit>> {
-        request.validate()?;
-
-        let mode = request.mode;
-        let endpoint = request.effective_endpoint();
-        let url = format!("{}{}", self.base_url, endpoint.path());
-
-        let mut params: Vec<(&str, String)> =
-            vec![("q", request.query.clone()), ("limit", limit.to_string())];
-
-        // Offset walks report where they are; cursor walks send the opaque token
-        // (empty on the first page, which is how the API is asked for a cursor
-        // walk at all). The two are never sent together.
-        let mut current_offset = 0_u64;
-        match mode {
-            crate::pagination::PaginationMode::Cursor => {
-                let token = continuation
-                    .as_ref()
-                    .and_then(|cursor| cursor.as_cursor())
-                    .unwrap_or("");
-                params.push(("cursor", token.to_string()));
-            }
-            crate::pagination::PaginationMode::Offset => {
-                current_offset = continuation
-                    .as_ref()
-                    .and_then(|cursor| cursor.as_offset())
-                    .or(request.offset)
-                    .unwrap_or(0);
-                params.push(("offset", current_offset.to_string()));
-            }
-        }
-
-        if !request.networks.is_empty() {
-            params.push(("networks", request.networks.join(",")));
-        }
-        if !request.categories.is_empty() {
-            params.push(("categories", request.categories.join(",")));
-        }
-        if !request.tags.is_empty() {
-            params.push(("tags", request.tags.join(",")));
-        }
-        if request.verified_only {
-            params.push(("verified_only", "true".to_string()));
-        }
-
-        let body = self.get(&url, &params).await?;
-        let raw: RawSearchResponse = serde_json::from_str(&body).map_err(|err| Error::Decode {
-            url: url.clone(),
-            reason: err.to_string(),
-        })?;
-
-        raw.into_page(mode, current_offset, limit)
+    /// Replace the authentication scheme.
+    pub fn with_auth(mut self, auth: Auth) -> Self {
+        self.map_config(|config| config.auth = auth);
+        self
     }
 
-    /// A paginator that walks the whole result set for `request`, subject to
-    /// `limits`.
-    ///
-    /// Validates the request up front, so mixing a cursor with an offset fails
-    /// here rather than part-way through a walk.
-    pub fn search_paginator(
-        &self,
-        request: ContractSearchRequest,
-        limits: PageLimits,
-    ) -> Result<Paginator<ContractSearchFetcher>> {
-        let start = request.start_continuation()?;
-        let mode = request.mode;
-        let fetcher = ContractSearchFetcher {
-            client: self.clone(),
-            request,
+    /// Bearer authentication, or anonymous when `token` is `None`.
+    pub fn with_bearer_token(mut self, token: Option<impl Into<String>>) -> Self {
+        let auth = match token {
+            Some(token) => Auth::bearer(token),
+            None => Auth::None,
         };
-
-        Paginator::new(fetcher, mode)
-            .with_limits(limits)
-            .start_at(start)
+        self.map_config(|config| config.auth = auth);
+        self
     }
 
-    /// GET with bounded retries for transient failures. Returns the body of the
-    /// first non-retryable response, or an error for a non-success status.
-    async fn get(&self, url: &str, params: &[(&str, String)]) -> Result<String> {
-        let mut last_transport_error: Option<String> = None;
-
-        for attempt in 1..=self.max_attempts {
-            let mut builder = self.http.get(url).query(params);
-            if let Some(token) = &self.bearer_token {
-                builder = builder.bearer_auth(token);
-            }
-
-            match builder.send().await {
-                Ok(response) => {
-                    let status = response.status();
-                    if is_retryable_status(status) && attempt < self.max_attempts {
-                        sleep_before_retry(attempt).await;
-                        continue;
-                    }
-
-                    let body = response.text().await.map_err(|err| Error::Decode {
-                        url: url.to_string(),
-                        reason: err.to_string(),
-                    })?;
-
-                    if !status.is_success() {
-                        let (code, message) = extract_api_error(&body);
-                        return Err(Error::Api {
-                            method: Method::GET.to_string(),
-                            url: url.to_string(),
-                            status: status.as_u16(),
-                            code,
-                            message,
-                        });
-                    }
-
-                    return Ok(body);
-                }
-                Err(err) => {
-                    let reason = describe_transport_error(&err);
-                    if is_transient(&err) && attempt < self.max_attempts {
-                        last_transport_error = Some(reason);
-                        sleep_before_retry(attempt).await;
-                        continue;
-                    }
-                    return Err(Error::Transport {
-                        url: url.to_string(),
-                        attempts: attempt,
-                        reason,
-                    });
-                }
-            }
-        }
-
-        Err(Error::Transport {
-            url: url.to_string(),
-            attempts: self.max_attempts,
-            reason: last_transport_error
-                .unwrap_or_else(|| "the registry kept returning a retryable status".to_string()),
-        })
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.map_config(|config| config.timeout = timeout);
+        self
     }
-}
 
-/// Fetches search pages for one request. Built by
-/// [`RegistryClient::search_paginator`].
-pub struct ContractSearchFetcher {
-    client: RegistryClient,
-    request: ContractSearchRequest,
-}
-
-impl ContractSearchFetcher {
-    pub fn request(&self) -> &ContractSearchRequest {
-        &self.request
+    pub fn with_user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        let user_agent = user_agent.into();
+        self.map_config(|config| config.user_agent = user_agent);
+        self
     }
-}
 
-impl PageFetcher for ContractSearchFetcher {
-    type Item = ContractHit;
-
-    fn fetch_page(&self, request: PageRequest) -> PageFuture<'_, ContractHit> {
-        Box::pin(async move {
-            self.client
-                .search_page(&self.request, request.cursor, request.limit)
-                .await
-        })
+    /// Replace the retry policy. [`RetryPolicy::none`] disables retrying.
+    pub fn with_retry_policy(mut self, retry: RetryPolicy) -> Self {
+        self.map_config(|config| config.retry = retry);
+        self
     }
-}
 
-fn is_retryable_status(status: StatusCode) -> bool {
-    matches!(
-        status,
-        StatusCode::REQUEST_TIMEOUT
-            | StatusCode::TOO_MANY_REQUESTS
-            | StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT
-    )
-}
-
-/// Search requests are GETs, so retrying any send failure is safe.
-fn is_transient(err: &reqwest::Error) -> bool {
-    err.is_connect() || err.is_timeout() || err.is_request()
-}
-
-fn describe_transport_error(err: &reqwest::Error) -> String {
-    if err.is_timeout() {
-        "the request timed out".to_string()
-    } else if err.is_connect() {
-        "could not connect to the registry".to_string()
-    } else if err.is_request() {
-        "the request could not be sent".to_string()
-    } else {
-        err.to_string()
+    /// Serve cacheable `GET`s from `cache` before hitting the network.
+    pub fn with_response_cache(mut self, cache: Arc<dyn ResponseCache>) -> Self {
+        self.transport.set_cache(Some(cache));
+        self
     }
-}
 
-/// Pull `code`/`message` out of an API error body, tolerating both the flat
-/// shape the API emits and a nested `{"error": {…}}` shape.
-fn extract_api_error(body: &str) -> (Option<String>, Option<String>) {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
-        return (None, None);
-    };
-    let scope = value.get("error").unwrap_or(&value);
-    let field = |name: &str| {
-        scope
-            .get(name)
-            .and_then(|value| value.as_str())
-            .map(str::to_string)
-    };
-    (
-        field("code").or_else(|| field("error_code")),
-        field("message"),
-    )
-}
+    /// Abort in-flight requests when `cancel` fires.
+    pub fn with_cancel_token(mut self, cancel: CancelToken) -> Self {
+        self.transport.set_cancel_token(Some(cancel));
+        self
+    }
 
-async fn sleep_before_retry(attempt: usize) {
-    let index = attempt.saturating_sub(1).min(BACKOFFS_MS.len() - 1);
-    tokio::time::sleep(Duration::from_millis(BACKOFFS_MS[index])).await;
+    /// The cancellation token this client honours, if any.
+    pub fn cancel_token(&self) -> Option<CancelToken> {
+        self.transport.cancel_token().cloned()
+    }
+
+    // ── Escape hatch ─────────────────────────────────────────────────────────
+
+    /// Execute an arbitrary request and decode the JSON response, for endpoints
+    /// this crate does not wrap yet. Retry, auth, cancellation, and error
+    /// classification behave exactly as for the typed methods.
+    pub async fn send_json<T: DeserializeOwned>(&self, spec: RequestSpec) -> Result<T> {
+        self.transport.send_json(spec).await
+    }
+
+    /// Execute an arbitrary request, returning the raw response body.
+    pub async fn send_raw(&self, spec: RequestSpec) -> Result<String> {
+        self.transport.send(spec).await
+    }
+
+    /// `GET` a JSON resource by path, e.g. `/api/contracts/tags`.
+    pub async fn get_json<T: DeserializeOwned>(&self, path: impl Into<String>) -> Result<T> {
+        self.transport.send_json(RequestSpec::get(path)).await
+    }
+
+    fn map_config(&mut self, apply: impl FnOnce(&mut ClientConfig)) {
+        self.transport.map_config(apply);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pagination::PaginationMode;
+    use crate::config::REDACTED;
 
     #[test]
     fn base_url_trailing_slash_is_normalised() {
@@ -304,44 +156,36 @@ mod tests {
     }
 
     #[test]
-    fn api_error_bodies_are_parsed() {
-        let (code, message) = extract_api_error(
-            r#"{"code":"INVALID_CURSOR","message":"The provided pagination cursor is invalid"}"#,
-        );
-        assert_eq!(code.as_deref(), Some("INVALID_CURSOR"));
-        assert_eq!(
-            message.as_deref(),
-            Some("The provided pagination cursor is invalid")
-        );
+    fn builder_methods_update_the_shared_config() {
+        let client = RegistryClient::new("http://registry.test")
+            .expect("client")
+            .with_user_agent("my-tool/2.0")
+            .with_timeout(Duration::from_secs(3))
+            .with_retry_policy(RetryPolicy::none())
+            .with_bearer_token(Some("token-abc"));
 
-        let (nested_code, _) =
-            extract_api_error(r#"{"error":{"code":"InvalidPaginationCursor","message":"nope"}}"#);
-        assert_eq!(nested_code.as_deref(), Some("InvalidPaginationCursor"));
-
-        assert_eq!(extract_api_error("not json"), (None, None));
+        assert_eq!(client.config().user_agent, "my-tool/2.0");
+        assert_eq!(client.config().timeout, Duration::from_secs(3));
+        assert_eq!(client.config().retry.max_attempts, 1);
+        assert!(matches!(client.config().auth, Auth::Bearer(_)));
     }
 
     #[test]
-    fn invalid_cursor_errors_are_recognisable() {
-        let err = Error::Api {
-            method: "GET".to_string(),
-            url: "http://registry.test/api/search".to_string(),
-            status: 400,
-            code: Some("INVALID_CURSOR".to_string()),
-            message: Some("The provided pagination cursor is invalid".to_string()),
-        };
-        assert!(err.is_invalid_cursor());
-        assert_eq!(err.status(), Some(400));
+    fn cloned_clients_do_not_share_later_config_edits() {
+        let anonymous = RegistryClient::new("http://registry.test").expect("client");
+        let authenticated = anonymous.clone().with_bearer_token(Some("token-abc"));
+
+        assert!(anonymous.config().auth.is_anonymous());
+        assert!(!authenticated.config().auth.is_anonymous());
     }
 
     #[test]
-    fn mixing_a_cursor_and_an_offset_fails_before_any_request() {
-        let client = RegistryClient::new("http://registry.test").expect("client");
-        let request = crate::models::ContractSearchRequest::new("swap", PaginationMode::Cursor)
-            .with_offset(Some(20));
-
-        assert!(client
-            .search_paginator(request, PageLimits::default())
-            .is_err());
+    fn debug_output_never_contains_the_token() {
+        let client = RegistryClient::new("http://registry.test")
+            .expect("client")
+            .with_bearer_token(Some("token-abc"));
+        let rendered = format!("{client:?}");
+        assert!(!rendered.contains("token-abc"), "{rendered}");
+        assert!(rendered.contains(REDACTED), "{rendered}");
     }
 }

--- a/backend/registry_client/src/client.rs
+++ b/backend/registry_client/src/client.rs
@@ -1,0 +1,347 @@
+//! HTTP client for the registry search endpoints.
+
+use std::time::Duration;
+
+use reqwest::{Method, StatusCode};
+
+use crate::error::{Error, Result};
+use crate::models::{ContractHit, ContractSearchRequest, RawSearchResponse};
+use crate::pagination::{
+    PageFetcher, PageFuture, PageLimits, PageRequest, Paginator, RegistryPage,
+};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_MAX_ATTEMPTS: usize = 3;
+const BACKOFFS_MS: [u64; 2] = [250, 750];
+
+/// Client for the Soroban Registry HTTP API.
+///
+/// Cloning is cheap; the underlying `reqwest::Client` shares its connection pool.
+#[derive(Debug, Clone)]
+pub struct RegistryClient {
+    http: reqwest::Client,
+    base_url: String,
+    bearer_token: Option<String>,
+    max_attempts: usize,
+}
+
+impl RegistryClient {
+    /// A client for `base_url` (e.g. `http://localhost:3001`).
+    pub fn new(base_url: impl Into<String>) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .build()
+            .map_err(|err| {
+                Error::InvalidRequest(format!("could not build an HTTP client: {err}"))
+            })?;
+        Ok(Self::with_http_client(base_url, http))
+    }
+
+    /// A client using a caller-supplied `reqwest::Client`, for callers that
+    /// already configure timeouts, proxies or TLS.
+    pub fn with_http_client(base_url: impl Into<String>, http: reqwest::Client) -> Self {
+        Self {
+            http,
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            bearer_token: None,
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+        }
+    }
+
+    /// Send `Authorization: Bearer …` with every request.
+    pub fn with_bearer_token(mut self, token: Option<String>) -> Self {
+        self.bearer_token = token;
+        self
+    }
+
+    /// Attempts per page fetch, retries included (minimum 1).
+    ///
+    /// Retries happen inside a single page fetch, so they can never cause a
+    /// paginated walk to emit an item twice.
+    pub fn with_max_attempts(mut self, max_attempts: usize) -> Self {
+        self.max_attempts = max_attempts.max(1);
+        self
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Fetch a single page of search results.
+    ///
+    /// `continuation` is `None` for the first page. Most callers want
+    /// [`RegistryClient::search_paginator`] instead, which manages continuations.
+    pub async fn search_page(
+        &self,
+        request: &ContractSearchRequest,
+        continuation: Option<crate::pagination::PageCursor>,
+        limit: u32,
+    ) -> Result<RegistryPage<ContractHit>> {
+        request.validate()?;
+
+        let mode = request.mode;
+        let endpoint = request.effective_endpoint();
+        let url = format!("{}{}", self.base_url, endpoint.path());
+
+        let mut params: Vec<(&str, String)> =
+            vec![("q", request.query.clone()), ("limit", limit.to_string())];
+
+        // Offset walks report where they are; cursor walks send the opaque token
+        // (empty on the first page, which is how the API is asked for a cursor
+        // walk at all). The two are never sent together.
+        let mut current_offset = 0_u64;
+        match mode {
+            crate::pagination::PaginationMode::Cursor => {
+                let token = continuation
+                    .as_ref()
+                    .and_then(|cursor| cursor.as_cursor())
+                    .unwrap_or("");
+                params.push(("cursor", token.to_string()));
+            }
+            crate::pagination::PaginationMode::Offset => {
+                current_offset = continuation
+                    .as_ref()
+                    .and_then(|cursor| cursor.as_offset())
+                    .or(request.offset)
+                    .unwrap_or(0);
+                params.push(("offset", current_offset.to_string()));
+            }
+        }
+
+        if !request.networks.is_empty() {
+            params.push(("networks", request.networks.join(",")));
+        }
+        if !request.categories.is_empty() {
+            params.push(("categories", request.categories.join(",")));
+        }
+        if !request.tags.is_empty() {
+            params.push(("tags", request.tags.join(",")));
+        }
+        if request.verified_only {
+            params.push(("verified_only", "true".to_string()));
+        }
+
+        let body = self.get(&url, &params).await?;
+        let raw: RawSearchResponse = serde_json::from_str(&body).map_err(|err| Error::Decode {
+            url: url.clone(),
+            reason: err.to_string(),
+        })?;
+
+        raw.into_page(mode, current_offset, limit)
+    }
+
+    /// A paginator that walks the whole result set for `request`, subject to
+    /// `limits`.
+    ///
+    /// Validates the request up front, so mixing a cursor with an offset fails
+    /// here rather than part-way through a walk.
+    pub fn search_paginator(
+        &self,
+        request: ContractSearchRequest,
+        limits: PageLimits,
+    ) -> Result<Paginator<ContractSearchFetcher>> {
+        let start = request.start_continuation()?;
+        let mode = request.mode;
+        let fetcher = ContractSearchFetcher {
+            client: self.clone(),
+            request,
+        };
+
+        Paginator::new(fetcher, mode)
+            .with_limits(limits)
+            .start_at(start)
+    }
+
+    /// GET with bounded retries for transient failures. Returns the body of the
+    /// first non-retryable response, or an error for a non-success status.
+    async fn get(&self, url: &str, params: &[(&str, String)]) -> Result<String> {
+        let mut last_transport_error: Option<String> = None;
+
+        for attempt in 1..=self.max_attempts {
+            let mut builder = self.http.get(url).query(params);
+            if let Some(token) = &self.bearer_token {
+                builder = builder.bearer_auth(token);
+            }
+
+            match builder.send().await {
+                Ok(response) => {
+                    let status = response.status();
+                    if is_retryable_status(status) && attempt < self.max_attempts {
+                        sleep_before_retry(attempt).await;
+                        continue;
+                    }
+
+                    let body = response.text().await.map_err(|err| Error::Decode {
+                        url: url.to_string(),
+                        reason: err.to_string(),
+                    })?;
+
+                    if !status.is_success() {
+                        let (code, message) = extract_api_error(&body);
+                        return Err(Error::Api {
+                            method: Method::GET.to_string(),
+                            url: url.to_string(),
+                            status: status.as_u16(),
+                            code,
+                            message,
+                        });
+                    }
+
+                    return Ok(body);
+                }
+                Err(err) => {
+                    let reason = describe_transport_error(&err);
+                    if is_transient(&err) && attempt < self.max_attempts {
+                        last_transport_error = Some(reason);
+                        sleep_before_retry(attempt).await;
+                        continue;
+                    }
+                    return Err(Error::Transport {
+                        url: url.to_string(),
+                        attempts: attempt,
+                        reason,
+                    });
+                }
+            }
+        }
+
+        Err(Error::Transport {
+            url: url.to_string(),
+            attempts: self.max_attempts,
+            reason: last_transport_error
+                .unwrap_or_else(|| "the registry kept returning a retryable status".to_string()),
+        })
+    }
+}
+
+/// Fetches search pages for one request. Built by
+/// [`RegistryClient::search_paginator`].
+pub struct ContractSearchFetcher {
+    client: RegistryClient,
+    request: ContractSearchRequest,
+}
+
+impl ContractSearchFetcher {
+    pub fn request(&self) -> &ContractSearchRequest {
+        &self.request
+    }
+}
+
+impl PageFetcher for ContractSearchFetcher {
+    type Item = ContractHit;
+
+    fn fetch_page(&self, request: PageRequest) -> PageFuture<'_, ContractHit> {
+        Box::pin(async move {
+            self.client
+                .search_page(&self.request, request.cursor, request.limit)
+                .await
+        })
+    }
+}
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::REQUEST_TIMEOUT
+            | StatusCode::TOO_MANY_REQUESTS
+            | StatusCode::INTERNAL_SERVER_ERROR
+            | StatusCode::BAD_GATEWAY
+            | StatusCode::SERVICE_UNAVAILABLE
+            | StatusCode::GATEWAY_TIMEOUT
+    )
+}
+
+/// Search requests are GETs, so retrying any send failure is safe.
+fn is_transient(err: &reqwest::Error) -> bool {
+    err.is_connect() || err.is_timeout() || err.is_request()
+}
+
+fn describe_transport_error(err: &reqwest::Error) -> String {
+    if err.is_timeout() {
+        "the request timed out".to_string()
+    } else if err.is_connect() {
+        "could not connect to the registry".to_string()
+    } else if err.is_request() {
+        "the request could not be sent".to_string()
+    } else {
+        err.to_string()
+    }
+}
+
+/// Pull `code`/`message` out of an API error body, tolerating both the flat
+/// shape the API emits and a nested `{"error": {…}}` shape.
+fn extract_api_error(body: &str) -> (Option<String>, Option<String>) {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return (None, None);
+    };
+    let scope = value.get("error").unwrap_or(&value);
+    let field = |name: &str| {
+        scope
+            .get(name)
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+    };
+    (
+        field("code").or_else(|| field("error_code")),
+        field("message"),
+    )
+}
+
+async fn sleep_before_retry(attempt: usize) {
+    let index = attempt.saturating_sub(1).min(BACKOFFS_MS.len() - 1);
+    tokio::time::sleep(Duration::from_millis(BACKOFFS_MS[index])).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pagination::PaginationMode;
+
+    #[test]
+    fn base_url_trailing_slash_is_normalised() {
+        let client = RegistryClient::new("http://registry.test/").expect("client");
+        assert_eq!(client.base_url(), "http://registry.test");
+    }
+
+    #[test]
+    fn api_error_bodies_are_parsed() {
+        let (code, message) = extract_api_error(
+            r#"{"code":"INVALID_CURSOR","message":"The provided pagination cursor is invalid"}"#,
+        );
+        assert_eq!(code.as_deref(), Some("INVALID_CURSOR"));
+        assert_eq!(
+            message.as_deref(),
+            Some("The provided pagination cursor is invalid")
+        );
+
+        let (nested_code, _) =
+            extract_api_error(r#"{"error":{"code":"InvalidPaginationCursor","message":"nope"}}"#);
+        assert_eq!(nested_code.as_deref(), Some("InvalidPaginationCursor"));
+
+        assert_eq!(extract_api_error("not json"), (None, None));
+    }
+
+    #[test]
+    fn invalid_cursor_errors_are_recognisable() {
+        let err = Error::Api {
+            method: "GET".to_string(),
+            url: "http://registry.test/api/search".to_string(),
+            status: 400,
+            code: Some("INVALID_CURSOR".to_string()),
+            message: Some("The provided pagination cursor is invalid".to_string()),
+        };
+        assert!(err.is_invalid_cursor());
+        assert_eq!(err.status(), Some(400));
+    }
+
+    #[test]
+    fn mixing_a_cursor_and_an_offset_fails_before_any_request() {
+        let client = RegistryClient::new("http://registry.test").expect("client");
+        let request = crate::models::ContractSearchRequest::new("swap", PaginationMode::Cursor)
+            .with_offset(Some(20));
+
+        assert!(client
+            .search_paginator(request, PageLimits::default())
+            .is_err());
+    }
+}

--- a/backend/registry_client/src/config.rs
+++ b/backend/registry_client/src/config.rs
@@ -1,0 +1,376 @@
+//! Client configuration: base URL, authentication, timeouts, user agent, and
+//! retry policy.
+//!
+//! Credentials are wrapped in [`Secret`], whose `Debug` and `Display` print a
+//! placeholder. Config and error values are therefore safe to log: a bearer
+//! token, API key, or signing secret never reaches a log line through them.
+
+use std::fmt;
+use std::time::Duration;
+
+/// Default per-request timeout.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Default number of attempts for a retryable request (1 try + 2 retries).
+pub const DEFAULT_MAX_ATTEMPTS: usize = 3;
+/// Longest `Retry-After` this client will wait for by default.
+pub const DEFAULT_MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
+
+/// A credential that must never be printed.
+///
+/// The inner value is reachable only through [`Secret::expose`], which is
+/// deliberately noisy at call sites.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Secret(String);
+
+/// What every redacted value renders as.
+pub const REDACTED: &str = "<redacted>";
+
+impl Secret {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// The raw credential. Only for putting it on the wire.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Debug for Secret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(REDACTED)
+    }
+}
+
+impl fmt::Display for Secret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(REDACTED)
+    }
+}
+
+impl<T: Into<String>> From<T> for Secret {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+/// How requests authenticate.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub enum Auth {
+    /// Anonymous — public read endpoints only.
+    #[default]
+    None,
+    /// `Authorization: Bearer <token>`.
+    Bearer(Secret),
+    /// A custom header, e.g. `X-API-Key: <key>`.
+    ApiKey { header: String, value: Secret },
+}
+
+impl Auth {
+    pub fn bearer(token: impl Into<String>) -> Self {
+        Auth::Bearer(Secret::new(token))
+    }
+
+    pub fn api_key(header: impl Into<String>, value: impl Into<String>) -> Self {
+        Auth::ApiKey {
+            header: header.into(),
+            value: Secret::new(value),
+        }
+    }
+
+    pub fn is_anonymous(&self) -> bool {
+        matches!(self, Auth::None)
+    }
+}
+
+/// Redacts the credential; only the *scheme* is identifiable.
+impl fmt::Debug for Auth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Auth::None => f.write_str("None"),
+            Auth::Bearer(_) => write!(f, "Bearer({REDACTED})"),
+            Auth::ApiKey { header, .. } => {
+                write!(f, "ApiKey {{ header: {header:?}, value: {REDACTED} }}")
+            }
+        }
+    }
+}
+
+/// When and how often a failed request is retried.
+///
+/// Retries are opt-out, explicit, and never silent about *what* is retried:
+/// a request is only ever retried when it is safe to repeat — see
+/// [`RetryPolicy::allows_retrying`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetryPolicy {
+    /// Total attempts, retries included. `1` disables retrying.
+    pub max_attempts: usize,
+    /// Backoff before the first retry.
+    pub initial_backoff: Duration,
+    /// Upper bound on the computed backoff.
+    pub max_backoff: Duration,
+    /// Growth factor applied per retry.
+    pub backoff_multiplier: f64,
+    /// Honour a `Retry-After` header instead of the computed backoff.
+    pub respect_retry_after: bool,
+    /// Refuse to wait longer than this for a `Retry-After`; a longer one is
+    /// surfaced as a [`crate::Error::RateLimited`] instead of blocking.
+    pub max_retry_after: Duration,
+    /// Retry requests that timed out.
+    pub retry_on_timeout: bool,
+    /// Retry mutating requests (POST/PATCH) when they carry an idempotency
+    /// key. With no key, a mutation is never retried, whatever this says.
+    pub retry_idempotent_mutations: bool,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            initial_backoff: Duration::from_millis(250),
+            max_backoff: Duration::from_secs(5),
+            backoff_multiplier: 3.0,
+            respect_retry_after: true,
+            max_retry_after: DEFAULT_MAX_RETRY_AFTER,
+            retry_on_timeout: true,
+            retry_idempotent_mutations: true,
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// No retries: every request is attempted exactly once.
+    pub fn none() -> Self {
+        Self {
+            max_attempts: 1,
+            ..Self::default()
+        }
+    }
+
+    /// `attempts` tries in total (clamped to at least 1).
+    pub fn attempts(attempts: usize) -> Self {
+        Self {
+            max_attempts: attempts.max(1),
+            ..Self::default()
+        }
+    }
+
+    pub fn with_initial_backoff(mut self, backoff: Duration) -> Self {
+        self.initial_backoff = backoff;
+        self
+    }
+
+    pub fn with_max_backoff(mut self, backoff: Duration) -> Self {
+        self.max_backoff = backoff;
+        self
+    }
+
+    pub fn with_respect_retry_after(mut self, respect: bool) -> Self {
+        self.respect_retry_after = respect;
+        self
+    }
+
+    pub fn with_max_retry_after(mut self, max: Duration) -> Self {
+        self.max_retry_after = max;
+        self
+    }
+
+    pub fn with_retry_on_timeout(mut self, retry: bool) -> Self {
+        self.retry_on_timeout = retry;
+        self
+    }
+
+    pub fn with_retry_idempotent_mutations(mut self, retry: bool) -> Self {
+        self.retry_idempotent_mutations = retry;
+        self
+    }
+
+    /// Whether a request may be repeated at all.
+    ///
+    /// Safe methods (GET/HEAD/OPTIONS) always may. A mutation may only when the
+    /// caller supplied an idempotency key *and* the policy allows it — repeating
+    /// a keyless publish would risk registering a contract twice.
+    pub fn allows_retrying(&self, safe_method: bool, has_idempotency_key: bool) -> bool {
+        if self.max_attempts <= 1 {
+            return false;
+        }
+        safe_method || (has_idempotency_key && self.retry_idempotent_mutations)
+    }
+
+    /// Backoff before the retry that follows `attempt` (1-based).
+    pub fn backoff_for(&self, attempt: usize) -> Duration {
+        let exponent = attempt.saturating_sub(1).min(16) as i32;
+        let scaled = self.initial_backoff.as_secs_f64() * self.backoff_multiplier.powi(exponent);
+        let capped = scaled.min(self.max_backoff.as_secs_f64()).max(0.0);
+        Duration::from_secs_f64(capped)
+    }
+}
+
+/// Everything a [`crate::RegistryClient`] needs, independent of transport.
+#[derive(Debug, Clone)]
+pub struct ClientConfig {
+    /// Registry base URL, without a trailing slash.
+    pub base_url: String,
+    pub auth: Auth,
+    /// Per-request timeout, applied to each attempt.
+    pub timeout: Duration,
+    /// `User-Agent` sent with every request.
+    pub user_agent: String,
+    pub retry: RetryPolicy,
+}
+
+impl ClientConfig {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: normalize_base_url(base_url),
+            auth: Auth::None,
+            timeout: DEFAULT_TIMEOUT,
+            user_agent: default_user_agent(),
+            retry: RetryPolicy::default(),
+        }
+    }
+
+    pub fn with_auth(mut self, auth: Auth) -> Self {
+        self.auth = auth;
+        self
+    }
+
+    /// Bearer authentication, or anonymous when `token` is `None`.
+    pub fn with_bearer_token(mut self, token: Option<impl Into<String>>) -> Self {
+        self.auth = match token {
+            Some(token) => Auth::bearer(token),
+            None => Auth::None,
+        };
+        self
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn with_user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        self.user_agent = user_agent.into();
+        self
+    }
+
+    pub fn with_retry_policy(mut self, retry: RetryPolicy) -> Self {
+        self.retry = retry;
+        self
+    }
+
+    /// Absolute URL for an API path such as `/api/contracts`.
+    pub fn url_for(&self, path: &str) -> String {
+        if path.starts_with('/') {
+            format!("{}{}", self.base_url, path)
+        } else {
+            format!("{}/{}", self.base_url, path)
+        }
+    }
+}
+
+fn normalize_base_url(base_url: impl Into<String>) -> String {
+    base_url.into().trim_end_matches('/').to_string()
+}
+
+/// `soroban-registry-client/<version>` — identifies the SDK to the registry.
+pub fn default_user_agent() -> String {
+    format!("soroban-registry-client/{}", env!("CARGO_PKG_VERSION"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secrets_are_redacted_in_debug_and_display() {
+        let secret = Secret::new("super-secret-token");
+        assert_eq!(format!("{secret:?}"), REDACTED);
+        assert_eq!(format!("{secret}"), REDACTED);
+        assert!(!format!("{secret:?}").contains("super-secret"));
+        assert_eq!(secret.expose(), "super-secret-token");
+    }
+
+    #[test]
+    fn auth_debug_keeps_the_scheme_but_drops_the_credential() {
+        let bearer = format!("{:?}", Auth::bearer("token-abc"));
+        assert!(bearer.contains("Bearer"));
+        assert!(!bearer.contains("token-abc"));
+
+        let api_key = format!("{:?}", Auth::api_key("X-API-Key", "key-xyz"));
+        assert!(
+            api_key.contains("X-API-Key"),
+            "the header name is not secret"
+        );
+        assert!(!api_key.contains("key-xyz"));
+    }
+
+    #[test]
+    fn config_debug_never_contains_the_token() {
+        let config = ClientConfig::new("http://registry.test").with_auth(Auth::bearer("token-abc"));
+        let rendered = format!("{config:?}");
+        assert!(!rendered.contains("token-abc"), "{rendered}");
+        assert!(rendered.contains(REDACTED), "{rendered}");
+    }
+
+    #[test]
+    fn base_urls_are_normalised_and_joined() {
+        let config = ClientConfig::new("http://registry.test/");
+        assert_eq!(config.base_url, "http://registry.test");
+        assert_eq!(
+            config.url_for("/api/contracts"),
+            "http://registry.test/api/contracts"
+        );
+        assert_eq!(
+            config.url_for("api/contracts"),
+            "http://registry.test/api/contracts"
+        );
+    }
+
+    #[test]
+    fn mutations_are_not_retried_without_an_idempotency_key() {
+        let policy = RetryPolicy::default();
+        assert!(policy.allows_retrying(true, false), "GET is safe to repeat");
+        assert!(
+            !policy.allows_retrying(false, false),
+            "a keyless mutation must never be repeated"
+        );
+        assert!(
+            policy.allows_retrying(false, true),
+            "a keyed mutation may be"
+        );
+    }
+
+    #[test]
+    fn a_disabled_policy_never_retries() {
+        let policy = RetryPolicy::none();
+        assert!(!policy.allows_retrying(true, true));
+    }
+
+    #[test]
+    fn opting_out_of_mutation_retries_is_honoured() {
+        let policy = RetryPolicy::default().with_retry_idempotent_mutations(false);
+        assert!(!policy.allows_retrying(false, true));
+        assert!(policy.allows_retrying(true, false));
+    }
+
+    #[test]
+    fn backoff_grows_and_is_capped() {
+        let policy = RetryPolicy::default()
+            .with_initial_backoff(Duration::from_millis(100))
+            .with_max_backoff(Duration::from_millis(500));
+        assert_eq!(policy.backoff_for(1), Duration::from_millis(100));
+        assert_eq!(policy.backoff_for(2), Duration::from_millis(300));
+        assert_eq!(policy.backoff_for(3), Duration::from_millis(500));
+        assert_eq!(policy.backoff_for(99), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn the_default_user_agent_names_the_sdk() {
+        assert!(default_user_agent().starts_with("soroban-registry-client/"));
+    }
+}

--- a/backend/registry_client/src/error.rs
+++ b/backend/registry_client/src/error.rs
@@ -1,40 +1,174 @@
 //! Error types for the registry client.
+//!
+//! The registry's failure modes are kept apart rather than collapsed into one
+//! "request failed": callers need to tell an expired session (401) from a
+//! permission problem (403), a duplicate publish (409) from a validation
+//! failure (422), and a rate limit (429) from a temporary upstream fault (5xx),
+//! because the correct response differs in every case.
+//!
+//! Nothing in here carries request headers or credentials, so an error is safe
+//! to log or bubble up verbatim.
 
+use std::fmt;
+use std::time::Duration;
+
+use crate::config::REDACTED;
 use crate::pagination::PaginationMode;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// The structured part of an API error response.
+///
+/// The registry answers failures with `{code, message, details, request_id, …}`;
+/// all of it is preserved so callers can branch on `code` and surface `details`
+/// to users without re-parsing the body.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ApiErrorDetails {
+    pub method: String,
+    pub url: String,
+    pub status: u16,
+    /// Server error code, e.g. `INVALID_CURSOR`, `ContractAlreadyExists`.
+    pub code: Option<String>,
+    pub message: Option<String>,
+    /// Structured `details` payload, preserved verbatim.
+    pub details: Option<serde_json::Value>,
+    /// Correlation id from the body or the `x-request-id` header.
+    pub request_id: Option<String>,
+    /// Parsed `Retry-After`, when the response carried one.
+    pub retry_after: Option<Duration>,
+}
+
+impl ApiErrorDetails {
+    pub fn new(method: impl Into<String>, url: impl Into<String>, status: u16) -> Self {
+        Self {
+            method: method.into(),
+            url: url.into(),
+            status,
+            ..Self::default()
+        }
+    }
+
+    /// `code`, or the HTTP status as a string when the server sent none.
+    pub fn code_or_status(&self) -> String {
+        self.code.clone().unwrap_or_else(|| self.status.to_string())
+    }
+}
+
+impl fmt::Display for ApiErrorDetails {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {} returned {}", self.method, self.url, self.status)?;
+        match (self.code.as_deref(), self.message.as_deref()) {
+            (Some(code), Some(message)) => write!(f, " ({code}: {message})")?,
+            (Some(code), None) => write!(f, " ({code})")?,
+            (None, Some(message)) => write!(f, " ({message})")?,
+            (None, None) => {}
+        }
+        if let Some(request_id) = &self.request_id {
+            write!(f, " [request_id={request_id}]")?;
+        }
+        Ok(())
+    }
+}
+
+/// Why a transport-level attempt failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportKind {
+    /// The connection could not be established.
+    Connect,
+    /// The request could not be sent or built.
+    Request,
+    /// The response body could not be read.
+    Body,
+    /// Something else reqwest reported.
+    Other,
+}
+
+impl fmt::Display for TransportKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            TransportKind::Connect => "could not connect to the registry",
+            TransportKind::Request => "the request could not be sent",
+            TransportKind::Body => "the response body could not be read",
+            TransportKind::Other => "the network request failed",
+        })
+    }
+}
+
 /// Anything that can go wrong while talking to the registry.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// The request never produced a response (DNS, connect, timeout, …), after
-    /// any internal retries were exhausted.
-    #[error("request to {url} failed after {attempts} attempt(s): {reason}. Check the API URL and your network connection.")]
+    /// The request never produced a response, after any retries.
+    #[error("request to {url} failed after {attempts} attempt(s): {kind}. Check the API URL and your network connection.")]
     Transport {
         url: String,
         attempts: usize,
+        kind: TransportKind,
+        /// Transport-level detail. Never contains headers or credentials.
         reason: String,
     },
 
-    /// The registry answered with a non-success status.
-    #[error("{method} {url} returned {status}{}", detail_suffix(code, message))]
-    Api {
-        method: String,
+    /// The request exceeded the configured timeout.
+    #[error("request to {url} timed out after {}s ({attempts} attempt(s))", timeout.as_secs())]
+    Timeout {
         url: String,
-        status: u16,
-        /// Machine-readable error code when the API supplied one
-        /// (e.g. `INVALID_CURSOR`, `InvalidPaginationCursor`).
-        code: Option<String>,
-        message: Option<String>,
+        attempts: usize,
+        timeout: Duration,
     },
 
-    /// The response body was not the shape this client expects.
+    /// 401 — missing, expired, or invalid credentials.
+    ///
+    /// The details are boxed so that `Result<T, Error>` stays cheap to return.
+    #[error("authentication failed: {0}")]
+    Unauthorized(Box<ApiErrorDetails>),
+
+    /// 403 — authenticated, but not allowed to do this.
+    #[error("not authorized: {0}")]
+    Forbidden(Box<ApiErrorDetails>),
+
+    /// 404 — no such resource.
+    #[error("not found: {0}")]
+    NotFound(Box<ApiErrorDetails>),
+
+    /// 400/422 — the request was rejected as invalid.
+    #[error("invalid request: {0}")]
+    Validation(Box<ApiErrorDetails>),
+
+    /// 409 — conflicting state, e.g. a contract already registered.
+    #[error("conflict: {0}")]
+    Conflict(Box<ApiErrorDetails>),
+
+    /// 409 with `IdempotencyKeyInProgress` — an identical request carrying the
+    /// same idempotency key is still running. Retry it later; do not re-send
+    /// with a fresh key, which would duplicate the effect.
+    #[error("idempotent request already in flight: {0}")]
+    IdempotencyInProgress(Box<ApiErrorDetails>),
+
+    /// 429 — rate limited. `retry_after` is the server's own advice, when given.
+    #[error("rate limited: {details}{}", retry_after_suffix(retry_after))]
+    RateLimited {
+        details: Box<ApiErrorDetails>,
+        retry_after: Option<Duration>,
+    },
+
+    /// 5xx — the registry or something behind it is temporarily unhealthy.
+    #[error("registry unavailable: {0}")]
+    Upstream(Box<ApiErrorDetails>),
+
+    /// A non-success status that is none of the above.
+    #[error("{0}")]
+    Api(Box<ApiErrorDetails>),
+
+    /// A 2xx response whose body was not what this client expects.
     #[error("could not decode the response from {url}: {reason}")]
-    Decode { url: String, reason: String },
+    MalformedResponse { url: String, reason: String },
 
     /// The client was asked to build an impossible request.
     #[error("invalid request: {0}")]
     InvalidRequest(String),
+
+    /// The caller cancelled the request.
+    #[error("request to {url} was cancelled")]
+    Cancelled { url: String },
 
     /// A pagination walk could not continue safely.
     #[error(transparent)]
@@ -42,39 +176,117 @@ pub enum Error {
 }
 
 impl Error {
-    /// The API error code, when this is an API error that carried one.
-    pub fn api_code(&self) -> Option<&str> {
-        match self {
-            Error::Api { code, .. } => code.as_deref(),
-            _ => None,
-        }
-    }
-
-    /// The HTTP status, when this error came from a response.
+    /// The HTTP status, for errors that came from a response.
     pub fn status(&self) -> Option<u16> {
+        self.details().map(|details| details.status)
+    }
+
+    /// The server's error code, when one was supplied.
+    pub fn code(&self) -> Option<&str> {
+        self.details().and_then(|details| details.code.as_deref())
+    }
+
+    /// The server's structured `details` payload, when one was supplied.
+    pub fn error_details(&self) -> Option<&serde_json::Value> {
+        self.details().and_then(|details| details.details.as_ref())
+    }
+
+    /// The correlation id, for quoting in a bug report.
+    pub fn request_id(&self) -> Option<&str> {
+        self.details()
+            .and_then(|details| details.request_id.as_deref())
+    }
+
+    /// `Retry-After`, when the server sent one.
+    pub fn retry_after(&self) -> Option<Duration> {
         match self {
-            Error::Api { status, .. } => Some(*status),
+            Error::RateLimited { retry_after, .. } => *retry_after,
+            other => other.details().and_then(|details| details.retry_after),
+        }
+    }
+
+    /// The structured API error, for the variants that carry one.
+    pub fn details(&self) -> Option<&ApiErrorDetails> {
+        match self {
+            Error::Unauthorized(details)
+            | Error::Forbidden(details)
+            | Error::NotFound(details)
+            | Error::Validation(details)
+            | Error::Conflict(details)
+            | Error::IdempotencyInProgress(details)
+            | Error::Upstream(details)
+            | Error::Api(details) => Some(details),
+            Error::RateLimited { details, .. } => Some(details),
             _ => None,
         }
     }
 
-    /// True when the registry rejected the continuation token we sent. Callers
-    /// walking a saved cursor should restart the walk rather than retry.
+    /// True when repeating the request could plausibly succeed — a transport
+    /// fault, a timeout, a rate limit, or a 5xx. Says nothing about whether the
+    /// request is *safe* to repeat; that is [`crate::RetryPolicy::allows_retrying`].
+    pub fn is_transient(&self) -> bool {
+        matches!(
+            self,
+            Error::Transport { .. }
+                | Error::Timeout { .. }
+                | Error::RateLimited { .. }
+                | Error::Upstream { .. }
+                | Error::IdempotencyInProgress(_)
+        )
+    }
+
+    /// True for 401/403 — the caller needs different credentials, not a retry.
+    pub fn is_auth(&self) -> bool {
+        matches!(self, Error::Unauthorized(_) | Error::Forbidden(_))
+    }
+
+    /// True when the registry rejected the continuation token we sent. Restart
+    /// the walk rather than retrying with the same cursor.
     pub fn is_invalid_cursor(&self) -> bool {
-        matches!(self.status(), Some(400))
-            && self.api_code().is_some_and(|code| {
+        matches!(self.status(), Some(400) | Some(422))
+            && self.code().is_some_and(|code| {
                 code.eq_ignore_ascii_case("INVALID_CURSOR") || code == "InvalidPaginationCursor"
             })
     }
+
+    /// Classify a non-success response into the taxonomy above.
+    pub fn from_response(details: ApiErrorDetails) -> Self {
+        let retry_after = details.retry_after;
+        let status = details.status;
+        let is_idempotency_replay = details
+            .code
+            .as_deref()
+            .is_some_and(|code| code.eq_ignore_ascii_case("IdempotencyKeyInProgress"));
+        let details = Box::new(details);
+
+        match status {
+            401 => Error::Unauthorized(details),
+            403 => Error::Forbidden(details),
+            404 => Error::NotFound(details),
+            409 if is_idempotency_replay => Error::IdempotencyInProgress(details),
+            409 => Error::Conflict(details),
+            400 | 422 => Error::Validation(details),
+            429 => Error::RateLimited {
+                details,
+                retry_after,
+            },
+            status if (500..600).contains(&status) => Error::Upstream(details),
+            _ => Error::Api(details),
+        }
+    }
 }
 
-fn detail_suffix(code: &Option<String>, message: &Option<String>) -> String {
-    match (code.as_deref(), message.as_deref()) {
-        (Some(code), Some(message)) => format!(" ({code}: {message})"),
-        (Some(code), None) => format!(" ({code})"),
-        (None, Some(message)) => format!(" ({message})"),
-        (None, None) => String::new(),
+fn retry_after_suffix(retry_after: &Option<Duration>) -> String {
+    match retry_after {
+        Some(after) => format!(" (retry after {}s)", after.as_secs()),
+        None => String::new(),
     }
+}
+
+/// Assert-friendly helper for tests and callers that log errors: confirms a
+/// rendered message carries no credential material.
+pub fn is_redacted(rendered: &str, secret: &str) -> bool {
+    !rendered.contains(secret) || rendered.contains(REDACTED)
 }
 
 /// Reasons a pagination walk stops with an error instead of simply ending.
@@ -122,5 +334,127 @@ fn article(mode: PaginationMode) -> &'static str {
     match mode {
         PaginationMode::Offset => "n",
         PaginationMode::Cursor => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn details(status: u16, code: Option<&str>) -> ApiErrorDetails {
+        ApiErrorDetails {
+            method: "POST".to_string(),
+            url: "http://registry.test/api/contracts".to_string(),
+            status,
+            code: code.map(str::to_string),
+            message: Some("boom".to_string()),
+            details: None,
+            request_id: Some("req-1".to_string()),
+            retry_after: None,
+        }
+    }
+
+    #[test]
+    fn statuses_map_to_distinct_variants() {
+        assert!(matches!(
+            Error::from_response(details(401, None)),
+            Error::Unauthorized(_)
+        ));
+        assert!(matches!(
+            Error::from_response(details(403, None)),
+            Error::Forbidden(_)
+        ));
+        assert!(matches!(
+            Error::from_response(details(404, None)),
+            Error::NotFound(_)
+        ));
+        assert!(matches!(
+            Error::from_response(details(409, Some("ContractAlreadyExists"))),
+            Error::Conflict(_)
+        ));
+        assert!(matches!(
+            Error::from_response(details(422, None)),
+            Error::Validation(_)
+        ));
+        assert!(matches!(
+            Error::from_response(details(400, None)),
+            Error::Validation(_)
+        ));
+        assert!(matches!(
+            Error::from_response(details(429, None)),
+            Error::RateLimited { .. }
+        ));
+        assert!(matches!(
+            Error::from_response(details(503, None)),
+            Error::Upstream(_)
+        ));
+        assert!(matches!(
+            Error::from_response(details(418, None)),
+            Error::Api(_)
+        ));
+    }
+
+    #[test]
+    fn an_in_flight_idempotent_replay_is_its_own_variant() {
+        let error = Error::from_response(details(409, Some("IdempotencyKeyInProgress")));
+        assert!(matches!(error, Error::IdempotencyInProgress(_)));
+        assert!(error.is_transient(), "the caller should retry it later");
+    }
+
+    #[test]
+    fn structured_details_are_preserved() {
+        let mut raw = details(422, Some("ValidationError"));
+        raw.details = Some(serde_json::json!({"field": "name", "reason": "too long"}));
+        raw.retry_after = Some(Duration::from_secs(4));
+        let error = Error::from_response(raw);
+
+        assert_eq!(error.status(), Some(422));
+        assert_eq!(error.code(), Some("ValidationError"));
+        assert_eq!(error.request_id(), Some("req-1"));
+        assert_eq!(
+            error
+                .error_details()
+                .and_then(|value| value["field"].as_str()),
+            Some("name")
+        );
+        assert_eq!(error.retry_after(), Some(Duration::from_secs(4)));
+    }
+
+    #[test]
+    fn rate_limit_errors_surface_retry_after() {
+        let mut raw = details(429, Some("RateLimited"));
+        raw.retry_after = Some(Duration::from_secs(30));
+        let error = Error::from_response(raw);
+
+        assert_eq!(error.retry_after(), Some(Duration::from_secs(30)));
+        assert!(error.is_transient());
+        assert!(error.to_string().contains("retry after 30s"), "{error}");
+    }
+
+    #[test]
+    fn transient_and_auth_errors_are_distinguishable() {
+        assert!(Error::from_response(details(503, None)).is_transient());
+        assert!(!Error::from_response(details(422, None)).is_transient());
+        assert!(Error::from_response(details(401, None)).is_auth());
+        assert!(Error::from_response(details(403, None)).is_auth());
+        assert!(!Error::from_response(details(409, None)).is_auth());
+    }
+
+    #[test]
+    fn display_includes_code_message_and_request_id() {
+        let rendered =
+            Error::from_response(details(409, Some("ContractAlreadyExists"))).to_string();
+        assert!(rendered.contains("ContractAlreadyExists"), "{rendered}");
+        assert!(rendered.contains("boom"), "{rendered}");
+        assert!(rendered.contains("req-1"), "{rendered}");
+    }
+
+    #[test]
+    fn invalid_cursor_is_recognised_from_either_code_spelling() {
+        assert!(Error::from_response(details(400, Some("INVALID_CURSOR"))).is_invalid_cursor());
+        assert!(
+            Error::from_response(details(400, Some("InvalidPaginationCursor"))).is_invalid_cursor()
+        );
+        assert!(!Error::from_response(details(400, Some("EMPTY_QUERY"))).is_invalid_cursor());
     }
 }

--- a/backend/registry_client/src/error.rs
+++ b/backend/registry_client/src/error.rs
@@ -1,0 +1,126 @@
+//! Error types for the registry client.
+
+use crate::pagination::PaginationMode;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Anything that can go wrong while talking to the registry.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The request never produced a response (DNS, connect, timeout, …), after
+    /// any internal retries were exhausted.
+    #[error("request to {url} failed after {attempts} attempt(s): {reason}. Check the API URL and your network connection.")]
+    Transport {
+        url: String,
+        attempts: usize,
+        reason: String,
+    },
+
+    /// The registry answered with a non-success status.
+    #[error("{method} {url} returned {status}{}", detail_suffix(code, message))]
+    Api {
+        method: String,
+        url: String,
+        status: u16,
+        /// Machine-readable error code when the API supplied one
+        /// (e.g. `INVALID_CURSOR`, `InvalidPaginationCursor`).
+        code: Option<String>,
+        message: Option<String>,
+    },
+
+    /// The response body was not the shape this client expects.
+    #[error("could not decode the response from {url}: {reason}")]
+    Decode { url: String, reason: String },
+
+    /// The client was asked to build an impossible request.
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
+
+    /// A pagination walk could not continue safely.
+    #[error(transparent)]
+    Pagination(#[from] PaginationError),
+}
+
+impl Error {
+    /// The API error code, when this is an API error that carried one.
+    pub fn api_code(&self) -> Option<&str> {
+        match self {
+            Error::Api { code, .. } => code.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// The HTTP status, when this error came from a response.
+    pub fn status(&self) -> Option<u16> {
+        match self {
+            Error::Api { status, .. } => Some(*status),
+            _ => None,
+        }
+    }
+
+    /// True when the registry rejected the continuation token we sent. Callers
+    /// walking a saved cursor should restart the walk rather than retry.
+    pub fn is_invalid_cursor(&self) -> bool {
+        matches!(self.status(), Some(400))
+            && self.api_code().is_some_and(|code| {
+                code.eq_ignore_ascii_case("INVALID_CURSOR") || code == "InvalidPaginationCursor"
+            })
+    }
+}
+
+fn detail_suffix(code: &Option<String>, message: &Option<String>) -> String {
+    match (code.as_deref(), message.as_deref()) {
+        (Some(code), Some(message)) => format!(" ({code}: {message})"),
+        (Some(code), None) => format!(" ({code})"),
+        (None, Some(message)) => format!(" ({message})"),
+        (None, None) => String::new(),
+    }
+}
+
+/// Reasons a pagination walk stops with an error instead of simply ending.
+///
+/// Every variant here is a *bounded failure*: the client refuses to keep
+/// requesting pages when the continuation state it was handed cannot make
+/// progress, so a misbehaving server can never spin a consumer forever.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PaginationError {
+    /// Cursor pagination and offset parameters are mutually exclusive: the
+    /// cursor already encodes the position, and an offset applied on top of it
+    /// silently skips rows.
+    #[error("cursor pagination cannot be combined with an offset (offset={offset}); drop the offset or switch to offset pagination")]
+    MixedPagination { offset: u64 },
+
+    /// A continuation token of the wrong kind for the active walk.
+    #[error("{expected} pagination cannot continue from a{} {returned} continuation", article(*returned))]
+    ModeMismatch {
+        expected: PaginationMode,
+        returned: PaginationMode,
+    },
+
+    /// The server handed back a cursor it had already handed back. Following it
+    /// would re-fetch a page we have already emitted, forever.
+    #[error("the registry repeated a pagination cursor after page {page}; stopping instead of looping over the same page")]
+    RepeatedCursor { page: u64 },
+
+    /// The offset did not move forward, so the next request would return the
+    /// same rows.
+    #[error("offset pagination did not advance past {offset} after page {page}; stopping instead of re-reading the same rows")]
+    StalledOffset { offset: u64, page: u64 },
+
+    /// `offset + page_len` does not fit in a `u64`.
+    #[error("offset pagination overflowed: {offset} + {page_len} exceeds the largest representable offset")]
+    OffsetOverflow { offset: u64, page_len: u64 },
+
+    /// Repeated empty pages that still carry a continuation token. A server
+    /// doing this cannot be distinguished from one looping, so stop.
+    #[error("the registry returned {pages} consecutive empty page(s) while still offering a continuation token; stopping to avoid an endless walk")]
+    EmptyPageLoop { pages: u32 },
+}
+
+/// `a`/`an` for the mode name, so messages read naturally.
+fn article(mode: PaginationMode) -> &'static str {
+    match mode {
+        PaginationMode::Offset => "n",
+        PaginationMode::Cursor => "",
+    }
+}

--- a/backend/registry_client/src/http.rs
+++ b/backend/registry_client/src/http.rs
@@ -1,0 +1,658 @@
+//! Request execution: authentication, retries, idempotency, cancellation, and
+//! the mapping from HTTP responses onto the typed error taxonomy.
+//!
+//! Credentials are attached here and nowhere else, and never copied into an
+//! error, a cache key, or a log line.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::header::{HeaderMap, RETRY_AFTER};
+use reqwest::{Method, StatusCode};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::config::{Auth, ClientConfig};
+use crate::error::{ApiErrorDetails, Error, Result, TransportKind};
+use crate::pagination::CancelToken;
+
+/// Header carrying the idempotency key for mutating requests.
+pub const IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";
+/// Longest idempotency key the registry accepts.
+pub const IDEMPOTENCY_KEY_MAX_LEN: usize = 255;
+
+/// A response body cache the client may consult for safe reads.
+///
+/// The CLI plugs its on-disk HTTP cache in here; other consumers can ignore it.
+/// Only `GET`s marked cacheable are ever looked up or stored, and authenticated
+/// responses are cached exactly as any other — supply a cache that is scoped to
+/// the credential if that matters to you.
+pub trait ResponseCache: Send + Sync {
+    /// Cached body for `key`, if any is still fresh.
+    fn get(&self, key: &str) -> Option<String>;
+    /// Store a successful response body.
+    fn put(&self, key: &str, body: &str);
+}
+
+/// One HTTP call, described independently of how it is executed.
+#[derive(Debug, Clone)]
+pub struct RequestSpec {
+    pub method: Method,
+    /// API path such as `/api/contracts`, or an absolute URL.
+    pub path: String,
+    pub query: Vec<(String, String)>,
+    pub body: Option<serde_json::Value>,
+    /// Sent as `Idempotency-Key`. Also the only thing that makes a mutation
+    /// eligible for retrying.
+    pub idempotency_key: Option<String>,
+    /// Allow the [`ResponseCache`] to serve this request (`GET` only).
+    pub cacheable: bool,
+}
+
+impl RequestSpec {
+    pub fn new(method: Method, path: impl Into<String>) -> Self {
+        Self {
+            method,
+            path: path.into(),
+            query: Vec::new(),
+            body: None,
+            idempotency_key: None,
+            cacheable: false,
+        }
+    }
+
+    /// A cacheable `GET`.
+    pub fn get(path: impl Into<String>) -> Self {
+        Self::new(Method::GET, path).cacheable(true)
+    }
+
+    pub fn post(path: impl Into<String>) -> Self {
+        Self::new(Method::POST, path)
+    }
+
+    pub fn patch(path: impl Into<String>) -> Self {
+        Self::new(Method::PATCH, path)
+    }
+
+    pub fn delete(path: impl Into<String>) -> Self {
+        Self::new(Method::DELETE, path)
+    }
+
+    pub fn query_pair(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.query.push((key.into(), value.into()));
+        self
+    }
+
+    /// Add a query pair only when the value is `Some`.
+    pub fn maybe_query<T: ToString>(self, key: &str, value: Option<T>) -> Self {
+        match value {
+            Some(value) => self.query_pair(key, value.to_string()),
+            None => self,
+        }
+    }
+
+    pub fn json_body<T: Serialize>(mut self, body: &T) -> Result<Self> {
+        self.body = Some(serde_json::to_value(body).map_err(|err| {
+            Error::InvalidRequest(format!("request body could not be serialized: {err}"))
+        })?);
+        Ok(self)
+    }
+
+    pub fn raw_body(mut self, body: serde_json::Value) -> Self {
+        self.body = Some(body);
+        self
+    }
+
+    /// Attach an idempotency key, making a safe retry of this mutation possible.
+    pub fn idempotency_key(mut self, key: Option<impl Into<String>>) -> Result<Self> {
+        self.idempotency_key = match key {
+            Some(key) => {
+                let key = key.into();
+                if key.is_empty() || key.len() > IDEMPOTENCY_KEY_MAX_LEN {
+                    return Err(Error::InvalidRequest(format!(
+                        "idempotency key must be 1..={IDEMPOTENCY_KEY_MAX_LEN} characters"
+                    )));
+                }
+                Some(key)
+            }
+            None => None,
+        };
+        Ok(self)
+    }
+
+    pub fn cacheable(mut self, cacheable: bool) -> Self {
+        self.cacheable = cacheable;
+        self
+    }
+
+    /// `GET`/`HEAD`/`OPTIONS` — free of side effects, so always safe to repeat.
+    pub fn is_safe(&self) -> bool {
+        matches!(self.method, Method::GET | Method::HEAD | Method::OPTIONS)
+    }
+}
+
+/// Executes [`RequestSpec`]s against one registry.
+#[derive(Clone)]
+pub(crate) struct Transport {
+    http: reqwest::Client,
+    config: Arc<ClientConfig>,
+    cache: Option<Arc<dyn ResponseCache>>,
+    cancel: Option<CancelToken>,
+}
+
+/// Redacts the credential-bearing config; see [`ClientConfig`]'s own `Debug`.
+impl std::fmt::Debug for Transport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Transport")
+            .field("config", &self.config)
+            .field("cache", &self.cache.is_some())
+            .field("cancellable", &self.cancel.is_some())
+            .finish()
+    }
+}
+
+impl Transport {
+    pub(crate) fn new(config: Arc<ClientConfig>, http: reqwest::Client) -> Self {
+        Self {
+            http,
+            config,
+            cache: None,
+            cancel: None,
+        }
+    }
+
+    pub(crate) fn config(&self) -> &ClientConfig {
+        &self.config
+    }
+
+    pub(crate) fn set_cache(&mut self, cache: Option<Arc<dyn ResponseCache>>) {
+        self.cache = cache;
+    }
+
+    /// Mutate the shared configuration, leaving clones of this transport that
+    /// were made earlier untouched.
+    pub(crate) fn map_config(&mut self, apply: impl FnOnce(&mut ClientConfig)) {
+        apply(Arc::make_mut(&mut self.config));
+    }
+
+    pub(crate) fn set_cancel_token(&mut self, cancel: Option<CancelToken>) {
+        self.cancel = cancel;
+    }
+
+    pub(crate) fn cancel_token(&self) -> Option<&CancelToken> {
+        self.cancel.as_ref()
+    }
+
+    /// Execute and decode a JSON response.
+    pub(crate) async fn send_json<T: DeserializeOwned>(&self, spec: RequestSpec) -> Result<T> {
+        let url = self.url_for(&spec.path);
+        let body = self.send(spec).await?;
+        serde_json::from_str(&body).map_err(|err| Error::MalformedResponse {
+            url,
+            reason: err.to_string(),
+        })
+    }
+
+    /// Execute a request whose response body is irrelevant (204 and friends).
+    pub(crate) async fn send_discard(&self, spec: RequestSpec) -> Result<()> {
+        self.send(spec).await.map(|_| ())
+    }
+
+    /// Execute a request, returning the raw response body.
+    ///
+    /// Retries follow the configured [`crate::RetryPolicy`]: safe methods and
+    /// mutations carrying an idempotency key may be repeated, nothing else is.
+    pub(crate) async fn send(&self, spec: RequestSpec) -> Result<String> {
+        match self.cancel.clone() {
+            Some(cancel) => {
+                let url = self.url_for(&spec.path);
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => Err(Error::Cancelled { url }),
+                    result = self.send_inner(spec) => result,
+                }
+            }
+            None => self.send_inner(spec).await,
+        }
+    }
+
+    async fn send_inner(&self, spec: RequestSpec) -> Result<String> {
+        let url = self.url_for(&spec.path);
+        let policy = &self.config.retry;
+        let may_retry = policy.allows_retrying(spec.is_safe(), spec.idempotency_key.is_some());
+        let max_attempts = if may_retry {
+            policy.max_attempts.max(1)
+        } else {
+            1
+        };
+
+        let cache_key = (spec.cacheable && spec.method == Method::GET)
+            .then(|| cache_key(&url, &spec.query))
+            .filter(|_| self.cache.is_some());
+        if let (Some(cache), Some(key)) = (&self.cache, &cache_key) {
+            if let Some(body) = cache.get(key) {
+                return Ok(body);
+            }
+        }
+
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+
+            let outcome = self.attempt(&spec, &url).await;
+            let error = match outcome {
+                Ok(body) => {
+                    if let (Some(cache), Some(key)) = (&self.cache, &cache_key) {
+                        cache.put(key, &body);
+                    }
+                    return Ok(body);
+                }
+                Err(error) => error,
+            };
+
+            if attempt >= max_attempts || !error.is_transient() {
+                return Err(self.finalize_error(error, attempt));
+            }
+
+            // A server-supplied Retry-After wins over the computed backoff, but
+            // only up to the configured ceiling: a caller should not silently
+            // block for minutes inside one call.
+            let delay = match (policy.respect_retry_after, error.retry_after()) {
+                (true, Some(after)) if after > policy.max_retry_after => {
+                    return Err(self.finalize_error(error, attempt));
+                }
+                (true, Some(after)) => after,
+                _ => policy.backoff_for(attempt),
+            };
+            if matches!(error, Error::Timeout { .. }) && !policy.retry_on_timeout {
+                return Err(self.finalize_error(error, attempt));
+            }
+
+            tokio::time::sleep(delay).await;
+        }
+    }
+
+    /// One attempt: send, read, classify.
+    async fn attempt(&self, spec: &RequestSpec, url: &str) -> Result<String> {
+        let mut builder = self
+            .http
+            .request(spec.method.clone(), url)
+            .timeout(self.config.timeout)
+            .header(reqwest::header::USER_AGENT, &self.config.user_agent);
+
+        if !spec.query.is_empty() {
+            builder = builder.query(&spec.query);
+        }
+        if let Some(body) = &spec.body {
+            builder = builder.json(body);
+        }
+        if let Some(key) = &spec.idempotency_key {
+            builder = builder.header(IDEMPOTENCY_KEY_HEADER, key);
+        }
+        // The only place a credential is ever attached.
+        builder = match &self.config.auth {
+            Auth::None => builder,
+            Auth::Bearer(token) => builder.bearer_auth(token.expose()),
+            Auth::ApiKey { header, value } => builder.header(header.as_str(), value.expose()),
+        };
+
+        let response = match builder.send().await {
+            Ok(response) => response,
+            Err(err) => return Err(self.transport_error(err, url)),
+        };
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = response.text().await.map_err(|err| Error::Transport {
+            url: url.to_string(),
+            attempts: 1,
+            kind: TransportKind::Body,
+            reason: err.to_string(),
+        })?;
+
+        if status.is_success() {
+            return Ok(body);
+        }
+
+        Err(Error::from_response(build_details(
+            &spec.method,
+            url,
+            status,
+            &headers,
+            &body,
+        )))
+    }
+
+    fn transport_error(&self, err: reqwest::Error, url: &str) -> Error {
+        if err.is_timeout() {
+            return Error::Timeout {
+                url: url.to_string(),
+                attempts: 1,
+                timeout: self.config.timeout,
+            };
+        }
+        let kind = if err.is_connect() {
+            TransportKind::Connect
+        } else if err.is_request() {
+            TransportKind::Request
+        } else {
+            TransportKind::Other
+        };
+        Error::Transport {
+            url: url.to_string(),
+            attempts: 1,
+            kind,
+            // reqwest's Display carries the URL and cause, never headers.
+            reason: err.to_string(),
+        }
+    }
+
+    /// Stamp the real attempt count onto transport-level errors, which are
+    /// constructed one attempt at a time.
+    fn finalize_error(&self, error: Error, attempts: usize) -> Error {
+        match error {
+            Error::Transport {
+                url, kind, reason, ..
+            } => Error::Transport {
+                url,
+                attempts,
+                kind,
+                reason,
+            },
+            Error::Timeout { url, timeout, .. } => Error::Timeout {
+                url,
+                attempts,
+                timeout,
+            },
+            other => other,
+        }
+    }
+
+    fn url_for(&self, path: &str) -> String {
+        if path.starts_with("http://") || path.starts_with("https://") {
+            path.to_string()
+        } else {
+            self.config.url_for(path)
+        }
+    }
+}
+
+/// Flatten a serializable request into query pairs.
+///
+/// Lets a typed params struct from `shared` (e.g. `ContractSearchParams`) be
+/// used as-is: `None` fields are dropped, scalars stringify, and sequences join
+/// with commas — the shape every list filter on the API accepts.
+pub fn query_pairs_from<T: Serialize>(params: &T) -> Result<Vec<(String, String)>> {
+    let value = serde_json::to_value(params).map_err(|err| {
+        Error::InvalidRequest(format!("query parameters could not be serialized: {err}"))
+    })?;
+    let serde_json::Value::Object(fields) = value else {
+        return Err(Error::InvalidRequest(
+            "query parameters must serialize to an object".to_string(),
+        ));
+    };
+
+    let mut pairs = Vec::new();
+    for (key, value) in fields {
+        match value {
+            serde_json::Value::Null => {}
+            serde_json::Value::String(text) => pairs.push((key, text)),
+            serde_json::Value::Bool(flag) => pairs.push((key, flag.to_string())),
+            serde_json::Value::Number(number) => pairs.push((key, number.to_string())),
+            serde_json::Value::Array(items) => {
+                let joined: Vec<String> = items
+                    .iter()
+                    .filter_map(|item| match item {
+                        serde_json::Value::String(text) => Some(text.clone()),
+                        serde_json::Value::Null => None,
+                        other => Some(other.to_string()),
+                    })
+                    .collect();
+                if !joined.is_empty() {
+                    pairs.push((key, joined.join(",")));
+                }
+            }
+            // Nested objects have no query-string representation; a caller that
+            // needs one should pass the field explicitly.
+            serde_json::Value::Object(_) => {}
+        }
+    }
+    pairs.sort();
+    Ok(pairs)
+}
+
+/// Cache key for a safe read. Built from the URL and query only — never from a
+/// header — so no credential can leak into a cache file name.
+fn cache_key(url: &str, query: &[(String, String)]) -> String {
+    if query.is_empty() {
+        return url.to_string();
+    }
+    let mut pairs: Vec<String> = query
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect();
+    pairs.sort();
+    format!("{url}?{}", pairs.join("&"))
+}
+
+/// Pull the structured error out of a failure response.
+fn build_details(
+    method: &Method,
+    url: &str,
+    status: StatusCode,
+    headers: &HeaderMap,
+    body: &str,
+) -> ApiErrorDetails {
+    let mut details = ApiErrorDetails::new(method.as_str(), url, status.as_u16());
+    details.retry_after = parse_retry_after(headers);
+    details.request_id = headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        // Not JSON: keep a bounded snippet so the caller can see *something*.
+        if !body.trim().is_empty() {
+            details.message = Some(truncate(body.trim(), 500));
+        }
+        return details;
+    };
+
+    // The API answers with a flat `{code, message, details, request_id}`; a
+    // nested `{"error": {…}}` shape is accepted too.
+    let scope = value.get("error").unwrap_or(&value);
+    let string_field = |name: &str| {
+        scope
+            .get(name)
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+    };
+
+    details.code = string_field("code").or_else(|| string_field("error_code"));
+    details.message = string_field("message").or_else(|| string_field("error"));
+    details.details = scope
+        .get("details")
+        .filter(|value| !value.is_null())
+        .cloned();
+    details.request_id = details
+        .request_id
+        .or_else(|| string_field("request_id"))
+        .or_else(|| string_field("correlation_id"));
+
+    details
+}
+
+/// `Retry-After` in delta-seconds, which is what the registry emits. An
+/// HTTP-date form is ignored rather than guessed at.
+fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
+    let raw = headers.get(RETRY_AFTER)?.to_str().ok()?;
+    raw.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+fn truncate(value: &str, max: usize) -> String {
+    if value.chars().count() <= max {
+        return value.to_string();
+    }
+    let kept: String = value.chars().take(max).collect();
+    format!("{kept}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers_with(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        for (name, value) in pairs {
+            headers.insert(
+                reqwest::header::HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                value.parse().unwrap(),
+            );
+        }
+        headers
+    }
+
+    #[test]
+    fn api_error_bodies_are_parsed_into_details() {
+        let details = build_details(
+            &Method::POST,
+            "http://registry.test/api/contracts",
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &headers_with(&[("x-request-id", "req-42")]),
+            r#"{"code":"ValidationError","message":"name too long","details":{"field":"name"}}"#,
+        );
+
+        assert_eq!(details.status, 422);
+        assert_eq!(details.code.as_deref(), Some("ValidationError"));
+        assert_eq!(details.message.as_deref(), Some("name too long"));
+        assert_eq!(details.request_id.as_deref(), Some("req-42"));
+        assert_eq!(details.details.unwrap()["field"], "name");
+    }
+
+    #[test]
+    fn nested_error_bodies_are_accepted() {
+        let details = build_details(
+            &Method::GET,
+            "http://registry.test/api/contracts/x",
+            StatusCode::NOT_FOUND,
+            &HeaderMap::new(),
+            r#"{"error":{"code":"NotFound","message":"no such contract"}}"#,
+        );
+        assert_eq!(details.code.as_deref(), Some("NotFound"));
+        assert_eq!(details.message.as_deref(), Some("no such contract"));
+    }
+
+    #[test]
+    fn non_json_error_bodies_keep_a_bounded_snippet() {
+        let details = build_details(
+            &Method::GET,
+            "http://registry.test/api/contracts",
+            StatusCode::BAD_GATEWAY,
+            &HeaderMap::new(),
+            &"upstream exploded ".repeat(100),
+        );
+        let message = details.message.expect("snippet");
+        assert!(message.starts_with("upstream exploded"));
+        assert!(message.chars().count() <= 501, "snippet must be bounded");
+    }
+
+    #[test]
+    fn retry_after_seconds_are_parsed() {
+        assert_eq!(
+            parse_retry_after(&headers_with(&[("retry-after", "30")])),
+            Some(Duration::from_secs(30))
+        );
+        // HTTP-date form is not guessed at.
+        assert_eq!(
+            parse_retry_after(&headers_with(&[(
+                "retry-after",
+                "Wed, 21 Oct 2026 07:28:00 GMT"
+            )])),
+            None
+        );
+        assert_eq!(parse_retry_after(&HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn cache_keys_are_order_independent_and_credential_free() {
+        let a = cache_key(
+            "http://registry.test/api/contracts",
+            &[
+                ("limit".to_string(), "20".to_string()),
+                ("network".to_string(), "testnet".to_string()),
+            ],
+        );
+        let b = cache_key(
+            "http://registry.test/api/contracts",
+            &[
+                ("network".to_string(), "testnet".to_string()),
+                ("limit".to_string(), "20".to_string()),
+            ],
+        );
+        assert_eq!(a, b);
+        assert!(!a.contains("Bearer"));
+    }
+
+    #[test]
+    fn typed_params_flatten_into_query_pairs() {
+        #[derive(serde::Serialize)]
+        struct Params {
+            query: Option<String>,
+            limit: Option<i64>,
+            verified_only: Option<bool>,
+            networks: Option<Vec<String>>,
+            missing: Option<String>,
+        }
+
+        let pairs = query_pairs_from(&Params {
+            query: Some("swap".to_string()),
+            limit: Some(20),
+            verified_only: Some(true),
+            networks: Some(vec!["testnet".to_string(), "mainnet".to_string()]),
+            missing: None,
+        })
+        .expect("params flatten");
+
+        assert_eq!(
+            pairs,
+            vec![
+                ("limit".to_string(), "20".to_string()),
+                ("networks".to_string(), "testnet,mainnet".to_string()),
+                ("query".to_string(), "swap".to_string()),
+                ("verified_only".to_string(), "true".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn safe_methods_are_recognised() {
+        assert!(RequestSpec::get("/api/contracts").is_safe());
+        assert!(!RequestSpec::post("/api/contracts").is_safe());
+        assert!(!RequestSpec::patch("/api/contracts/x/metadata").is_safe());
+        assert!(!RequestSpec::delete("/api/webhooks/x").is_safe());
+    }
+
+    #[test]
+    fn idempotency_keys_are_validated() {
+        assert!(RequestSpec::post("/api/contracts")
+            .idempotency_key(Some("key-1"))
+            .is_ok());
+        assert!(RequestSpec::post("/api/contracts")
+            .idempotency_key(Some(""))
+            .is_err());
+        assert!(RequestSpec::post("/api/contracts")
+            .idempotency_key(Some("k".repeat(IDEMPOTENCY_KEY_MAX_LEN + 1)))
+            .is_err());
+        assert!(RequestSpec::post("/api/contracts")
+            .idempotency_key(None::<String>)
+            .is_ok());
+    }
+
+    #[test]
+    fn optional_query_pairs_are_skipped_when_absent() {
+        let spec = RequestSpec::get("/api/contracts")
+            .maybe_query("limit", Some(20))
+            .maybe_query("cursor", None::<String>);
+        assert_eq!(spec.query, vec![("limit".to_string(), "20".to_string())]);
+    }
+}

--- a/backend/registry_client/src/lib.rs
+++ b/backend/registry_client/src/lib.rs
@@ -1,55 +1,128 @@
-//! Typed client for the Soroban Registry HTTP API.
+//! Typed Rust client for the Soroban Registry HTTP API.
 //!
-//! The registry paginates in two ways — stable keyset **cursor** pagination
-//! served by PostgreSQL, and **offset** pagination served by Elasticsearch (see
-//! `docs/pagination.md`). Consumers used to have to know which endpoint uses
-//! which, and manage continuation state by hand: easy to mix a cursor with an
-//! offset, lose results, re-read a page, or loop forever on a bad token.
+//! The registry's HTTP surface — request construction, authentication, retries,
+//! pagination, response decoding, and error mapping — lives here rather than in
+//! any one consumer. The CLI, CI integrations, publisher automation, and
+//! third-party tools then share one interpretation of pagination tokens,
+//! authentication failures, conflict responses, and structured API errors.
 //!
-//! This crate wraps both behind one abstraction. Pick a mode, get a
-//! [`Paginator`], and iterate:
+//! # Searching
 //!
 //! ```no_run
-//! use futures_util::StreamExt;
 //! use registry_client::{ContractSearchRequest, PageLimits, RegistryClient};
 //!
 //! # async fn example() -> registry_client::Result<()> {
-//! let client = RegistryClient::new("http://localhost:3001")?;
-//! let request = ContractSearchRequest::cursor("swap").with_networks(["testnet"]);
+//! let client = RegistryClient::new("https://registry.example")?;
 //!
-//! // Page at a time…
+//! // Walk every page of a search, bounded at 1000 items.
 //! let mut walk = client.search_paginator(
-//!     request.clone(),
+//!     ContractSearchRequest::cursor("swap").with_networks(["testnet"]),
 //!     PageLimits::default().with_max_items(Some(1_000)),
 //! )?;
 //! while let Some(page) = walk.next_page().await? {
-//!     println!("{} result(s) of {:?}", page.items.len(), page.total);
-//! }
-//!
-//! // …or as a stream of items. The stream is not `Unpin`, so pin it to poll it.
-//! let mut items = Box::pin(
-//!     client
-//!         .search_paginator(request, PageLimits::default().with_max_items(Some(1_000)))?
-//!         .items(),
-//! );
-//! while let Some(hit) = items.next().await {
-//!     println!("{}", hit?.name);
+//!     for hit in page.items {
+//!         println!("{} — {}", hit.name, hit.contract_id);
+//!     }
 //! }
 //! # Ok(())
 //! # }
 //! ```
 //!
-//! Every walk is bounded, cancellable, and refuses to follow a continuation that
-//! cannot make progress — see [`pagination`] for the full list of guarantees.
+//! # Publishing
+//!
+//! ```no_run
+//! use registry_client::{Auth, ClientConfig, Network, PublishRequest, RegistryClient};
+//!
+//! # async fn example() -> registry_client::Result<()> {
+//! let client = RegistryClient::from_config(
+//!     ClientConfig::new("https://registry.example").with_auth(Auth::bearer("…token…")),
+//! )?;
+//!
+//! let request = PublishRequest {
+//!     contract_id: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC".to_string(),
+//!     wasm_hash: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08".to_string(),
+//!     wasm_artifact_base64: None,
+//!     name: "swap-router".to_string(),
+//!     slug: None,
+//!     description: Some("AMM router".to_string()),
+//!     network: Network::Testnet,
+//!     category: Some("DeFi".to_string()),
+//!     tags: vec!["amm".to_string()],
+//!     source_url: None,
+//!     publisher_address: "GDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC".to_string(),
+//!     dependencies: Vec::new(),
+//!     is_cicd: true,
+//! };
+//!
+//! // With an idempotency key a lost response can be retried safely: the
+//! // registry replays the original result instead of publishing twice.
+//! match client
+//!     .publish_contract(&request, Some("release-1.4.2".to_string()))
+//!     .await
+//! {
+//!     Ok(contract) => println!("published {}", contract.contract_id),
+//!     Err(err) if err.is_auth() => eprintln!("log in again: {err}"),
+//!     Err(err) => return Err(err),
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Errors
+//!
+//! Failure modes stay distinct — [`Error::Unauthorized`], [`Error::Forbidden`],
+//! [`Error::Validation`], [`Error::Conflict`], [`Error::IdempotencyInProgress`],
+//! [`Error::RateLimited`], [`Error::Upstream`], [`Error::Timeout`],
+//! [`Error::MalformedResponse`] — and each carries the server's `code`,
+//! `message`, structured `details`, request id, and `Retry-After` where present.
+//!
+//! # Retries
+//!
+//! [`RetryPolicy`] is explicit and configurable. Safe methods may be retried;
+//! a mutation is retried **only** when the call supplies an idempotency key, so
+//! a publish is never silently repeated. `Retry-After` is honoured up to a
+//! configurable ceiling.
+//!
+//! # Secrets
+//!
+//! Bearer tokens, API keys, and webhook signing secrets are held in [`Secret`],
+//! whose `Debug`/`Display` print `<redacted>`. Errors carry no headers, so
+//! logging a client, a config, or an error cannot leak a credential.
+//!
+//! # Cancellation
+//!
+//! [`RegistryClient::with_cancel_token`] aborts in-flight requests, and a
+//! [`Paginator`] stops between pages, keeping what it already emitted.
 
+pub mod api;
 pub mod client;
+pub mod config;
 pub mod error;
+pub mod http;
 pub mod models;
 pub mod pagination;
 
-pub use client::{ContractSearchFetcher, RegistryClient};
-pub use error::{Error, PaginationError, Result};
-pub use models::{ContractHit, ContractSearchRequest, SearchEndpoint};
+pub use api::contracts::{ContractListFetcher, ContractSearchFetcher};
+pub use api::snapshots::RegistrySigningKey;
+pub use api::verification::{
+    ContractVerifyRequest, VerificationHistoryEntry, VerificationHistoryResponse,
+    VerificationStatusResponse, VerificationSubmitResponse,
+};
+pub use api::webhooks::{CreatedWebhook, WebhookDelivery};
+pub use client::RegistryClient;
+pub use config::{
+    default_user_agent, Auth, ClientConfig, RetryPolicy, Secret, DEFAULT_MAX_ATTEMPTS,
+    DEFAULT_TIMEOUT, REDACTED,
+};
+pub use error::{ApiErrorDetails, Error, PaginationError, Result, TransportKind};
+pub use http::{query_pairs_from, RequestSpec, ResponseCache, IDEMPOTENCY_KEY_HEADER};
+pub use models::{
+    ConfirmOwnershipTransferRequest, Contract, ContractGetResponse, ContractHit,
+    ContractSearchParams, ContractSearchRequest, ContractSnapshot, CreateOwnershipTransferRequest,
+    CreateWebhookRequest, DependencyScanReport, DeprecateContractRequest, DeprecationInfo, Network,
+    OwnershipTransfer, OwnershipTransferLog, PaginatedResponse, PublishRequest, SearchEndpoint,
+    UpdateContractMetadataRequest, WebhookConfiguration,
+};
 pub use pagination::{
     CancelToken, PageCollection, PageCursor, PageFetcher, PageLimits, PageRequest, PaginationMode,
     Paginator, RegistryPage, StopReason, DEFAULT_MAX_PAGES, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,

--- a/backend/registry_client/src/lib.rs
+++ b/backend/registry_client/src/lib.rs
@@ -1,0 +1,56 @@
+//! Typed client for the Soroban Registry HTTP API.
+//!
+//! The registry paginates in two ways — stable keyset **cursor** pagination
+//! served by PostgreSQL, and **offset** pagination served by Elasticsearch (see
+//! `docs/pagination.md`). Consumers used to have to know which endpoint uses
+//! which, and manage continuation state by hand: easy to mix a cursor with an
+//! offset, lose results, re-read a page, or loop forever on a bad token.
+//!
+//! This crate wraps both behind one abstraction. Pick a mode, get a
+//! [`Paginator`], and iterate:
+//!
+//! ```no_run
+//! use futures_util::StreamExt;
+//! use registry_client::{ContractSearchRequest, PageLimits, RegistryClient};
+//!
+//! # async fn example() -> registry_client::Result<()> {
+//! let client = RegistryClient::new("http://localhost:3001")?;
+//! let request = ContractSearchRequest::cursor("swap").with_networks(["testnet"]);
+//!
+//! // Page at a time…
+//! let mut walk = client.search_paginator(
+//!     request.clone(),
+//!     PageLimits::default().with_max_items(Some(1_000)),
+//! )?;
+//! while let Some(page) = walk.next_page().await? {
+//!     println!("{} result(s) of {:?}", page.items.len(), page.total);
+//! }
+//!
+//! // …or as a stream of items. The stream is not `Unpin`, so pin it to poll it.
+//! let mut items = Box::pin(
+//!     client
+//!         .search_paginator(request, PageLimits::default().with_max_items(Some(1_000)))?
+//!         .items(),
+//! );
+//! while let Some(hit) = items.next().await {
+//!     println!("{}", hit?.name);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Every walk is bounded, cancellable, and refuses to follow a continuation that
+//! cannot make progress — see [`pagination`] for the full list of guarantees.
+
+pub mod client;
+pub mod error;
+pub mod models;
+pub mod pagination;
+
+pub use client::{ContractSearchFetcher, RegistryClient};
+pub use error::{Error, PaginationError, Result};
+pub use models::{ContractHit, ContractSearchRequest, SearchEndpoint};
+pub use pagination::{
+    CancelToken, PageCollection, PageCursor, PageFetcher, PageLimits, PageRequest, PaginationMode,
+    Paginator, RegistryPage, StopReason, DEFAULT_MAX_PAGES, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
+};

--- a/backend/registry_client/src/models.rs
+++ b/backend/registry_client/src/models.rs
@@ -5,6 +5,17 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Error, PaginationError, Result};
 use crate::pagination::{advance_offset, PageCursor, PaginationMode};
 
+// Request and response types the registry already defines are re-exported
+// rather than redeclared, so a consumer never has to keep a parallel copy in
+// sync with the backend.
+pub use shared::models::{
+    ConfirmOwnershipTransferRequest, Contract, ContractGetResponse, ContractSearchParams,
+    CreateOwnershipTransferRequest, CreateWebhookRequest, DependencyScanReport,
+    DeprecateContractRequest, DeprecationInfo, Network, OwnershipTransfer, OwnershipTransferLog,
+    PaginatedResponse, PublishRequest, UpdateContractMetadataRequest, WebhookConfiguration,
+};
+pub use shared::snapshot::ContractSnapshot;
+
 /// One search result, normalised across the registry's search endpoints.
 ///
 /// `GET /api/search` names the array `contracts` and `GET /api/v1/contracts/search`
@@ -516,5 +527,21 @@ mod tests {
                 .unwrap(),
             None
         );
+    }
+}
+
+#[cfg(test)]
+mod wire_compat_tests {
+    use super::*;
+
+    /// The registry omits `next_cursor` when there is no next page, so the
+    /// paginated envelope must decode without it.
+    #[test]
+    fn a_paginated_envelope_decodes_without_its_optional_fields() {
+        let page: PaginatedResponse<serde_json::Value> =
+            serde_json::from_str(r#"{"items":[],"total":0,"page":1,"per_page":20,"pages":0}"#)
+                .expect("a response without optional fields must decode");
+        assert!(page.next_cursor.is_none());
+        assert!(page.filters.is_none());
     }
 }

--- a/backend/registry_client/src/models.rs
+++ b/backend/registry_client/src/models.rs
@@ -1,0 +1,520 @@
+//! Request and response models for the registry search endpoints.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, PaginationError, Result};
+use crate::pagination::{advance_offset, PageCursor, PaginationMode};
+
+/// One search result, normalised across the registry's search endpoints.
+///
+/// `GET /api/search` names the array `contracts` and `GET /api/v1/contracts/search`
+/// names it `results`; both carry the same fields, so consumers see one type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContractHit {
+    /// Registry UUID.
+    #[serde(default)]
+    pub id: String,
+    /// On-chain contract address.
+    #[serde(default)]
+    pub contract_id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub category: Option<String>,
+    #[serde(default)]
+    pub network: String,
+    #[serde(default)]
+    pub is_verified: bool,
+    #[serde(default)]
+    pub is_deprecated: bool,
+    #[serde(default)]
+    pub deprecation_status: Option<String>,
+    #[serde(default)]
+    pub replacement_contract_id: Option<String>,
+    #[serde(default)]
+    pub relevance_score: Option<f64>,
+}
+
+/// Which registry endpoint serves a search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchEndpoint {
+    /// `GET /api/search` — PostgreSQL full-text search. Serves cursor pagination
+    /// and is the only search endpoint that filters by tag.
+    FullText,
+    /// `GET /api/v1/contracts/search` — advanced search, Elasticsearch-backed
+    /// with a PostgreSQL fallback. Offset pagination.
+    AdvancedV1,
+}
+
+impl SearchEndpoint {
+    pub fn path(self) -> &'static str {
+        match self {
+            SearchEndpoint::FullText => "/api/search",
+            SearchEndpoint::AdvancedV1 => "/api/v1/contracts/search",
+        }
+    }
+}
+
+/// A contract search, independent of how it is paginated.
+///
+/// The pagination mode is explicit: the client never guesses, because cursor and
+/// offset pagination are served by different backends with different ordering
+/// guarantees (see `docs/pagination.md`).
+#[derive(Debug, Clone)]
+pub struct ContractSearchRequest {
+    /// Full-text query. Required — the API rejects an empty one.
+    pub query: String,
+    /// Network filters (`mainnet`, `testnet`, `futurenet`).
+    pub networks: Vec<String>,
+    pub categories: Vec<String>,
+    /// Tag filters. Only `GET /api/search` supports these.
+    pub tags: Vec<String>,
+    pub verified_only: bool,
+    pub mode: PaginationMode,
+    /// Opaque continuation token to resume a cursor walk from. Cursor mode only.
+    pub cursor: Option<String>,
+    /// Starting row offset. Offset mode only.
+    pub offset: Option<u64>,
+    /// Force a specific endpoint. Defaults to the one that natively serves the
+    /// chosen pagination mode.
+    pub endpoint: Option<SearchEndpoint>,
+}
+
+impl ContractSearchRequest {
+    /// A cursor-paginated search — stable under concurrent writes, and the right
+    /// default for walking a whole result set.
+    pub fn cursor(query: impl Into<String>) -> Self {
+        Self::new(query, PaginationMode::Cursor)
+    }
+
+    /// An offset-paginated search — relevance ordered, jump-to-page capable.
+    pub fn offset(query: impl Into<String>) -> Self {
+        Self::new(query, PaginationMode::Offset)
+    }
+
+    pub fn new(query: impl Into<String>, mode: PaginationMode) -> Self {
+        Self {
+            query: query.into(),
+            networks: Vec::new(),
+            categories: Vec::new(),
+            tags: Vec::new(),
+            verified_only: false,
+            mode,
+            cursor: None,
+            offset: None,
+            endpoint: None,
+        }
+    }
+
+    pub fn with_networks<I, S>(mut self, networks: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.networks = networks.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_categories<I, S>(mut self, categories: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.categories = categories.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_tags<I, S>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tags = tags.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_verified_only(mut self, verified_only: bool) -> Self {
+        self.verified_only = verified_only;
+        self
+    }
+
+    /// Resume a cursor walk. The token stays opaque — it is sent back exactly as
+    /// received.
+    pub fn with_cursor(mut self, cursor: Option<String>) -> Self {
+        self.cursor = cursor;
+        self
+    }
+
+    pub fn with_offset(mut self, offset: Option<u64>) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    pub fn with_endpoint(mut self, endpoint: Option<SearchEndpoint>) -> Self {
+        self.endpoint = endpoint;
+        self
+    }
+
+    /// The endpoint this request will hit.
+    pub fn effective_endpoint(&self) -> SearchEndpoint {
+        if let Some(endpoint) = self.endpoint {
+            return endpoint;
+        }
+        if !self.tags.is_empty() {
+            // Only the full-text endpoint filters by tag.
+            return SearchEndpoint::FullText;
+        }
+        match self.mode {
+            PaginationMode::Cursor => SearchEndpoint::FullText,
+            PaginationMode::Offset => SearchEndpoint::AdvancedV1,
+        }
+    }
+
+    /// Reject requests that cannot be served faithfully, rather than sending
+    /// them and silently losing a filter or a page boundary.
+    pub fn validate(&self) -> Result<()> {
+        if self.query.trim().is_empty() {
+            return Err(Error::InvalidRequest(
+                "a search query is required and cannot be empty".to_string(),
+            ));
+        }
+
+        // Cursor and offset pagination can never be combined: the cursor already
+        // encodes a position, and an offset on top of it skips rows.
+        if let Some(offset) = self.offset {
+            if self.mode == PaginationMode::Cursor || self.cursor.is_some() {
+                return Err(PaginationError::MixedPagination { offset }.into());
+            }
+        }
+        if self.cursor.is_some() && self.mode == PaginationMode::Offset {
+            return Err(PaginationError::ModeMismatch {
+                expected: PaginationMode::Offset,
+                returned: PaginationMode::Cursor,
+            }
+            .into());
+        }
+
+        if !self.tags.is_empty() && self.effective_endpoint() == SearchEndpoint::AdvancedV1 {
+            return Err(Error::InvalidRequest(
+                "tag filters are only supported by GET /api/search; drop --endpoint or drop the tag filter".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Where a walk of this request starts, as a continuation.
+    pub fn start_continuation(&self) -> Result<Option<PageCursor>> {
+        self.validate()?;
+        Ok(match self.mode {
+            PaginationMode::Cursor => self
+                .cursor
+                .as_ref()
+                .filter(|token| !token.is_empty())
+                .map(|token| PageCursor::Cursor(token.clone())),
+            PaginationMode::Offset => self
+                .offset
+                .filter(|offset| *offset > 0)
+                .map(|offset| PageCursor::Offset { offset }),
+        })
+    }
+}
+
+/// The wire shape of a search response, tolerant of both endpoints.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawSearchResponse {
+    /// `GET /api/search` calls this `contracts`; the v1 endpoint calls it `results`.
+    #[serde(default, alias = "results")]
+    pub contracts: Vec<ContractHit>,
+    #[serde(default)]
+    pub total: Option<i64>,
+    /// Present only for cursor-paginated responses, and only while more rows remain.
+    #[serde(default)]
+    pub next_cursor: Option<String>,
+}
+
+impl RawSearchResponse {
+    /// Convert to a page, deriving the continuation for the active mode.
+    ///
+    /// `current_offset` is the offset this response was fetched at and
+    /// `requested_limit` the page size that was asked for; both are needed to
+    /// decide whether an offset walk has more rows.
+    pub(crate) fn into_page(
+        self,
+        mode: PaginationMode,
+        current_offset: u64,
+        requested_limit: u32,
+    ) -> Result<crate::pagination::RegistryPage<ContractHit>> {
+        // A negative total is meaningless; treat it as "not reported" rather than
+        // inventing a value.
+        let total = self.total.and_then(|total| u64::try_from(total).ok());
+        let items = self.contracts;
+        let page_len = items.len() as u64;
+
+        let next = match mode {
+            PaginationMode::Cursor => self
+                .next_cursor
+                .filter(|token| !token.is_empty())
+                .map(PageCursor::Cursor),
+            PaginationMode::Offset => {
+                if page_len == 0 {
+                    None
+                } else {
+                    let next_offset = advance_offset(current_offset, page_len)?;
+                    let has_more = match total {
+                        Some(total) => next_offset < total,
+                        // Without a total, a full page implies there may be more.
+                        None => page_len >= u64::from(requested_limit),
+                    };
+                    has_more.then_some(PageCursor::Offset {
+                        offset: next_offset,
+                    })
+                }
+            }
+        };
+
+        Ok(crate::pagination::RegistryPage::new(items, next, total))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_text_response_shape_parses() {
+        let raw: RawSearchResponse = serde_json::from_str(
+            r#"{
+                "contracts": [{
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "contract_id": "CA...",
+                    "name": "swap",
+                    "description": null,
+                    "category": "DeFi",
+                    "network": "testnet",
+                    "is_verified": true,
+                    "deprecation_status": "active",
+                    "is_deprecated": false,
+                    "relevance_score": 0.75,
+                    "matched_terms": null,
+                    "highlighted": null
+                }],
+                "total": 42,
+                "took_ms": 3,
+                "next_cursor": "opaque-token"
+            }"#,
+        )
+        .expect("full-text response should parse");
+
+        assert_eq!(raw.contracts.len(), 1);
+        assert_eq!(raw.contracts[0].name, "swap");
+        assert_eq!(raw.total, Some(42));
+
+        let page = raw
+            .into_page(PaginationMode::Cursor, 0, 20)
+            .expect("page conversion");
+        assert_eq!(
+            page.next,
+            Some(PageCursor::Cursor("opaque-token".to_string()))
+        );
+        assert_eq!(page.total, Some(42));
+    }
+
+    #[test]
+    fn advanced_v1_response_shape_parses() {
+        let raw: RawSearchResponse = serde_json::from_str(
+            r#"{
+                "query": "swap",
+                "total": 5,
+                "limit": 2,
+                "offset": 2,
+                "took_ms": 7,
+                "backend": "elasticsearch",
+                "results": [
+                    {"id": "a", "contract_id": "CA1", "name": "one", "network": "mainnet", "is_verified": false, "relevance_score": 1.0},
+                    {"id": "b", "contract_id": "CA2", "name": "two", "network": "mainnet", "is_verified": false, "relevance_score": 0.5}
+                ],
+                "facets": {"categories": [], "networks": [], "tags": []}
+            }"#,
+        )
+        .expect("advanced response should parse");
+
+        let page = raw
+            .into_page(PaginationMode::Offset, 2, 2)
+            .expect("page conversion");
+        assert_eq!(page.items.len(), 2);
+        assert_eq!(page.next, Some(PageCursor::Offset { offset: 4 }));
+        assert_eq!(page.total, Some(5));
+    }
+
+    #[test]
+    fn offset_page_at_the_total_has_no_continuation() {
+        let raw = RawSearchResponse {
+            contracts: vec![ContractHit {
+                id: "a".into(),
+                contract_id: "CA1".into(),
+                name: "one".into(),
+                description: None,
+                category: None,
+                network: "mainnet".into(),
+                is_verified: false,
+                is_deprecated: false,
+                deprecation_status: None,
+                replacement_contract_id: None,
+                relevance_score: None,
+            }],
+            total: Some(3),
+            next_cursor: None,
+        };
+
+        let page = raw
+            .into_page(PaginationMode::Offset, 2, 2)
+            .expect("page conversion");
+        assert!(page.next.is_none(), "offset 2 + 1 item reaches total 3");
+    }
+
+    #[test]
+    fn offset_conversion_detects_overflow() {
+        let raw = RawSearchResponse {
+            contracts: vec![ContractHit {
+                id: "a".into(),
+                contract_id: "CA1".into(),
+                name: "one".into(),
+                description: None,
+                category: None,
+                network: "mainnet".into(),
+                is_verified: false,
+                is_deprecated: false,
+                deprecation_status: None,
+                replacement_contract_id: None,
+                relevance_score: None,
+            }],
+            total: None,
+            next_cursor: None,
+        };
+
+        let err = raw
+            .into_page(PaginationMode::Offset, u64::MAX, 1)
+            .expect_err("advancing past u64::MAX must fail");
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::OffsetOverflow { .. })
+        ));
+    }
+
+    #[test]
+    fn empty_next_cursor_ends_the_walk() {
+        let raw = RawSearchResponse {
+            contracts: Vec::new(),
+            total: Some(0),
+            next_cursor: Some(String::new()),
+        };
+
+        let page = raw
+            .into_page(PaginationMode::Cursor, 0, 20)
+            .expect("page conversion");
+        assert!(page.next.is_none());
+    }
+
+    #[test]
+    fn negative_total_is_treated_as_unreported() {
+        let raw = RawSearchResponse {
+            contracts: Vec::new(),
+            total: Some(-1),
+            next_cursor: None,
+        };
+
+        let page = raw
+            .into_page(PaginationMode::Cursor, 0, 20)
+            .expect("page conversion");
+        assert!(page.total.is_none());
+    }
+
+    #[test]
+    fn cursor_mode_rejects_an_offset_parameter() {
+        let err = ContractSearchRequest::cursor("swap")
+            .with_offset(Some(40))
+            .validate()
+            .expect_err("cursor + offset must be rejected");
+
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::MixedPagination { offset: 40 })
+        ));
+        assert!(err.to_string().contains("cannot be combined"));
+    }
+
+    #[test]
+    fn offset_mode_rejects_a_cursor_parameter() {
+        let err = ContractSearchRequest::offset("swap")
+            .with_cursor(Some("token".to_string()))
+            .validate()
+            .expect_err("offset + cursor must be rejected");
+
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::ModeMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn empty_query_is_rejected_before_a_request_is_made() {
+        assert!(ContractSearchRequest::cursor("   ").validate().is_err());
+    }
+
+    #[test]
+    fn endpoint_defaults_follow_the_pagination_mode() {
+        assert_eq!(
+            ContractSearchRequest::cursor("swap").effective_endpoint(),
+            SearchEndpoint::FullText
+        );
+        assert_eq!(
+            ContractSearchRequest::offset("swap").effective_endpoint(),
+            SearchEndpoint::AdvancedV1
+        );
+        // Tag filters are only served by the full-text endpoint.
+        assert_eq!(
+            ContractSearchRequest::offset("swap")
+                .with_tags(["defi"])
+                .effective_endpoint(),
+            SearchEndpoint::FullText
+        );
+    }
+
+    #[test]
+    fn forcing_the_advanced_endpoint_with_tags_is_rejected() {
+        let err = ContractSearchRequest::offset("swap")
+            .with_tags(["defi"])
+            .with_endpoint(Some(SearchEndpoint::AdvancedV1))
+            .validate()
+            .expect_err("tags are unsupported there");
+
+        assert!(matches!(err, Error::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn start_continuation_reflects_the_mode() {
+        assert_eq!(
+            ContractSearchRequest::cursor("swap")
+                .with_cursor(Some("token".to_string()))
+                .start_continuation()
+                .unwrap(),
+            Some(PageCursor::Cursor("token".to_string()))
+        );
+        assert_eq!(
+            ContractSearchRequest::offset("swap")
+                .with_offset(Some(40))
+                .start_continuation()
+                .unwrap(),
+            Some(PageCursor::Offset { offset: 40 })
+        );
+        assert_eq!(
+            ContractSearchRequest::cursor("swap")
+                .start_continuation()
+                .unwrap(),
+            None
+        );
+    }
+}

--- a/backend/registry_client/src/pagination.rs
+++ b/backend/registry_client/src/pagination.rs
@@ -1193,7 +1193,8 @@ mod tests {
             Err(Error::Transport {
                 url: "http://registry.test/api/search".to_string(),
                 attempts: 3,
-                reason: "the request timed out".to_string(),
+                kind: crate::error::TransportKind::Connect,
+                reason: "could not connect to the registry".to_string(),
             }),
             Ok(cursor_page(&[3, 4], None, Some(4))),
         ]);

--- a/backend/registry_client/src/pagination.rs
+++ b/backend/registry_client/src/pagination.rs
@@ -1,0 +1,1288 @@
+//! Backend-agnostic pagination.
+//!
+//! The registry exposes two pagination strategies (see `docs/pagination.md`):
+//! stable keyset **cursor** pagination served by PostgreSQL, and **offset**
+//! pagination served by Elasticsearch (and by the PostgreSQL fallback). Both are
+//! wrapped here behind one type so consumers never manage continuation state,
+//! and never mix parameters from the two schemes.
+//!
+//! The guarantees this module enforces, all of them bounded so a misbehaving
+//! server cannot spin a consumer forever:
+//!
+//! * Cursors stay **opaque** — they are compared and echoed back, never decoded.
+//! * Cursor pagination and offset parameters can never be combined.
+//! * A repeated cursor, or an offset that fails to advance, is a hard error.
+//! * `offset + page_len` is checked for overflow on every page.
+//! * Empty pages that still carry a continuation token are bounded.
+//! * A failed fetch leaves the walk untouched, so a retry re-requests the same
+//!   page and can never duplicate or skip already-emitted items.
+//! * Server-supplied ordering is preserved exactly; items are never re-sorted.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use futures_util::stream::{self, Stream, TryStreamExt};
+use tokio::sync::watch;
+
+use crate::error::{Error, PaginationError, Result};
+
+/// Page size used when the caller does not pick one.
+pub const DEFAULT_PAGE_SIZE: u32 = 50;
+/// Largest page size the API honours (`limit` is clamped to `1..=100` server side).
+pub const MAX_PAGE_SIZE: u32 = 100;
+/// Safety bound on a full walk when the caller does not pick one.
+pub const DEFAULT_MAX_PAGES: u64 = 200;
+/// Consecutive empty-but-continuable pages tolerated before giving up.
+pub const DEFAULT_MAX_EMPTY_PAGES: u32 = 3;
+
+/// Which pagination scheme a walk uses. Chosen explicitly by the caller — the
+/// client never guesses, because the two schemes hit different endpoints and
+/// give different ordering guarantees.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaginationMode {
+    /// Stable keyset pagination: `(created_at DESC, id DESC)`, no skips or
+    /// duplicates under concurrent writes.
+    Cursor,
+    /// `limit`/`offset` pagination: relevance ordering, may drift under
+    /// concurrent writes.
+    Offset,
+}
+
+impl PaginationMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PaginationMode::Cursor => "cursor",
+            PaginationMode::Offset => "offset",
+        }
+    }
+}
+
+impl fmt::Display for PaginationMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PaginationMode {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "cursor" | "keyset" => Ok(PaginationMode::Cursor),
+            "offset" | "limit-offset" => Ok(PaginationMode::Offset),
+            other => Err(Error::InvalidRequest(format!(
+                "unknown pagination mode `{other}`; expected `cursor` or `offset`"
+            ))),
+        }
+    }
+}
+
+/// Where the next page starts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PageCursor {
+    /// An opaque server token. The client compares it for repetition and sends
+    /// it back verbatim; it never parses, decodes or synthesises one.
+    Cursor(String),
+    /// A row offset into the result set.
+    Offset { offset: u64 },
+}
+
+impl PageCursor {
+    /// The pagination scheme this continuation belongs to.
+    pub fn mode(&self) -> PaginationMode {
+        match self {
+            PageCursor::Cursor(_) => PaginationMode::Cursor,
+            PageCursor::Offset { .. } => PaginationMode::Offset,
+        }
+    }
+
+    /// The opaque token, for cursor continuations.
+    pub fn as_cursor(&self) -> Option<&str> {
+        match self {
+            PageCursor::Cursor(token) => Some(token),
+            PageCursor::Offset { .. } => None,
+        }
+    }
+
+    /// The row offset, for offset continuations.
+    pub fn as_offset(&self) -> Option<u64> {
+        match self {
+            PageCursor::Offset { offset } => Some(*offset),
+            PageCursor::Cursor(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for PageCursor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PageCursor::Cursor(token) => f.write_str(token),
+            PageCursor::Offset { offset } => write!(f, "{offset}"),
+        }
+    }
+}
+
+/// Advance an offset by a page length, refusing to wrap.
+pub fn advance_offset(offset: u64, page_len: u64) -> Result<u64> {
+    offset
+        .checked_add(page_len)
+        .ok_or(PaginationError::OffsetOverflow { offset, page_len })
+        .map_err(Error::from)
+}
+
+/// One page of results, in the order the server returned them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryPage<T> {
+    /// Items in server order. Never re-sorted by this client, so whatever
+    /// ordering guarantee the endpoint provides is the ordering you observe.
+    pub items: Vec<T>,
+    /// Continuation for the following page, or `None` on the last page.
+    pub next: Option<PageCursor>,
+    /// Total matches reported by the server, preserved verbatim when supplied.
+    pub total: Option<u64>,
+}
+
+impl<T> RegistryPage<T> {
+    pub fn new(items: Vec<T>, next: Option<PageCursor>, total: Option<u64>) -> Self {
+        Self { items, next, total }
+    }
+
+    /// A terminal page carrying nothing.
+    pub fn empty() -> Self {
+        Self {
+            items: Vec::new(),
+            next: None,
+            total: None,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Convert the items while keeping the pagination metadata.
+    pub fn map<U, F: FnMut(T) -> U>(self, f: F) -> RegistryPage<U> {
+        RegistryPage {
+            items: self.items.into_iter().map(f).collect(),
+            next: self.next,
+            total: self.total,
+        }
+    }
+}
+
+/// What the paginator asks a fetcher for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageRequest {
+    /// `None` for the first page of a walk.
+    pub cursor: Option<PageCursor>,
+    /// Maximum items wanted in this page.
+    pub limit: u32,
+    pub mode: PaginationMode,
+    /// 0-based index of the page being fetched, for logging and diagnostics.
+    pub page_index: u64,
+}
+
+pub type PageFuture<'a, T> = Pin<Box<dyn Future<Output = Result<RegistryPage<T>>> + Send + 'a>>;
+
+/// Fetches one page. Implementors own the transport concerns — including
+/// retries, which must happen *inside* a single `fetch_page` call so the
+/// paginator never re-emits items it has already handed out.
+pub trait PageFetcher: Send + Sync {
+    type Item: Send;
+
+    fn fetch_page(&self, request: PageRequest) -> PageFuture<'_, Self::Item>;
+}
+
+/// Safety bounds for a walk. The defaults are deliberately finite: an
+/// unbounded "fetch everything" is never the default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageLimits {
+    /// Items requested per page (clamped to `1..=MAX_PAGE_SIZE`).
+    pub page_size: u32,
+    /// Hard cap on pages fetched. `None` means unbounded, which only the
+    /// caller can ask for explicitly.
+    pub max_pages: Option<u64>,
+    /// Hard cap on items emitted. `None` means unbounded.
+    pub max_items: Option<u64>,
+    /// Consecutive empty-but-continuable pages tolerated (minimum 1).
+    pub max_empty_pages: u32,
+}
+
+impl Default for PageLimits {
+    fn default() -> Self {
+        Self {
+            page_size: DEFAULT_PAGE_SIZE,
+            max_pages: Some(DEFAULT_MAX_PAGES),
+            max_items: None,
+            max_empty_pages: DEFAULT_MAX_EMPTY_PAGES,
+        }
+    }
+}
+
+impl PageLimits {
+    /// Limits for fetching exactly one page of `page_size` items.
+    pub fn single_page(page_size: u32) -> Self {
+        Self {
+            page_size,
+            max_pages: Some(1),
+            max_items: None,
+            max_empty_pages: DEFAULT_MAX_EMPTY_PAGES,
+        }
+    }
+
+    pub fn with_page_size(mut self, page_size: u32) -> Self {
+        self.page_size = page_size;
+        self
+    }
+
+    pub fn with_max_pages(mut self, max_pages: Option<u64>) -> Self {
+        self.max_pages = max_pages;
+        self
+    }
+
+    pub fn with_max_items(mut self, max_items: Option<u64>) -> Self {
+        self.max_items = max_items;
+        self
+    }
+
+    pub fn with_max_empty_pages(mut self, max_empty_pages: u32) -> Self {
+        self.max_empty_pages = max_empty_pages;
+        self
+    }
+
+    /// Page size to request, never asking for more than the remaining item
+    /// budget so `--max-items` is respected without over-fetching.
+    fn effective_page_size(&self, remaining_items: Option<u64>) -> u32 {
+        let size = self.page_size.clamp(1, MAX_PAGE_SIZE);
+        match remaining_items {
+            Some(remaining) => size.min(remaining.clamp(1, MAX_PAGE_SIZE as u64) as u32),
+            None => size,
+        }
+    }
+
+    fn empty_page_budget(&self) -> u32 {
+        self.max_empty_pages.max(1)
+    }
+}
+
+/// Why a walk stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StopReason {
+    /// The server reported no further pages.
+    Exhausted,
+    /// The `max_items` bound was reached.
+    MaxItems,
+    /// The `max_pages` bound was reached.
+    MaxPages,
+    /// The caller cancelled the walk.
+    Cancelled,
+}
+
+impl StopReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            StopReason::Exhausted => "exhausted",
+            StopReason::MaxItems => "max_items",
+            StopReason::MaxPages => "max_pages",
+            StopReason::Cancelled => "cancelled",
+        }
+    }
+
+    /// True when the walk really did reach the end of the result set.
+    pub fn is_complete(self) -> bool {
+        matches!(self, StopReason::Exhausted)
+    }
+}
+
+impl fmt::Display for StopReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Cooperative cancellation for a walk. Cloneable, so a signal handler can hold
+/// one while the walk holds another.
+#[derive(Debug, Clone)]
+pub struct CancelToken {
+    sender: Arc<watch::Sender<bool>>,
+}
+
+impl Default for CancelToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CancelToken {
+    pub fn new() -> Self {
+        Self {
+            sender: Arc::new(watch::channel(false).0),
+        }
+    }
+
+    /// Request cancellation. Idempotent, and safe from any task.
+    pub fn cancel(&self) {
+        // `send_replace`, not `send`: the flag must be set even when nobody is
+        // currently awaiting `cancelled()`.
+        self.sender.send_replace(true);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        *self.sender.borrow()
+    }
+
+    /// Resolves once cancelled. Used to abandon an in-flight page fetch.
+    pub async fn cancelled(&self) {
+        let mut receiver = self.sender.subscribe();
+        while !*receiver.borrow_and_update() {
+            // The sender is held in this `Arc`, so `changed()` cannot fail while
+            // `self` is alive; treat an error as "never cancelled" regardless.
+            if receiver.changed().await.is_err() {
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+}
+
+/// Everything a completed (or bounded) walk produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageCollection<T> {
+    /// Items in server order, across all pages.
+    pub items: Vec<T>,
+    /// Server-reported total for the query, when the API supplied one.
+    pub total: Option<u64>,
+    pub pages_fetched: u64,
+    pub stop_reason: StopReason,
+    /// Continuation to resume from, when the walk stopped at a bound rather
+    /// than at the end of the result set.
+    pub next: Option<PageCursor>,
+}
+
+impl<T> PageCollection<T> {
+    /// True when the whole result set was read.
+    pub fn is_complete(&self) -> bool {
+        self.stop_reason.is_complete()
+    }
+}
+
+/// Walks pages for one query, in one pagination mode.
+///
+/// Construct it from a [`PageFetcher`] (the HTTP client builds one for you via
+/// [`crate::RegistryClient::search_paginator`]) and drive it with
+/// [`Paginator::next_page`], [`Paginator::collect_all`], or the
+/// [`Paginator::pages`] / [`Paginator::items`] streams.
+pub struct Paginator<F: PageFetcher> {
+    fetcher: F,
+    mode: PaginationMode,
+    limits: PageLimits,
+    cancel: CancelToken,
+    /// Continuation for the next fetch; `None` before the first page.
+    next: Option<PageCursor>,
+    /// Current position in offset mode, tracked so a stalled or overflowing
+    /// advance is detected against what the client actually walked.
+    offset_position: u64,
+    /// Every cursor already requested or offered, for repeat detection. Holds
+    /// the tokens verbatim — they are compared, never decoded.
+    seen_cursors: HashSet<String>,
+    pages_fetched: u64,
+    items_emitted: u64,
+    total: Option<u64>,
+    consecutive_empty_pages: u32,
+    stop_reason: Option<StopReason>,
+}
+
+impl<F: PageFetcher> fmt::Debug for Paginator<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Paginator")
+            .field("mode", &self.mode)
+            .field("limits", &self.limits)
+            .field("next", &self.next)
+            .field("pages_fetched", &self.pages_fetched)
+            .field("items_emitted", &self.items_emitted)
+            .field("total", &self.total)
+            .field("stop_reason", &self.stop_reason)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<F: PageFetcher> Paginator<F> {
+    /// A walk over `fetcher` in `mode`, with default safety bounds.
+    pub fn new(fetcher: F, mode: PaginationMode) -> Self {
+        Self {
+            fetcher,
+            mode,
+            limits: PageLimits::default(),
+            cancel: CancelToken::new(),
+            next: None,
+            offset_position: 0,
+            seen_cursors: HashSet::new(),
+            pages_fetched: 0,
+            items_emitted: 0,
+            total: None,
+            consecutive_empty_pages: 0,
+            stop_reason: None,
+        }
+    }
+
+    pub fn with_limits(mut self, limits: PageLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    pub fn with_cancel_token(mut self, cancel: CancelToken) -> Self {
+        self.cancel = cancel;
+        self
+    }
+
+    /// Resume from a continuation obtained earlier.
+    ///
+    /// Errors when the continuation belongs to the other pagination scheme:
+    /// resuming a cursor walk from an offset would silently skip rows, so it is
+    /// rejected rather than reinterpreted.
+    pub fn start_at(mut self, start: Option<PageCursor>) -> Result<Self> {
+        match (&start, self.mode) {
+            (Some(PageCursor::Offset { offset }), PaginationMode::Cursor) => {
+                return Err(PaginationError::MixedPagination { offset: *offset }.into());
+            }
+            (Some(PageCursor::Cursor(_)), PaginationMode::Offset) => {
+                return Err(PaginationError::ModeMismatch {
+                    expected: PaginationMode::Offset,
+                    returned: PaginationMode::Cursor,
+                }
+                .into());
+            }
+            _ => {}
+        }
+
+        if let Some(PageCursor::Cursor(token)) = &start {
+            // The starting token counts as seen: a server that hands it straight
+            // back is looping, and that must be an error, not a re-read.
+            if !token.is_empty() {
+                self.seen_cursors.insert(token.clone());
+            }
+        }
+        if let Some(PageCursor::Offset { offset }) = &start {
+            self.offset_position = *offset;
+        }
+
+        self.next = start;
+        Ok(self)
+    }
+
+    pub fn mode(&self) -> PaginationMode {
+        self.mode
+    }
+
+    pub fn limits(&self) -> PageLimits {
+        self.limits
+    }
+
+    pub fn cancel_token(&self) -> CancelToken {
+        self.cancel.clone()
+    }
+
+    /// Latest server-reported total, preserved across the walk.
+    pub fn total(&self) -> Option<u64> {
+        self.total
+    }
+
+    pub fn pages_fetched(&self) -> u64 {
+        self.pages_fetched
+    }
+
+    pub fn items_emitted(&self) -> u64 {
+        self.items_emitted
+    }
+
+    /// Continuation for the page that has not been fetched yet, if any. Use it
+    /// to resume a walk that stopped at a bound.
+    pub fn next_continuation(&self) -> Option<&PageCursor> {
+        self.next.as_ref()
+    }
+
+    /// Why the walk finished, once it has.
+    pub fn stop_reason(&self) -> Option<StopReason> {
+        self.stop_reason
+    }
+
+    /// Fetch the next page, or `Ok(None)` once the walk is over — because the
+    /// result set ran out, a bound was hit, or the walk was cancelled. Check
+    /// [`Paginator::stop_reason`] to tell those apart.
+    ///
+    /// On error the walk state is left exactly as it was, so calling again
+    /// re-requests the *same* page: a retry can neither duplicate nor skip
+    /// items that were already emitted.
+    pub async fn next_page(&mut self) -> Result<Option<RegistryPage<F::Item>>> {
+        if self.stop_reason.is_some() {
+            return Ok(None);
+        }
+        if self.cancel.is_cancelled() {
+            return Ok(self.stop(StopReason::Cancelled));
+        }
+        if self
+            .limits
+            .max_pages
+            .is_some_and(|max| self.pages_fetched >= max)
+        {
+            return Ok(self.stop(StopReason::MaxPages));
+        }
+
+        let remaining_items = match self.limits.max_items {
+            Some(max) => {
+                let remaining = max.saturating_sub(self.items_emitted);
+                if remaining == 0 {
+                    return Ok(self.stop(StopReason::MaxItems));
+                }
+                Some(remaining)
+            }
+            None => None,
+        };
+
+        let request = PageRequest {
+            cursor: self.next.clone(),
+            limit: self.limits.effective_page_size(remaining_items),
+            mode: self.mode,
+            page_index: self.pages_fetched,
+        };
+        // Fetch, abandoning the in-flight request if cancellation arrives. The
+        // cancel token is cloned so the select does not borrow `self` twice.
+        let cancel = self.cancel.clone();
+        let fetched = {
+            let fetch = self.fetcher.fetch_page(request);
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => None,
+                result = fetch => Some(result),
+            }
+        };
+        let Some(result) = fetched else {
+            return Ok(self.stop(StopReason::Cancelled));
+        };
+        // `?` here leaves every field untouched — that is what makes a caller's
+        // retry safe.
+        let mut page = result?;
+
+        // ── Validate the continuation before committing anything ──────────────
+        let page_len = page.items.len() as u64;
+        let next = self.validate_continuation(&page, page_len)?;
+
+        if page.items.is_empty() {
+            let empties = self.consecutive_empty_pages.saturating_add(1);
+            if next.is_some() && empties >= self.limits.empty_page_budget() {
+                return Err(PaginationError::EmptyPageLoop { pages: empties }.into());
+            }
+        }
+
+        // A well-behaved server already honoured `limit`, but clamp regardless so
+        // `max_items` is an upper bound on what a consumer ever sees.
+        let mut truncated = false;
+        if let Some(remaining) = remaining_items {
+            if page_len > remaining {
+                page.items.truncate(remaining as usize);
+                truncated = true;
+            }
+        }
+
+        // ── Commit ────────────────────────────────────────────────────────────
+        self.pages_fetched += 1;
+        self.items_emitted += page.items.len() as u64;
+        if let Some(total) = page.total {
+            self.total = Some(total);
+        }
+        if page.items.is_empty() {
+            self.consecutive_empty_pages = self.consecutive_empty_pages.saturating_add(1);
+        } else {
+            self.consecutive_empty_pages = 0;
+        }
+        if let Some(PageCursor::Cursor(token)) = &next {
+            self.seen_cursors.insert(token.clone());
+        }
+        if let Some(PageCursor::Offset { offset }) = &next {
+            self.offset_position = *offset;
+        }
+
+        if truncated {
+            // Resuming from `next` would skip the rows just dropped, so the walk
+            // ends here without a resume point.
+            self.next = None;
+            self.stop_reason = Some(StopReason::MaxItems);
+        } else {
+            self.next = next;
+            if self.next.is_none() {
+                self.stop_reason = Some(StopReason::Exhausted);
+            } else if self
+                .limits
+                .max_items
+                .is_some_and(|max| self.items_emitted >= max)
+            {
+                // Bound reached exactly on a page boundary: keep `next` so the
+                // caller can resume, and stop without another request.
+                self.stop_reason = Some(StopReason::MaxItems);
+            }
+            // A short page that still carries a continuation is followed, not
+            // second-guessed: dropping the server's token here would silently
+            // lose results.
+        }
+
+        Ok(Some(page))
+    }
+
+    /// Validate the server's continuation against the walk so far, returning the
+    /// continuation to use next (`None` ends the walk).
+    fn validate_continuation(
+        &self,
+        page: &RegistryPage<F::Item>,
+        page_len: u64,
+    ) -> Result<Option<PageCursor>> {
+        let page_number = self.pages_fetched + 1;
+
+        let Some(next) = page.next.clone() else {
+            return Ok(None);
+        };
+        if next.mode() != self.mode {
+            return Err(PaginationError::ModeMismatch {
+                expected: self.mode,
+                returned: next.mode(),
+            }
+            .into());
+        }
+
+        match next {
+            PageCursor::Cursor(token) => {
+                if token.is_empty() {
+                    // Carries no position; treat as the end of the walk rather
+                    // than restarting from page one.
+                    return Ok(None);
+                }
+                if self.seen_cursors.contains(&token) {
+                    return Err(PaginationError::RepeatedCursor { page: page_number }.into());
+                }
+                Ok(Some(PageCursor::Cursor(token)))
+            }
+            PageCursor::Offset { offset } => {
+                // Always validate the walk's own advance, so a position that runs
+                // off the end of `u64` fails loudly instead of wrapping.
+                advance_offset(self.offset_position, page_len)?;
+                if offset <= self.offset_position {
+                    return Err(PaginationError::StalledOffset {
+                        offset: self.offset_position,
+                        page: page_number,
+                    }
+                    .into());
+                }
+                Ok(Some(PageCursor::Offset { offset }))
+            }
+        }
+    }
+
+    fn stop(&mut self, reason: StopReason) -> Option<RegistryPage<F::Item>> {
+        self.stop_reason = Some(reason);
+        None
+    }
+
+    /// Walk every remaining page, subject to the configured bounds.
+    pub async fn collect_all(&mut self) -> Result<PageCollection<F::Item>> {
+        let mut items = Vec::new();
+        while let Some(page) = self.next_page().await? {
+            items.extend(page.items);
+        }
+
+        Ok(PageCollection {
+            items,
+            total: self.total,
+            pages_fetched: self.pages_fetched,
+            stop_reason: self.stop_reason.unwrap_or(StopReason::Exhausted),
+            next: self.next.clone(),
+        })
+    }
+
+    /// The walk as a stream of pages.
+    pub fn pages(self) -> impl Stream<Item = Result<RegistryPage<F::Item>>> {
+        stream::try_unfold(self, |mut paginator| async move {
+            match paginator.next_page().await? {
+                Some(page) => Ok(Some((page, paginator))),
+                None => Ok(None),
+            }
+        })
+    }
+
+    /// The walk as a flat stream of items, in server order.
+    pub fn items(self) -> impl Stream<Item = Result<F::Item>> {
+        self.pages()
+            .map_ok(|page| stream::iter(page.items.into_iter().map(Ok)))
+            .try_flatten()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt;
+    use std::sync::Mutex;
+
+    /// A scripted fetcher: each entry is the page returned for the matching
+    /// request index. Records the continuation it was handed so tests can assert
+    /// what the paginator actually sent.
+    struct ScriptedFetcher {
+        pages: Mutex<Vec<Result<RegistryPage<u32>>>>,
+        seen_requests: Mutex<Vec<PageRequest>>,
+    }
+
+    impl ScriptedFetcher {
+        fn new(pages: Vec<Result<RegistryPage<u32>>>) -> Self {
+            Self {
+                pages: Mutex::new(pages),
+                seen_requests: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn ok(pages: Vec<RegistryPage<u32>>) -> Self {
+            Self::new(pages.into_iter().map(Ok).collect())
+        }
+
+        fn requests(&self) -> Vec<PageRequest> {
+            self.seen_requests.lock().unwrap().clone()
+        }
+    }
+
+    impl PageFetcher for ScriptedFetcher {
+        type Item = u32;
+
+        fn fetch_page(&self, request: PageRequest) -> PageFuture<'_, u32> {
+            self.seen_requests.lock().unwrap().push(request);
+            let mut pages = self.pages.lock().unwrap();
+            let page = if pages.is_empty() {
+                Ok(RegistryPage::empty())
+            } else {
+                pages.remove(0)
+            };
+            Box::pin(async move { page })
+        }
+    }
+
+    fn cursor_page(items: &[u32], next: Option<&str>, total: Option<u64>) -> RegistryPage<u32> {
+        RegistryPage::new(
+            items.to_vec(),
+            next.map(|token| PageCursor::Cursor(token.to_string())),
+            total,
+        )
+    }
+
+    fn offset_page(items: &[u32], next: Option<u64>, total: Option<u64>) -> RegistryPage<u32> {
+        RegistryPage::new(
+            items.to_vec(),
+            next.map(|offset| PageCursor::Offset { offset }),
+            total,
+        )
+    }
+
+    fn paginator(fetcher: ScriptedFetcher, mode: PaginationMode) -> Paginator<ScriptedFetcher> {
+        Paginator::new(fetcher, mode).with_limits(PageLimits::default().with_page_size(2))
+    }
+
+    #[tokio::test]
+    async fn cursor_walk_collects_every_page_in_order() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1, 2], Some("c1"), Some(5)),
+            cursor_page(&[3, 4], Some("c2"), Some(5)),
+            cursor_page(&[5], None, Some(5)),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor);
+
+        let collected = walk.collect_all().await.expect("walk should succeed");
+
+        assert_eq!(collected.items, vec![1, 2, 3, 4, 5]);
+        assert_eq!(collected.total, Some(5));
+        assert_eq!(collected.pages_fetched, 3);
+        assert_eq!(collected.stop_reason, StopReason::Exhausted);
+        assert!(collected.is_complete());
+        assert!(collected.next.is_none());
+    }
+
+    #[tokio::test]
+    async fn cursor_tokens_are_echoed_back_verbatim_and_never_decoded() {
+        // Deliberately not valid base64 or JSON: the client must treat the token
+        // as an opaque string.
+        let opaque = "!!not-base64!!";
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1, 2], Some(opaque), None),
+            cursor_page(&[3], None, None),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor);
+
+        walk.next_page().await.unwrap();
+        walk.next_page().await.unwrap();
+
+        let requests = walk.fetcher.requests();
+        assert_eq!(requests[0].cursor, None);
+        assert_eq!(
+            requests[1].cursor,
+            Some(PageCursor::Cursor(opaque.to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_cursor_terminates_with_an_error() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1, 2], Some("same"), None),
+            cursor_page(&[3, 4], Some("same"), None),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor);
+
+        walk.next_page().await.expect("first page");
+        let err = walk.next_page().await.expect_err("repeat must be rejected");
+
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::RepeatedCursor { page: 2 })
+        ));
+        assert!(err.to_string().contains("repeated a pagination cursor"));
+    }
+
+    #[tokio::test]
+    async fn cursor_echoed_from_the_starting_position_is_a_repeat() {
+        let fetcher = ScriptedFetcher::ok(vec![cursor_page(&[1, 2], Some("resume"), None)]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor)
+            .start_at(Some(PageCursor::Cursor("resume".to_string())))
+            .expect("cursor start is valid for a cursor walk");
+
+        let err = walk.next_page().await.expect_err("echoed cursor is a loop");
+
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::RepeatedCursor { page: 1 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn empty_continuable_pages_are_bounded() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[], Some("c1"), Some(9)),
+            cursor_page(&[], Some("c2"), Some(9)),
+            cursor_page(&[], Some("c3"), Some(9)),
+            cursor_page(&[], Some("c4"), Some(9)),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor).with_limits(
+            PageLimits::default()
+                .with_page_size(2)
+                .with_max_empty_pages(3),
+        );
+
+        assert!(walk.next_page().await.unwrap().is_some());
+        assert!(walk.next_page().await.unwrap().is_some());
+        let err = walk
+            .next_page()
+            .await
+            .expect_err("a third empty page must stop the walk");
+
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::EmptyPageLoop { pages: 3 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn empty_final_page_without_continuation_ends_cleanly() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1, 2], Some("c1"), Some(2)),
+            cursor_page(&[], None, Some(2)),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor);
+
+        let collected = walk.collect_all().await.expect("walk should succeed");
+
+        assert_eq!(collected.items, vec![1, 2]);
+        assert_eq!(collected.stop_reason, StopReason::Exhausted);
+    }
+
+    #[tokio::test]
+    async fn offset_walk_advances_and_stops_at_the_total() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            offset_page(&[1, 2], Some(2), Some(5)),
+            offset_page(&[3, 4], Some(4), Some(5)),
+            offset_page(&[5], None, Some(5)),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Offset);
+
+        let collected = walk.collect_all().await.expect("walk should succeed");
+
+        assert_eq!(collected.items, vec![1, 2, 3, 4, 5]);
+        assert_eq!(collected.total, Some(5));
+        let offsets: Vec<Option<u64>> = walk
+            .fetcher
+            .requests()
+            .iter()
+            .map(|request| request.cursor.as_ref().and_then(PageCursor::as_offset))
+            .collect();
+        assert_eq!(offsets, vec![None, Some(2), Some(4)]);
+    }
+
+    #[tokio::test]
+    async fn unchanged_offset_terminates_with_an_error() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            offset_page(&[1, 2], Some(2), Some(9)),
+            // Server hands back the offset we are already at.
+            offset_page(&[3, 4], Some(2), Some(9)),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Offset);
+
+        walk.next_page().await.expect("first page");
+        let err = walk.next_page().await.expect_err("stalled offset");
+
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::StalledOffset { offset: 2, page: 2 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn offset_overflow_is_detected() {
+        let fetcher = ScriptedFetcher::ok(vec![offset_page(&[1, 2], Some(u64::MAX), None)]);
+        let mut walk = paginator(fetcher, PaginationMode::Offset)
+            .start_at(Some(PageCursor::Offset {
+                offset: u64::MAX - 1,
+            }))
+            .expect("offset start is valid for an offset walk");
+
+        let err = walk.next_page().await.expect_err("overflowing advance");
+
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::OffsetOverflow {
+                offset,
+                page_len: 2
+            }) if offset == u64::MAX - 1
+        ));
+    }
+
+    #[test]
+    fn advance_offset_rejects_wrapping() {
+        assert_eq!(advance_offset(10, 5).unwrap(), 15);
+        assert!(advance_offset(u64::MAX, 1).is_err());
+    }
+
+    #[tokio::test]
+    async fn cursor_walk_rejects_an_offset_continuation() {
+        let fetcher = ScriptedFetcher::ok(vec![offset_page(&[1, 2], Some(2), None)]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor);
+
+        let err = walk.next_page().await.expect_err("mode mismatch");
+
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::ModeMismatch {
+                expected: PaginationMode::Cursor,
+                returned: PaginationMode::Offset
+            })
+        ));
+    }
+
+    #[test]
+    fn cursor_mode_rejects_an_offset_start() {
+        let fetcher = ScriptedFetcher::ok(vec![]);
+        let err = Paginator::new(fetcher, PaginationMode::Cursor)
+            .start_at(Some(PageCursor::Offset { offset: 40 }))
+            .expect_err("cursor + offset must be rejected");
+
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::MixedPagination { offset: 40 })
+        ));
+    }
+
+    #[test]
+    fn offset_mode_rejects_a_cursor_start() {
+        let fetcher = ScriptedFetcher::ok(vec![]);
+        let err = Paginator::new(fetcher, PaginationMode::Offset)
+            .start_at(Some(PageCursor::Cursor("abc".into())))
+            .expect_err("offset walk cannot resume from a cursor");
+
+        assert!(matches!(
+            err,
+            Error::Pagination(PaginationError::ModeMismatch { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn max_items_on_a_page_boundary_keeps_a_resume_point() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1, 2], Some("c1"), Some(100)),
+            cursor_page(&[3, 4], Some("c2"), Some(100)),
+            cursor_page(&[5, 6], Some("c3"), Some(100)),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor).with_limits(
+            PageLimits::default()
+                .with_page_size(2)
+                .with_max_items(Some(4)),
+        );
+
+        let collected = walk.collect_all().await.expect("walk should succeed");
+
+        assert_eq!(collected.items, vec![1, 2, 3, 4]);
+        assert_eq!(collected.stop_reason, StopReason::MaxItems);
+        assert!(!collected.is_complete());
+        assert_eq!(collected.total, Some(100));
+        // Third page was never requested.
+        assert_eq!(walk.fetcher.requests().len(), 2);
+        assert_eq!(
+            collected.next,
+            Some(PageCursor::Cursor("c2".to_string())),
+            "stopping at a bound leaves a usable resume point"
+        );
+    }
+
+    #[tokio::test]
+    async fn max_items_trims_the_last_requested_page_size() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1, 2], Some("c1"), Some(100)),
+            cursor_page(&[3], Some("c2"), Some(100)),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor).with_limits(
+            PageLimits::default()
+                .with_page_size(2)
+                .with_max_items(Some(3)),
+        );
+
+        let collected = walk.collect_all().await.expect("walk should succeed");
+
+        assert_eq!(collected.items, vec![1, 2, 3]);
+        assert_eq!(collected.stop_reason, StopReason::MaxItems);
+        // The final request asks only for the remaining item budget.
+        assert_eq!(walk.fetcher.requests()[1].limit, 1);
+    }
+
+    #[tokio::test]
+    async fn max_items_truncates_an_oversized_page() {
+        // Server ignores `limit` and returns more than the remaining budget.
+        let fetcher = ScriptedFetcher::ok(vec![cursor_page(&[1, 2, 3, 4, 5], Some("c1"), None)]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor).with_limits(
+            PageLimits::default()
+                .with_page_size(2)
+                .with_max_items(Some(2)),
+        );
+
+        let collected = walk.collect_all().await.expect("walk should succeed");
+
+        assert_eq!(collected.items, vec![1, 2]);
+        assert_eq!(collected.stop_reason, StopReason::MaxItems);
+    }
+
+    #[tokio::test]
+    async fn max_pages_bounds_the_walk() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1, 2], Some("c1"), Some(100)),
+            cursor_page(&[3, 4], Some("c2"), Some(100)),
+            cursor_page(&[5, 6], Some("c3"), Some(100)),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor).with_limits(
+            PageLimits::default()
+                .with_page_size(2)
+                .with_max_pages(Some(2)),
+        );
+
+        let collected = walk.collect_all().await.expect("walk should succeed");
+
+        assert_eq!(collected.items, vec![1, 2, 3, 4]);
+        assert_eq!(collected.pages_fetched, 2);
+        assert_eq!(collected.stop_reason, StopReason::MaxPages);
+        assert_eq!(
+            collected.next,
+            Some(PageCursor::Cursor("c2".to_string())),
+            "a bounded walk exposes where to resume"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_page_limits_fetch_exactly_one_page() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1, 2], Some("c1"), Some(50)),
+            cursor_page(&[3, 4], Some("c2"), Some(50)),
+        ]);
+        let mut walk =
+            Paginator::new(fetcher, PaginationMode::Cursor).with_limits(PageLimits::single_page(2));
+
+        let collected = walk.collect_all().await.expect("walk should succeed");
+
+        assert_eq!(collected.items, vec![1, 2]);
+        assert_eq!(collected.pages_fetched, 1);
+        assert_eq!(collected.total, Some(50));
+    }
+
+    #[tokio::test]
+    async fn cancellation_before_the_walk_yields_nothing() {
+        let fetcher = ScriptedFetcher::ok(vec![cursor_page(&[1, 2], Some("c1"), None)]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor);
+        walk.cancel_token().cancel();
+
+        let collected = walk
+            .collect_all()
+            .await
+            .expect("cancellation is not an error");
+
+        assert!(collected.items.is_empty());
+        assert_eq!(collected.stop_reason, StopReason::Cancelled);
+        assert!(walk.fetcher.requests().is_empty(), "nothing was requested");
+    }
+
+    #[tokio::test]
+    async fn cancellation_mid_walk_keeps_the_pages_already_emitted() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1, 2], Some("c1"), Some(100)),
+            cursor_page(&[3, 4], Some("c2"), Some(100)),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor);
+        let cancel = walk.cancel_token();
+
+        let first = walk.next_page().await.unwrap().expect("first page");
+        assert_eq!(first.items, vec![1, 2]);
+
+        cancel.cancel();
+        assert!(walk.next_page().await.unwrap().is_none());
+        assert_eq!(walk.stop_reason(), Some(StopReason::Cancelled));
+        assert_eq!(walk.items_emitted(), 2);
+        assert_eq!(
+            walk.next_continuation(),
+            Some(&PageCursor::Cursor("c1".to_string())),
+            "a cancelled walk can be resumed"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_interrupts_an_in_flight_fetch() {
+        struct HangingFetcher;
+
+        impl PageFetcher for HangingFetcher {
+            type Item = u32;
+
+            fn fetch_page(&self, _request: PageRequest) -> PageFuture<'_, u32> {
+                Box::pin(async {
+                    std::future::pending::<()>().await;
+                    unreachable!("the fetch never completes")
+                })
+            }
+        }
+
+        let mut walk = Paginator::new(HangingFetcher, PaginationMode::Cursor);
+        let cancel = walk.cancel_token();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            cancel.cancel();
+        });
+
+        let page = walk
+            .next_page()
+            .await
+            .expect("cancellation is not an error");
+
+        assert!(page.is_none());
+        assert_eq!(walk.stop_reason(), Some(StopReason::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn a_failed_fetch_does_not_advance_the_walk_or_duplicate_items() {
+        let fetcher = ScriptedFetcher::new(vec![
+            Ok(cursor_page(&[1, 2], Some("c1"), Some(4))),
+            Err(Error::Transport {
+                url: "http://registry.test/api/search".to_string(),
+                attempts: 3,
+                reason: "the request timed out".to_string(),
+            }),
+            Ok(cursor_page(&[3, 4], None, Some(4))),
+        ]);
+        let mut walk = paginator(fetcher, PaginationMode::Cursor);
+
+        let mut items = Vec::new();
+        items.extend(walk.next_page().await.unwrap().unwrap().items);
+        assert!(walk.next_page().await.is_err(), "second fetch fails");
+        // Retrying re-requests the same cursor rather than skipping ahead.
+        items.extend(walk.next_page().await.unwrap().unwrap().items);
+        assert!(walk.next_page().await.unwrap().is_none());
+
+        assert_eq!(items, vec![1, 2, 3, 4], "no duplicates, no skips");
+        let cursors: Vec<Option<PageCursor>> = walk
+            .fetcher
+            .requests()
+            .iter()
+            .map(|request| request.cursor.clone())
+            .collect();
+        assert_eq!(
+            cursors,
+            vec![
+                None,
+                Some(PageCursor::Cursor("c1".to_string())),
+                Some(PageCursor::Cursor("c1".to_string())),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn items_stream_yields_every_item_in_order() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1, 2], Some("c1"), Some(5)),
+            cursor_page(&[3, 4], Some("c2"), Some(5)),
+            cursor_page(&[5], None, Some(5)),
+        ]);
+        let walk = paginator(fetcher, PaginationMode::Cursor);
+
+        let items: Vec<u32> = walk
+            .items()
+            .map(|item| item.expect("stream item"))
+            .collect::<Vec<_>>()
+            .await;
+
+        assert_eq!(items, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[tokio::test]
+    async fn pages_stream_surfaces_pagination_errors() {
+        let fetcher = ScriptedFetcher::ok(vec![
+            cursor_page(&[1], Some("same"), None),
+            cursor_page(&[2], Some("same"), None),
+        ]);
+        let walk = paginator(fetcher, PaginationMode::Cursor);
+
+        let results: Vec<Result<RegistryPage<u32>>> = walk.pages().collect::<Vec<_>>().await;
+
+        assert_eq!(results.len(), 2);
+        assert!(results[0].is_ok());
+        assert!(matches!(
+            results[1],
+            Err(Error::Pagination(PaginationError::RepeatedCursor { .. }))
+        ));
+    }
+
+    #[test]
+    fn pagination_mode_parses_the_documented_spellings() {
+        assert_eq!(
+            "cursor".parse::<PaginationMode>().unwrap(),
+            PaginationMode::Cursor
+        );
+        assert_eq!(
+            " OFFSET ".parse::<PaginationMode>().unwrap(),
+            PaginationMode::Offset
+        );
+        assert!("pages".parse::<PaginationMode>().is_err());
+    }
+
+    #[test]
+    fn effective_page_size_respects_the_remaining_budget_and_server_cap() {
+        let limits = PageLimits::default().with_page_size(50);
+        assert_eq!(limits.effective_page_size(None), 50);
+        assert_eq!(limits.effective_page_size(Some(7)), 7);
+        assert_eq!(limits.effective_page_size(Some(1_000)), 50);
+        assert_eq!(
+            PageLimits::default()
+                .with_page_size(5_000)
+                .effective_page_size(None),
+            MAX_PAGE_SIZE
+        );
+    }
+}

--- a/backend/registry_client/tests/api_surface_tests.rs
+++ b/backend/registry_client/tests/api_surface_tests.rs
@@ -1,0 +1,678 @@
+// tests/api_surface_tests.rs
+//
+// The typed endpoint groups, over real HTTP: what each method sends (method,
+// path, query, body, headers) and what it decodes. Also covers the retry rules
+// for mutations, the response-cache hook, and cancellation.
+
+mod support;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use registry_client::{
+    Auth, CancelToken, ClientConfig, ContractSearchParams, ContractVerifyRequest,
+    CreateWebhookRequest, Error, Network, PageLimits, PaginationMode, PublishRequest,
+    RegistryClient, ResponseCache, RetryPolicy, StopReason, UpdateContractMetadataRequest,
+    IDEMPOTENCY_KEY_HEADER,
+};
+use serde_json::json;
+use support::{FakeRegistry, Reply};
+
+fn publish_request() -> PublishRequest {
+    PublishRequest {
+        contract_id: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC".to_string(),
+        wasm_hash: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08".to_string(),
+        wasm_artifact_base64: None,
+        name: "swap-router".to_string(),
+        slug: None,
+        description: Some("AMM router".to_string()),
+        network: Network::Testnet,
+        category: Some("DeFi".to_string()),
+        tags: vec!["amm".to_string()],
+        source_url: None,
+        publisher_address: "GDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC".to_string(),
+        dependencies: Vec::new(),
+        is_cicd: true,
+    }
+}
+
+// ── Publish ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn publish_posts_the_typed_request_and_decodes_the_contract() {
+    let registry =
+        FakeRegistry::start(vec![Reply::ok(&support::contract_body(1).to_string())]).await;
+
+    let contract = registry
+        .client()
+        .publish_contract(&publish_request(), None)
+        .await
+        .expect("publish should succeed");
+
+    assert_eq!(contract.name, "contract-1");
+
+    let request = &registry.requests()[0];
+    assert_eq!(request.method(), "POST");
+    assert_eq!(request.target(), "/api/contracts");
+    let body = request.json();
+    assert_eq!(body["contract_id"], publish_request().contract_id);
+    assert_eq!(body["network"], "testnet");
+    assert_eq!(body["is_cicd"], true);
+    assert!(
+        request.header(IDEMPOTENCY_KEY_HEADER).is_none(),
+        "no key was asked for, so none is sent"
+    );
+}
+
+#[tokio::test]
+async fn publish_sends_the_idempotency_key_when_given_one() {
+    let registry =
+        FakeRegistry::start(vec![Reply::ok(&support::contract_body(1).to_string())]).await;
+
+    registry
+        .client()
+        .publish_contract(&publish_request(), Some("release-1.4.2".to_string()))
+        .await
+        .expect("publish should succeed");
+
+    assert_eq!(
+        registry.requests()[0].header(IDEMPOTENCY_KEY_HEADER),
+        Some("release-1.4.2".to_string())
+    );
+}
+
+#[tokio::test]
+async fn a_keyless_publish_is_never_retried() {
+    let registry = FakeRegistry::start(vec![
+        Reply::error(503, r#"{"code":"ServiceUnavailable"}"#),
+        Reply::ok(&support::contract_body(1).to_string()),
+    ])
+    .await;
+    let client =
+        RegistryClient::from_config(ClientConfig::new(registry.base_url()).with_retry_policy(
+            RetryPolicy::attempts(3).with_initial_backoff(Duration::from_millis(1)),
+        ))
+        .expect("client");
+
+    let err = client
+        .publish_contract(&publish_request(), None)
+        .await
+        .expect_err("a keyless mutation must not be repeated");
+
+    assert!(matches!(err, Error::Upstream(_)), "{err:?}");
+    assert_eq!(
+        registry.requests().len(),
+        1,
+        "publishing twice could register the contract twice"
+    );
+}
+
+#[tokio::test]
+async fn a_keyed_publish_is_retried_and_replays_the_original_response() {
+    let registry = FakeRegistry::start(vec![
+        Reply::error(503, r#"{"code":"ServiceUnavailable"}"#),
+        Reply::ok(&support::contract_body(1).to_string()),
+    ])
+    .await;
+    let client =
+        RegistryClient::from_config(ClientConfig::new(registry.base_url()).with_retry_policy(
+            RetryPolicy::attempts(3).with_initial_backoff(Duration::from_millis(1)),
+        ))
+        .expect("client");
+
+    let contract = client
+        .publish_contract(&publish_request(), Some("release-1".to_string()))
+        .await
+        .expect("the retry should succeed");
+
+    assert_eq!(contract.name, "contract-1");
+    let requests = registry.requests();
+    assert_eq!(requests.len(), 2);
+    for request in &requests {
+        assert_eq!(
+            request.header(IDEMPOTENCY_KEY_HEADER),
+            Some("release-1".to_string()),
+            "every attempt carries the same key, so the registry can dedupe"
+        );
+    }
+}
+
+#[tokio::test]
+async fn mutation_retries_can_be_disabled_even_with_a_key() {
+    let registry = FakeRegistry::start(vec![
+        Reply::error(503, r#"{"code":"ServiceUnavailable"}"#),
+        Reply::ok(&support::contract_body(1).to_string()),
+    ])
+    .await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url())
+            .with_retry_policy(RetryPolicy::attempts(3).with_retry_idempotent_mutations(false)),
+    )
+    .expect("client");
+
+    let err = client
+        .publish_contract(&publish_request(), Some("release-1".to_string()))
+        .await
+        .expect_err("retrying was switched off");
+
+    assert!(matches!(err, Error::Upstream(_)), "{err:?}");
+    assert_eq!(registry.requests().len(), 1);
+}
+
+#[tokio::test]
+async fn an_invalid_idempotency_key_is_rejected_before_sending() {
+    let registry = FakeRegistry::start(Vec::new()).await;
+
+    let err = registry
+        .client()
+        .publish_contract(&publish_request(), Some(String::new()))
+        .await
+        .expect_err("an empty key is invalid");
+
+    assert!(matches!(err, Error::InvalidRequest(_)), "{err:?}");
+    assert!(
+        registry.requests().is_empty(),
+        "nothing should reach the network"
+    );
+}
+
+// ── Metadata ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn metadata_updates_patch_the_metadata_path() {
+    let registry =
+        FakeRegistry::start(vec![Reply::ok(&support::contract_body(2).to_string())]).await;
+
+    let update = UpdateContractMetadataRequest {
+        name: Some("renamed".to_string()),
+        description: None,
+        category: Some("NFT".to_string()),
+        tags: Some(vec!["art".to_string()]),
+        user_id: None,
+    };
+    let contract = registry
+        .client()
+        .update_contract_metadata("11111111-1111-1111-1111-111111111111", &update, None)
+        .await
+        .expect("update should succeed");
+
+    assert_eq!(contract.name, "contract-2");
+    let request = &registry.requests()[0];
+    assert_eq!(request.method(), "PATCH");
+    assert_eq!(
+        request.target(),
+        "/api/contracts/11111111-1111-1111-1111-111111111111/metadata"
+    );
+    assert_eq!(request.json()["name"], "renamed");
+    assert_eq!(request.json()["category"], "NFT");
+}
+
+#[tokio::test]
+async fn contract_metadata_reads_use_the_v1_endpoint() {
+    let registry = FakeRegistry::start(vec![Reply::ok(r#"{"contract_id":"CA1","abi":{}}"#)]).await;
+
+    let metadata = registry
+        .client()
+        .get_contract_metadata("CA1")
+        .await
+        .expect("metadata should decode");
+
+    assert_eq!(metadata["contract_id"], "CA1");
+    assert_eq!(
+        registry.requests()[0].target(),
+        "/api/v1/contracts/CA1/metadata"
+    );
+}
+
+#[tokio::test]
+async fn get_contract_decodes_the_flattened_response() {
+    let mut body = support::contract_body(3);
+    body["current_network"] = json!("testnet");
+    let registry = FakeRegistry::start(vec![Reply::ok(&body.to_string())]).await;
+
+    let response = registry
+        .client()
+        .get_contract("contract-3")
+        .await
+        .expect("contract should decode");
+
+    assert_eq!(response.contract.name, "contract-3");
+    assert!(matches!(response.current_network, Some(Network::Testnet)));
+    assert_eq!(registry.requests()[0].target(), "/api/contracts/contract-3");
+}
+
+// ── List pagination ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn the_list_paginator_walks_cursor_pages() {
+    let registry = FakeRegistry::start(vec![
+        Reply::ok(&support::contract_list_body_with_cursor(
+            2,
+            3,
+            Some("tok-2"),
+        )),
+        Reply::ok(&support::contract_list_body(1, 3)),
+    ])
+    .await;
+
+    let mut walk = registry
+        .client()
+        .list_paginator(
+            ContractSearchParams::default(),
+            PaginationMode::Cursor,
+            PageLimits::default().with_page_size(2),
+        )
+        .expect("paginator");
+
+    let collected = walk.collect_all().await.expect("walk should succeed");
+
+    assert_eq!(collected.items.len(), 3);
+    assert_eq!(collected.total, Some(3));
+    assert_eq!(collected.stop_reason, StopReason::Exhausted);
+
+    let targets = registry
+        .requests()
+        .iter()
+        .map(|request| request.target().to_string())
+        .collect::<Vec<_>>();
+    assert!(
+        targets[0].contains("cursor=&") || targets[0].ends_with("cursor="),
+        "{:?}",
+        targets[0]
+    );
+    assert!(targets[1].contains("cursor=tok-2"), "{:?}", targets[1]);
+}
+
+#[tokio::test]
+async fn the_list_paginator_walks_offset_pages_and_stops_at_the_total() {
+    let registry = FakeRegistry::start(vec![
+        Reply::ok(&support::contract_list_body(2, 3)),
+        Reply::ok(&support::contract_list_body(1, 3)),
+    ])
+    .await;
+
+    let mut walk = registry
+        .client()
+        .list_paginator(
+            ContractSearchParams::default(),
+            PaginationMode::Offset,
+            PageLimits::default().with_page_size(2),
+        )
+        .expect("paginator");
+
+    let collected = walk.collect_all().await.expect("walk should succeed");
+
+    assert_eq!(collected.items.len(), 3);
+    assert_eq!(collected.stop_reason, StopReason::Exhausted);
+    let targets = registry
+        .requests()
+        .iter()
+        .map(|request| request.target().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(targets.len(), 2, "the total ends the walk");
+    assert!(targets[0].contains("offset=0"), "{:?}", targets[0]);
+    assert!(targets[1].contains("offset=2"), "{:?}", targets[1]);
+    assert!(
+        !targets[1].contains("cursor="),
+        "an offset walk never sends a cursor: {:?}",
+        targets[1]
+    );
+}
+
+// ── Verification, deprecation, vulnerabilities ─────────────────────────────────
+
+#[tokio::test]
+async fn verification_submission_posts_to_the_contract_verify_path() {
+    let registry = FakeRegistry::start(vec![Reply::ok(
+        r#"{"verification_id":"33333333-3333-3333-3333-333333333333","contract_id":"CA1","status":"pending","message":"queued","submitted_at":"2026-01-01T00:00:00Z"}"#,
+    )])
+    .await;
+
+    let request =
+        ContractVerifyRequest::new("fn main() {}", "1.81.0", json!({"profile": "release"}))
+            .with_notes(Some("first attempt".to_string()));
+    let response = registry
+        .client()
+        .submit_contract_verification("CA1", &request, Some("verify-1".to_string()))
+        .await
+        .expect("submission should succeed");
+
+    assert_eq!(response.status, "pending");
+    let recorded = &registry.requests()[0];
+    assert_eq!(recorded.method(), "POST");
+    assert_eq!(recorded.target(), "/api/contracts/CA1/verify");
+    assert_eq!(recorded.json()["compiler_version"], "1.81.0");
+    assert_eq!(recorded.json()["notes"], "first attempt");
+    assert_eq!(
+        recorded.header(IDEMPOTENCY_KEY_HEADER),
+        Some("verify-1".to_string())
+    );
+}
+
+#[tokio::test]
+async fn verification_status_and_history_decode() {
+    let registry = FakeRegistry::start(vec![
+        Reply::ok(
+            r#"{"contract_id":"CA1","verification_status":"verified","is_verified":true,"verified_at":"2026-01-01T00:00:00Z","verification_method":"source","auditor":null,"report_url":null,"verification_notes":null,"cached":true}"#,
+        ),
+        Reply::ok(
+            r#"{"contract_id":"CA1","total":1,"history":[{"id":"44444444-4444-4444-4444-444444444444","from_status":"pending","to_status":"verified","changed_by":null,"notes":null,"created_at":"2026-01-01T00:00:00Z"}]}"#,
+        ),
+    ])
+    .await;
+    let client = registry.client();
+
+    let status = client
+        .contract_verification_status("CA1")
+        .await
+        .expect("status should decode");
+    assert!(status.is_verified);
+    assert!(status.cached);
+
+    let history = client
+        .contract_verification_history("CA1")
+        .await
+        .expect("history should decode");
+    assert_eq!(history.total, 1);
+    assert_eq!(history.history[0].to_status, "verified");
+
+    assert_eq!(
+        registry
+            .requests()
+            .iter()
+            .map(|request| request.target().to_string())
+            .collect::<Vec<_>>(),
+        vec![
+            "/api/contracts/CA1/verification-status",
+            "/api/contracts/CA1/verification-history"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn deprecation_calls_hit_the_documented_paths() {
+    let info = r#"{"contract_id":"11111111-1111-1111-1111-111111111111","is_deprecated":true,"deprecation_status":"deprecated","deprecated_at":"2026-01-01T00:00:00Z","retirement_at":"2026-06-01T00:00:00Z","replacement_contract_id":null,"migration_guide_url":null,"notes":null,"deprecated_reason":"superseded","grace_period_days":null}"#;
+    let registry = FakeRegistry::start(vec![Reply::ok(info), Reply::ok(info)]).await;
+    let client = registry.client();
+
+    client
+        .deprecation_info("11111111-1111-1111-1111-111111111111")
+        .await
+        .ok();
+    client
+        .undeprecate_contract("11111111-1111-1111-1111-111111111111", None)
+        .await
+        .ok();
+
+    let requests = registry.requests();
+    assert_eq!(requests[0].method(), "GET");
+    assert!(requests[0].target().ends_with("/deprecation-info"));
+    assert_eq!(requests[1].method(), "DELETE");
+    assert!(requests[1].target().ends_with("/deprecate"));
+}
+
+#[tokio::test]
+async fn dependency_scan_reports_decode_into_the_shared_model() {
+    let registry = FakeRegistry::start(vec![Reply::ok(
+        r#"{"contract_id":"11111111-1111-1111-1111-111111111111","status":"vulnerable","dependencies_scanned":12,"vulnerable_dependency_count":1,"last_scanned_at":"2026-01-01T00:00:00Z","findings":[]}"#,
+    )])
+    .await;
+
+    let report = registry
+        .client()
+        .dependency_scan_report("11111111-1111-1111-1111-111111111111")
+        .await
+        .expect("report should decode");
+
+    assert_eq!(report.status, "vulnerable");
+    assert_eq!(report.dependencies_scanned, 12);
+    assert!(registry.requests()[0]
+        .target()
+        .ends_with("/dependency-scan"));
+}
+
+// ── Webhooks ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn creating_a_webhook_lifts_the_signing_secret_out_of_the_model() {
+    let registry = FakeRegistry::start(vec![Reply::ok(
+        r#"{"id":"55555555-5555-5555-5555-555555555555","user_id":null,"organization_id":null,"name":"ci","url":"https://ci.example/hook","notification_types":[],"is_active":true,"verify_ssl":true,"custom_headers":null,"rate_limit_per_minute":null,"total_deliveries":0,"failed_deliveries":0,"last_delivery_at":null,"last_success_at":null,"last_failure_at":null,"consecutive_failures":0,"secret":"whsec_super_secret","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}"#,
+    )])
+    .await;
+
+    let created = registry
+        .client()
+        .create_webhook(
+            &CreateWebhookRequest {
+                name: "ci".to_string(),
+                url: "https://ci.example/hook".to_string(),
+                notification_types: Vec::new(),
+                secret: None,
+                verify_ssl: Some(true),
+                custom_headers: None,
+            },
+            None,
+        )
+        .await
+        .expect("creation should succeed");
+
+    assert_eq!(created.webhook.name, "ci");
+    assert!(
+        created.webhook.secret.is_none(),
+        "the secret is moved out of the loggable model"
+    );
+    assert_eq!(
+        created.secret.as_ref().map(|secret| secret.expose()),
+        Some("whsec_super_secret")
+    );
+    let rendered = format!("{created:?}");
+    assert!(
+        !rendered.contains("whsec_super_secret"),
+        "debug output must not print the signing secret: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn webhook_deletes_and_test_sends_tolerate_empty_bodies() {
+    let registry = FakeRegistry::start(vec![Reply::no_content(), Reply::no_content()]).await;
+    let client = registry.client();
+
+    client
+        .delete_webhook("55555555-5555-5555-5555-555555555555", None)
+        .await
+        .expect("delete should succeed");
+    client
+        .test_webhook("55555555-5555-5555-5555-555555555555", None)
+        .await
+        .expect("test send should succeed");
+
+    let requests = registry.requests();
+    assert_eq!(requests[0].method(), "DELETE");
+    assert_eq!(requests[1].method(), "POST");
+    assert!(requests[1].target().ends_with("/test"));
+}
+
+// ── Snapshots ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn the_registry_signing_key_decodes() {
+    let registry = FakeRegistry::start(vec![Reply::ok(
+        r#"{"algorithm":"ed25519","public_key":"BASE64KEY","key_fingerprint":"ab12"}"#,
+    )])
+    .await;
+
+    let key = registry
+        .client()
+        .registry_signing_key()
+        .await
+        .expect("key should decode");
+
+    assert_eq!(key.algorithm, "ed25519");
+    assert_eq!(key.key_fingerprint, "ab12");
+    assert_eq!(registry.requests()[0].target(), "/api/registry/signing-key");
+}
+
+// ── Cross-cutting behaviour ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn every_request_carries_the_configured_user_agent_and_credential() {
+    let registry = FakeRegistry::start(vec![Reply::ok(&support::contract_list_body(1, 1))]).await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url())
+            .with_user_agent("my-tool/9.9")
+            .with_auth(Auth::bearer("token-abc")),
+    )
+    .expect("client");
+
+    client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect("list should succeed");
+
+    let request = &registry.requests()[0];
+    assert_eq!(
+        request.header("user-agent"),
+        Some("my-tool/9.9".to_string())
+    );
+    assert_eq!(
+        request.header("authorization"),
+        Some("Bearer token-abc".to_string()),
+        "the credential must reach the wire even though it is redacted in logs"
+    );
+}
+
+#[tokio::test]
+async fn an_api_key_scheme_uses_its_own_header() {
+    let registry = FakeRegistry::start(vec![Reply::ok(&support::contract_list_body(1, 1))]).await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url()).with_auth(Auth::api_key("X-API-Key", "key-xyz")),
+    )
+    .expect("client");
+
+    client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect("list should succeed");
+
+    let request = &registry.requests()[0];
+    assert_eq!(request.header("x-api-key"), Some("key-xyz".to_string()));
+    assert!(request.header("authorization").is_none());
+}
+
+#[tokio::test]
+async fn the_response_cache_hook_serves_repeat_reads() {
+    #[derive(Default)]
+    struct CountingCache {
+        entries: Mutex<Vec<(String, String)>>,
+        hits: AtomicUsize,
+    }
+
+    impl ResponseCache for CountingCache {
+        fn get(&self, key: &str) -> Option<String> {
+            let entries = self.entries.lock().expect("cache");
+            let hit = entries
+                .iter()
+                .find(|(cached, _)| cached == key)
+                .map(|(_, body)| body.clone());
+            if hit.is_some() {
+                self.hits.fetch_add(1, Ordering::SeqCst);
+            }
+            hit
+        }
+
+        fn put(&self, key: &str, body: &str) {
+            self.entries
+                .lock()
+                .expect("cache")
+                .push((key.to_string(), body.to_string()));
+        }
+    }
+
+    let registry = FakeRegistry::start(vec![Reply::ok(&support::contract_list_body(1, 1))]).await;
+    let cache = Arc::new(CountingCache::default());
+    let client = RegistryClient::from_config(ClientConfig::new(registry.base_url()))
+        .expect("client")
+        .with_response_cache(cache.clone());
+
+    let params = ContractSearchParams {
+        limit: Some(1),
+        ..Default::default()
+    };
+    client.list_contracts(&params).await.expect("first read");
+    client.list_contracts(&params).await.expect("second read");
+
+    assert_eq!(
+        registry.requests().len(),
+        1,
+        "the second read came from the cache"
+    );
+    assert_eq!(cache.hits.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn mutations_are_never_served_from_the_cache() {
+    struct AlwaysHit;
+
+    impl ResponseCache for AlwaysHit {
+        fn get(&self, _key: &str) -> Option<String> {
+            Some(support::contract_body(99).to_string())
+        }
+        fn put(&self, _key: &str, _body: &str) {}
+    }
+
+    let registry =
+        FakeRegistry::start(vec![Reply::ok(&support::contract_body(1).to_string())]).await;
+    let client = RegistryClient::from_config(ClientConfig::new(registry.base_url()))
+        .expect("client")
+        .with_response_cache(Arc::new(AlwaysHit));
+
+    let contract = client
+        .publish_contract(&publish_request(), None)
+        .await
+        .expect("publish should succeed");
+
+    assert_eq!(contract.name, "contract-1", "the cache was bypassed");
+    assert_eq!(registry.requests().len(), 1);
+}
+
+#[tokio::test]
+async fn a_cancelled_client_abandons_the_request() {
+    let registry = FakeRegistry::start(vec![Reply::hang()]).await;
+    let cancel = CancelToken::new();
+    let client = RegistryClient::from_config(ClientConfig::new(registry.base_url()))
+        .expect("client")
+        .with_cancel_token(cancel.clone());
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        cancel.cancel();
+    });
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("cancellation must surface");
+
+    assert!(matches!(err, Error::Cancelled { .. }), "{err:?}");
+}
+
+#[tokio::test]
+async fn the_escape_hatch_shares_the_clients_behaviour() {
+    let registry = FakeRegistry::start(vec![Reply::ok(r#"["defi","amm"]"#)]).await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url()).with_auth(Auth::bearer("token-abc")),
+    )
+    .expect("client");
+
+    let tags: Vec<String> = client
+        .get_json("/api/contracts/tags")
+        .await
+        .expect("tags should decode");
+
+    assert_eq!(tags, vec!["defi", "amm"]);
+    assert_eq!(
+        registry.requests()[0].header("authorization"),
+        Some("Bearer token-abc".to_string())
+    );
+}

--- a/backend/registry_client/tests/error_taxonomy_tests.rs
+++ b/backend/registry_client/tests/error_taxonomy_tests.rs
@@ -1,0 +1,478 @@
+// tests/error_taxonomy_tests.rs
+//
+// Every failure mode the registry can produce, over real HTTP, asserted through
+// the client's public API: success, malformed JSON, timeouts, 401, 403, 409,
+// 422, 429 and 5xx — plus what the retry policy does with each.
+//
+// The fake registry is a few lines of tokio rather than a mocking framework, so
+// these tests stay dependency-free and run offline.
+
+mod support;
+
+use std::time::Duration;
+
+use registry_client::{
+    ClientConfig, ContractSearchParams, Error, PublishRequest, RegistryClient, RetryPolicy,
+};
+use support::{FakeRegistry, Reply};
+
+fn publish_request() -> PublishRequest {
+    PublishRequest {
+        contract_id: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC".to_string(),
+        wasm_hash: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08".to_string(),
+        wasm_artifact_base64: None,
+        name: "swap-router".to_string(),
+        slug: None,
+        description: None,
+        network: registry_client::Network::Testnet,
+        category: None,
+        tags: Vec::new(),
+        source_url: None,
+        publisher_address: "GDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC".to_string(),
+        dependencies: Vec::new(),
+        is_cicd: false,
+    }
+}
+
+/// A client with retries off, so one request means one attempt.
+fn single_attempt_client(registry: &FakeRegistry) -> RegistryClient {
+    RegistryClient::from_config(
+        ClientConfig::new(registry.base_url()).with_retry_policy(RetryPolicy::none()),
+    )
+    .expect("client")
+}
+
+// ── Success ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_successful_list_decodes_into_typed_models() {
+    let registry = FakeRegistry::start(vec![Reply::ok(&support::contract_list_body(2, 7))]).await;
+    let client = single_attempt_client(&registry);
+
+    let page = client
+        .list_contracts(&ContractSearchParams {
+            limit: Some(2),
+            ..Default::default()
+        })
+        .await
+        .expect("list should succeed");
+
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.total, 7);
+    assert_eq!(page.items[0].name, "contract-0");
+    let target = registry.requests()[0].target().to_string();
+    assert!(target.starts_with("/api/contracts?"), "{target}");
+    assert!(target.contains("limit=2"), "{target}");
+}
+
+// ── Malformed responses ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn malformed_json_is_reported_as_a_decode_failure() {
+    let registry = FakeRegistry::start(vec![Reply::ok("{ this is not json")]).await;
+    let client = single_attempt_client(&registry);
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("a malformed body must not be swallowed");
+
+    assert!(
+        matches!(err, Error::MalformedResponse { .. }),
+        "unexpected error: {err:?}"
+    );
+    assert!(err.to_string().contains("could not decode"), "{err}");
+}
+
+#[tokio::test]
+async fn a_well_formed_body_of_the_wrong_shape_is_a_decode_failure() {
+    // Valid JSON, but not a paginated contract list.
+    let registry = FakeRegistry::start(vec![Reply::ok(r#"{"unexpected": true}"#)]).await;
+    let client = single_attempt_client(&registry);
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("shape mismatch must surface");
+
+    assert!(matches!(err, Error::MalformedResponse { .. }), "{err:?}");
+}
+
+// ── Timeouts ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_slow_endpoint_produces_a_timeout_error() {
+    let registry = FakeRegistry::start(vec![Reply::hang()]).await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url())
+            .with_timeout(Duration::from_millis(150))
+            .with_retry_policy(RetryPolicy::none()),
+    )
+    .expect("client");
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("the request must time out");
+
+    assert!(matches!(err, Error::Timeout { .. }), "unexpected: {err:?}");
+    assert!(err.is_transient(), "a timeout is worth retrying");
+    assert!(err.to_string().contains("timed out"), "{err}");
+}
+
+#[tokio::test]
+async fn timeouts_are_retried_when_the_policy_allows_it() {
+    let registry = FakeRegistry::start(vec![
+        Reply::hang(),
+        Reply::ok(&support::contract_list_body(1, 1)),
+    ])
+    .await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url())
+            .with_timeout(Duration::from_millis(150))
+            .with_retry_policy(
+                RetryPolicy::attempts(2).with_initial_backoff(Duration::from_millis(1)),
+            ),
+    )
+    .expect("client");
+
+    let page = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect("the retry should succeed");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(registry.requests().len(), 2);
+}
+
+#[tokio::test]
+async fn timeout_retries_can_be_switched_off() {
+    let registry = FakeRegistry::start(vec![
+        Reply::hang(),
+        Reply::ok(&support::contract_list_body(1, 1)),
+    ])
+    .await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url())
+            .with_timeout(Duration::from_millis(150))
+            .with_retry_policy(RetryPolicy::attempts(3).with_retry_on_timeout(false)),
+    )
+    .expect("client");
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("timeouts must not be retried");
+
+    assert!(matches!(err, Error::Timeout { .. }), "{err:?}");
+    assert_eq!(registry.requests().len(), 1);
+}
+
+// ── Status classification ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn unauthorized_responses_are_distinct_from_forbidden_ones() {
+    let registry = FakeRegistry::start(vec![
+        Reply::error(
+            401,
+            r#"{"code":"Unauthorized","message":"session expired","request_id":"req-1"}"#,
+        ),
+        Reply::error(
+            403,
+            r#"{"code":"Forbidden","message":"not the publisher","request_id":"req-2"}"#,
+        ),
+    ])
+    .await;
+    let client = single_attempt_client(&registry);
+
+    let unauthorized = client
+        .get_contract("abc")
+        .await
+        .expect_err("401 must surface");
+    assert!(
+        matches!(unauthorized, Error::Unauthorized(_)),
+        "{unauthorized:?}"
+    );
+    assert!(unauthorized.is_auth());
+    assert!(
+        !unauthorized.is_transient(),
+        "retrying will not fix credentials"
+    );
+    assert_eq!(unauthorized.code(), Some("Unauthorized"));
+    assert_eq!(unauthorized.request_id(), Some("req-1"));
+
+    let forbidden = client
+        .get_contract("abc")
+        .await
+        .expect_err("403 must surface");
+    assert!(matches!(forbidden, Error::Forbidden(_)), "{forbidden:?}");
+    assert!(forbidden.is_auth());
+    assert_eq!(forbidden.status(), Some(403));
+}
+
+#[tokio::test]
+async fn a_missing_contract_is_a_not_found_error() {
+    let registry = FakeRegistry::start(vec![Reply::error(
+        404,
+        r#"{"code":"NotFound","message":"no such contract"}"#,
+    )])
+    .await;
+    let client = single_attempt_client(&registry);
+
+    let err = client.get_contract("missing").await.expect_err("404");
+
+    assert!(matches!(err, Error::NotFound(_)), "{err:?}");
+    assert!(!err.is_transient());
+}
+
+#[tokio::test]
+async fn a_duplicate_publish_is_a_conflict_with_the_server_code() {
+    let registry = FakeRegistry::start(vec![Reply::error(
+        409,
+        r#"{"code":"ContractAlreadyExists","message":"already registered","details":{"contract_id":"CDLZ"}}"#,
+    )])
+    .await;
+    let client = single_attempt_client(&registry);
+
+    let err = client
+        .publish_contract(&publish_request(), None)
+        .await
+        .expect_err("409");
+
+    assert!(matches!(err, Error::Conflict(_)), "{err:?}");
+    assert_eq!(err.code(), Some("ContractAlreadyExists"));
+    assert_eq!(
+        err.error_details()
+            .and_then(|details| details["contract_id"].as_str()),
+        Some("CDLZ"),
+        "structured details are preserved"
+    );
+}
+
+#[tokio::test]
+async fn an_in_flight_idempotent_publish_is_its_own_error() {
+    let registry = FakeRegistry::start(vec![Reply::error(
+        409,
+        r#"{"code":"IdempotencyKeyInProgress","message":"already processing"}"#,
+    )])
+    .await;
+    let client = single_attempt_client(&registry);
+
+    let err = client
+        .publish_contract(&publish_request(), Some("release-1".to_string()))
+        .await
+        .expect_err("409 in-progress");
+
+    assert!(
+        matches!(err, Error::IdempotencyInProgress(_)),
+        "an in-flight replay must be distinguishable from a duplicate: {err:?}"
+    );
+    assert!(err.is_transient(), "the caller should try again shortly");
+}
+
+#[tokio::test]
+async fn validation_failures_carry_field_details() {
+    let registry = FakeRegistry::start(vec![Reply::error(
+        422,
+        r#"{"code":"ValidationError","message":"invalid metadata","details":{"errors":[{"field":"name","reason":"too long"}]}}"#,
+    )])
+    .await;
+    let client = single_attempt_client(&registry);
+
+    let err = client
+        .publish_contract(&publish_request(), None)
+        .await
+        .expect_err("422");
+
+    assert!(matches!(err, Error::Validation(_)), "{err:?}");
+    assert!(!err.is_transient(), "a bad request will not fix itself");
+    let details = err.error_details().expect("structured details");
+    assert_eq!(details["errors"][0]["field"], "name");
+}
+
+#[tokio::test]
+async fn a_400_is_also_a_validation_failure() {
+    let registry = FakeRegistry::start(vec![Reply::error(
+        400,
+        r#"{"code":"EMPTY_QUERY","message":"Search query cannot be empty"}"#,
+    )])
+    .await;
+    let client = single_attempt_client(&registry);
+
+    let err = client.get_contract("abc").await.expect_err("400");
+
+    assert!(matches!(err, Error::Validation(_)), "{err:?}");
+    assert_eq!(err.code(), Some("EMPTY_QUERY"));
+}
+
+#[tokio::test]
+async fn rate_limits_preserve_retry_after() {
+    let registry = FakeRegistry::start(vec![Reply::error(
+        429,
+        r#"{"code":"RateLimited","message":"slow down"}"#,
+    )
+    .with_header("retry-after", "42")])
+    .await;
+    let client = single_attempt_client(&registry);
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("429");
+
+    assert!(matches!(err, Error::RateLimited { .. }), "{err:?}");
+    assert_eq!(err.retry_after(), Some(Duration::from_secs(42)));
+    assert!(err.is_transient());
+    assert!(err.to_string().contains("retry after 42s"), "{err}");
+}
+
+#[tokio::test]
+async fn a_retry_after_beyond_the_ceiling_is_surfaced_instead_of_slept_through() {
+    let registry = FakeRegistry::start(vec![
+        Reply::error(429, r#"{"code":"RateLimited"}"#).with_header("retry-after", "3600"),
+        Reply::ok(&support::contract_list_body(1, 1)),
+    ])
+    .await;
+    let client =
+        RegistryClient::from_config(ClientConfig::new(registry.base_url()).with_retry_policy(
+            RetryPolicy::attempts(3).with_max_retry_after(Duration::from_secs(5)),
+        ))
+        .expect("client");
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("an hour-long wait must not block the call");
+
+    assert!(matches!(err, Error::RateLimited { .. }), "{err:?}");
+    assert_eq!(err.retry_after(), Some(Duration::from_secs(3600)));
+    assert_eq!(
+        registry.requests().len(),
+        1,
+        "the client stopped instead of sleeping"
+    );
+}
+
+#[tokio::test]
+async fn a_short_retry_after_is_honoured_before_retrying() {
+    let registry = FakeRegistry::start(vec![
+        Reply::error(429, r#"{"code":"RateLimited"}"#).with_header("retry-after", "0"),
+        Reply::ok(&support::contract_list_body(1, 1)),
+    ])
+    .await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url()).with_retry_policy(RetryPolicy::attempts(2)),
+    )
+    .expect("client");
+
+    let page = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect("the retry should succeed");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(registry.requests().len(), 2);
+}
+
+#[tokio::test]
+async fn server_faults_are_temporary_upstream_errors() {
+    let registry = FakeRegistry::start(vec![Reply::error(
+        503,
+        r#"{"code":"ServiceUnavailable","message":"database down"}"#,
+    )])
+    .await;
+    let client = single_attempt_client(&registry);
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("503");
+
+    assert!(matches!(err, Error::Upstream(_)), "{err:?}");
+    assert!(err.is_transient());
+    assert_eq!(err.status(), Some(503));
+}
+
+#[tokio::test]
+async fn a_5xx_is_retried_for_safe_reads() {
+    let registry = FakeRegistry::start(vec![
+        Reply::error(500, r#"{"code":"Internal"}"#),
+        Reply::error(502, r#"{"code":"BadGateway"}"#),
+        Reply::ok(&support::contract_list_body(1, 1)),
+    ])
+    .await;
+    let client =
+        RegistryClient::from_config(ClientConfig::new(registry.base_url()).with_retry_policy(
+            RetryPolicy::attempts(3).with_initial_backoff(Duration::from_millis(1)),
+        ))
+        .expect("client");
+
+    let page = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect("the third attempt should succeed");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(registry.requests().len(), 3);
+}
+
+#[tokio::test]
+async fn retries_are_bounded_by_the_policy() {
+    let registry = FakeRegistry::start(vec![
+        Reply::error(500, r#"{"code":"Internal"}"#),
+        Reply::error(500, r#"{"code":"Internal"}"#),
+        Reply::error(500, r#"{"code":"Internal"}"#),
+        Reply::error(500, r#"{"code":"Internal"}"#),
+    ])
+    .await;
+    let client =
+        RegistryClient::from_config(ClientConfig::new(registry.base_url()).with_retry_policy(
+            RetryPolicy::attempts(2).with_initial_backoff(Duration::from_millis(1)),
+        ))
+        .expect("client");
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("all attempts fail");
+
+    assert!(matches!(err, Error::Upstream(_)), "{err:?}");
+    assert_eq!(registry.requests().len(), 2, "exactly max_attempts tries");
+}
+
+#[tokio::test]
+async fn an_unreachable_registry_is_a_transport_error() {
+    // Port 1 is reserved and refuses connections.
+    let client = RegistryClient::from_config(
+        ClientConfig::new("http://127.0.0.1:1").with_retry_policy(RetryPolicy::none()),
+    )
+    .expect("client");
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("nothing is listening");
+
+    assert!(matches!(err, Error::Transport { .. }), "{err:?}");
+    assert!(err.is_transient());
+    assert!(err.to_string().contains("attempt(s)"), "{err}");
+}
+
+#[tokio::test]
+async fn an_unrecognised_status_stays_a_generic_api_error() {
+    let registry = FakeRegistry::start(vec![Reply::error(
+        418,
+        r#"{"code":"Teapot","message":"nope"}"#,
+    )])
+    .await;
+    let client = single_attempt_client(&registry);
+
+    let err = client
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("418");
+
+    assert!(matches!(err, Error::Api(_)), "{err:?}");
+    assert_eq!(err.status(), Some(418));
+    assert_eq!(err.code(), Some("Teapot"));
+}

--- a/backend/registry_client/tests/pagination_http_tests.rs
+++ b/backend/registry_client/tests/pagination_http_tests.rs
@@ -1,117 +1,19 @@
 // tests/pagination_http_tests.rs
 //
-// End-to-end pagination over real HTTP: the client walks pages served by a
-// throwaway local server that mimics the registry's two search endpoints —
+// End-to-end pagination over real HTTP: the client walks pages served by the
+// fake registry in `support`, mimicking the two search endpoints —
 // `GET /api/search` (PostgreSQL, `contracts` + `next_cursor`) and
 // `GET /api/v1/contracts/search` (Elasticsearch, `results` + `total`/`offset`).
-//
-// The server is a few lines of tokio rather than a mocking framework so these
-// tests stay dependency-free and run offline.
 
-use std::sync::{Arc, Mutex};
+mod support;
+
+use std::time::Duration;
 
 use registry_client::{
-    ContractSearchRequest, PageCursor, PageLimits, PaginationMode, RegistryClient, StopReason,
+    ClientConfig, ContractSearchRequest, PageCursor, PageLimits, PaginationMode, RegistryClient,
+    RetryPolicy, StopReason,
 };
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
-
-/// One canned HTTP reply.
-#[derive(Clone)]
-struct Reply {
-    status: u16,
-    body: String,
-}
-
-impl Reply {
-    fn ok(body: &str) -> Self {
-        Self {
-            status: 200,
-            body: body.to_string(),
-        }
-    }
-
-    fn error(status: u16, body: &str) -> Self {
-        Self {
-            status,
-            body: body.to_string(),
-        }
-    }
-}
-
-/// A local server that answers each request with the next canned reply and
-/// records the request lines it saw.
-struct FakeRegistry {
-    base_url: String,
-    requests: Arc<Mutex<Vec<String>>>,
-}
-
-impl FakeRegistry {
-    async fn start(replies: Vec<Reply>) -> Self {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind a local port");
-        let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
-        let requests = Arc::new(Mutex::new(Vec::new()));
-        let recorded = Arc::clone(&requests);
-
-        tokio::spawn(async move {
-            let mut replies = replies.into_iter();
-            while let Ok((mut socket, _)) = listener.accept().await {
-                let mut head = Vec::new();
-                let mut chunk = [0_u8; 1024];
-                loop {
-                    match socket.read(&mut chunk).await {
-                        Ok(0) | Err(_) => break,
-                        Ok(read) => head.extend_from_slice(&chunk[..read]),
-                    }
-                    if head.windows(4).any(|window| window == b"\r\n\r\n") {
-                        break;
-                    }
-                }
-
-                let text = String::from_utf8_lossy(&head).to_string();
-                recorded
-                    .lock()
-                    .expect("record request")
-                    .push(text.lines().next().unwrap_or_default().to_string());
-
-                let reply = replies
-                    .next()
-                    .unwrap_or_else(|| Reply::error(500, r#"{"code":"NO_REPLY_SCRIPTED"}"#));
-                let payload = format!(
-                    "HTTP/1.1 {} {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
-                    reply.status,
-                    reason(reply.status),
-                    reply.body.len(),
-                    reply.body
-                );
-                let _ = socket.write_all(payload.as_bytes()).await;
-                let _ = socket.flush().await;
-            }
-        });
-
-        Self { base_url, requests }
-    }
-
-    fn client(&self) -> RegistryClient {
-        RegistryClient::new(&self.base_url).expect("build client")
-    }
-
-    fn requests(&self) -> Vec<String> {
-        self.requests.lock().expect("read requests").clone()
-    }
-}
-
-fn reason(status: u16) -> &'static str {
-    match status {
-        200 => "OK",
-        400 => "Bad Request",
-        500 => "Internal Server Error",
-        503 => "Service Unavailable",
-        _ => "Unknown",
-    }
-}
+use support::{FakeRegistry, Reply};
 
 fn hit(name: &str) -> String {
     format!(
@@ -154,7 +56,7 @@ async fn cursor_walk_follows_next_cursor_to_the_end() {
     assert_eq!(collected.pages_fetched, 2);
     assert_eq!(collected.stop_reason, StopReason::Exhausted);
 
-    let requests = registry.requests();
+    let requests = registry.request_lines();
     assert!(
         requests[0].contains("/api/search?"),
         "cursor mode uses the full-text endpoint: {}",
@@ -204,7 +106,7 @@ async fn a_rejected_cursor_surfaces_as_a_typed_error() {
     assert_eq!(err.status(), Some(400));
     assert!(err.to_string().contains("INVALID_CURSOR"));
     // The malformed token was forwarded untouched — the client never decodes one.
-    assert!(registry.requests()[0].contains("cursor=not-a-real-cursor"));
+    assert!(registry.request_lines()[0].contains("cursor=not-a-real-cursor"));
 }
 
 #[tokio::test]
@@ -266,7 +168,7 @@ async fn empty_pages_with_a_continuation_token_cannot_loop_forever() {
         "unexpected error: {err}"
     );
     assert_eq!(
-        registry.requests().len(),
+        registry.request_lines().len(),
         3,
         "the walk stops instead of requesting more"
     );
@@ -304,7 +206,7 @@ async fn offset_walk_uses_the_advanced_endpoint_and_stops_at_the_total() {
     assert_eq!(collected.total, Some(3));
     assert_eq!(collected.stop_reason, StopReason::Exhausted);
 
-    let requests = registry.requests();
+    let requests = registry.request_lines();
     assert_eq!(
         requests.len(),
         2,
@@ -349,7 +251,7 @@ async fn offset_walk_can_resume_from_a_given_offset() {
     assert_eq!(page.items.len(), 1);
     assert_eq!(page.total, Some(41));
     assert!(page.next.is_none(), "offset 40 + 1 item reaches total 41");
-    assert!(registry.requests()[0].contains("offset=40"));
+    assert!(registry.request_lines()[0].contains("offset=40"));
 }
 
 // ── Cross-cutting behaviour ───────────────────────────────────────────────────
@@ -369,8 +271,12 @@ async fn a_retried_page_is_emitted_exactly_once() {
     ])
     .await;
 
-    let mut walk = registry
-        .client()
+    let retrying =
+        RegistryClient::from_config(ClientConfig::new(registry.base_url()).with_retry_policy(
+            RetryPolicy::attempts(3).with_initial_backoff(Duration::from_millis(1)),
+        ))
+        .expect("client");
+    let mut walk = retrying
         .search_paginator(
             ContractSearchRequest::cursor("swap"),
             PageLimits::default().with_page_size(2),
@@ -390,7 +296,7 @@ async fn a_retried_page_is_emitted_exactly_once() {
         "a retried fetch is still one page"
     );
     assert_eq!(
-        registry.requests().len(),
+        registry.request_lines().len(),
         2,
         "the transient failure was retried"
     );
@@ -431,7 +337,11 @@ async fn max_items_bounds_a_full_walk_and_reports_where_it_stopped() {
         Some(PageCursor::Cursor("tok-later".to_string())),
         "the walk reports where a follow-up should resume"
     );
-    assert_eq!(registry.requests().len(), 2, "no page beyond the bound");
+    assert_eq!(
+        registry.request_lines().len(),
+        2,
+        "no page beyond the bound"
+    );
 }
 
 #[tokio::test]
@@ -466,7 +376,7 @@ async fn cancelling_between_pages_keeps_what_was_already_fetched() {
         .is_none());
     assert_eq!(walk.stop_reason(), Some(StopReason::Cancelled));
     assert_eq!(
-        registry.requests().len(),
+        registry.request_lines().len(),
         1,
         "no request is made after cancellation"
     );
@@ -486,7 +396,7 @@ async fn a_cursor_walk_cannot_be_combined_with_an_offset() {
 
     assert!(err.to_string().contains("cannot be combined"), "{err}");
     assert!(
-        registry.requests().is_empty(),
+        registry.request_lines().is_empty(),
         "the request never reaches the server"
     );
 }

--- a/backend/registry_client/tests/pagination_http_tests.rs
+++ b/backend/registry_client/tests/pagination_http_tests.rs
@@ -1,0 +1,492 @@
+// tests/pagination_http_tests.rs
+//
+// End-to-end pagination over real HTTP: the client walks pages served by a
+// throwaway local server that mimics the registry's two search endpoints —
+// `GET /api/search` (PostgreSQL, `contracts` + `next_cursor`) and
+// `GET /api/v1/contracts/search` (Elasticsearch, `results` + `total`/`offset`).
+//
+// The server is a few lines of tokio rather than a mocking framework so these
+// tests stay dependency-free and run offline.
+
+use std::sync::{Arc, Mutex};
+
+use registry_client::{
+    ContractSearchRequest, PageCursor, PageLimits, PaginationMode, RegistryClient, StopReason,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// One canned HTTP reply.
+#[derive(Clone)]
+struct Reply {
+    status: u16,
+    body: String,
+}
+
+impl Reply {
+    fn ok(body: &str) -> Self {
+        Self {
+            status: 200,
+            body: body.to_string(),
+        }
+    }
+
+    fn error(status: u16, body: &str) -> Self {
+        Self {
+            status,
+            body: body.to_string(),
+        }
+    }
+}
+
+/// A local server that answers each request with the next canned reply and
+/// records the request lines it saw.
+struct FakeRegistry {
+    base_url: String,
+    requests: Arc<Mutex<Vec<String>>>,
+}
+
+impl FakeRegistry {
+    async fn start(replies: Vec<Reply>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind a local port");
+        let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&requests);
+
+        tokio::spawn(async move {
+            let mut replies = replies.into_iter();
+            while let Ok((mut socket, _)) = listener.accept().await {
+                let mut head = Vec::new();
+                let mut chunk = [0_u8; 1024];
+                loop {
+                    match socket.read(&mut chunk).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => head.extend_from_slice(&chunk[..read]),
+                    }
+                    if head.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+
+                let text = String::from_utf8_lossy(&head).to_string();
+                recorded
+                    .lock()
+                    .expect("record request")
+                    .push(text.lines().next().unwrap_or_default().to_string());
+
+                let reply = replies
+                    .next()
+                    .unwrap_or_else(|| Reply::error(500, r#"{"code":"NO_REPLY_SCRIPTED"}"#));
+                let payload = format!(
+                    "HTTP/1.1 {} {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    reply.status,
+                    reason(reply.status),
+                    reply.body.len(),
+                    reply.body
+                );
+                let _ = socket.write_all(payload.as_bytes()).await;
+                let _ = socket.flush().await;
+            }
+        });
+
+        Self { base_url, requests }
+    }
+
+    fn client(&self) -> RegistryClient {
+        RegistryClient::new(&self.base_url).expect("build client")
+    }
+
+    fn requests(&self) -> Vec<String> {
+        self.requests.lock().expect("read requests").clone()
+    }
+}
+
+fn reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        400 => "Bad Request",
+        500 => "Internal Server Error",
+        503 => "Service Unavailable",
+        _ => "Unknown",
+    }
+}
+
+fn hit(name: &str) -> String {
+    format!(
+        r#"{{"id":"11111111-1111-1111-1111-11111111111{n}","contract_id":"CA{name}","name":"{name}","description":null,"category":"DeFi","network":"testnet","is_verified":true,"is_deprecated":false,"deprecation_status":"active","relevance_score":0.5}}"#,
+        n = name.len(),
+        name = name
+    )
+}
+
+// ── Cursor pagination (PostgreSQL, `next_cursor`) ─────────────────────────────
+
+#[tokio::test]
+async fn cursor_walk_follows_next_cursor_to_the_end() {
+    let registry = FakeRegistry::start(vec![
+        Reply::ok(&format!(
+            r#"{{"contracts":[{},{}],"total":3,"took_ms":2,"next_cursor":"tok-2"}}"#,
+            hit("aa"),
+            hit("bb")
+        )),
+        Reply::ok(&format!(
+            r#"{{"contracts":[{}],"total":3,"took_ms":1}}"#,
+            hit("cc")
+        )),
+    ])
+    .await;
+
+    let mut walk = registry
+        .client()
+        .search_paginator(
+            ContractSearchRequest::cursor("swap").with_networks(["testnet"]),
+            PageLimits::default().with_page_size(2),
+        )
+        .expect("paginator");
+
+    let collected = walk.collect_all().await.expect("walk should succeed");
+
+    let names: Vec<String> = collected.items.iter().map(|hit| hit.name.clone()).collect();
+    assert_eq!(names, vec!["aa", "bb", "cc"], "server order is preserved");
+    assert_eq!(collected.total, Some(3), "server total is preserved");
+    assert_eq!(collected.pages_fetched, 2);
+    assert_eq!(collected.stop_reason, StopReason::Exhausted);
+
+    let requests = registry.requests();
+    assert!(
+        requests[0].contains("/api/search?"),
+        "cursor mode uses the full-text endpoint: {}",
+        requests[0]
+    );
+    assert!(
+        requests[0].contains("cursor=") && !requests[0].contains("cursor=tok"),
+        "the first page opens a cursor walk with an empty cursor: {}",
+        requests[0]
+    );
+    assert!(
+        requests[1].contains("cursor=tok-2"),
+        "the second page echoes the server's token verbatim: {}",
+        requests[1]
+    );
+    assert!(
+        !requests[1].contains("offset="),
+        "a cursor walk never sends an offset: {}",
+        requests[1]
+    );
+    assert!(
+        requests[1].contains("networks=testnet"),
+        "filters persist across pages"
+    );
+}
+
+#[tokio::test]
+async fn a_rejected_cursor_surfaces_as_a_typed_error() {
+    let registry = FakeRegistry::start(vec![Reply::error(
+        400,
+        r#"{"code":"INVALID_CURSOR","message":"The provided pagination cursor is invalid"}"#,
+    )])
+    .await;
+
+    let mut walk = registry
+        .client()
+        .search_paginator(
+            ContractSearchRequest::cursor("swap")
+                .with_cursor(Some("not-a-real-cursor".to_string())),
+            PageLimits::default().with_page_size(2),
+        )
+        .expect("paginator");
+
+    let err = walk.next_page().await.expect_err("400 must surface");
+
+    assert!(err.is_invalid_cursor(), "unexpected error: {err}");
+    assert_eq!(err.status(), Some(400));
+    assert!(err.to_string().contains("INVALID_CURSOR"));
+    // The malformed token was forwarded untouched — the client never decodes one.
+    assert!(registry.requests()[0].contains("cursor=not-a-real-cursor"));
+}
+
+#[tokio::test]
+async fn a_repeated_cursor_stops_the_walk_with_an_error() {
+    let page = format!(
+        r#"{{"contracts":[{}],"total":9,"next_cursor":"stuck"}}"#,
+        hit("aa")
+    );
+    let registry = FakeRegistry::start(vec![Reply::ok(&page), Reply::ok(&page)]).await;
+
+    let mut walk = registry
+        .client()
+        .search_paginator(
+            ContractSearchRequest::cursor("swap"),
+            PageLimits::default().with_page_size(1),
+        )
+        .expect("paginator");
+
+    assert!(walk.next_page().await.expect("first page").is_some());
+    let err = walk
+        .next_page()
+        .await
+        .expect_err("a repeated cursor must not loop");
+
+    assert!(
+        err.to_string().contains("repeated a pagination cursor"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn empty_pages_with_a_continuation_token_cannot_loop_forever() {
+    let empty_with_token = r#"{"contracts":[],"total":9,"next_cursor":"tok-a"}"#;
+    let registry = FakeRegistry::start(vec![
+        Reply::ok(r#"{"contracts":[],"total":9,"next_cursor":"tok-a"}"#),
+        Reply::ok(r#"{"contracts":[],"total":9,"next_cursor":"tok-b"}"#),
+        Reply::ok(r#"{"contracts":[],"total":9,"next_cursor":"tok-c"}"#),
+        Reply::ok(empty_with_token),
+    ])
+    .await;
+
+    let mut walk = registry
+        .client()
+        .search_paginator(
+            ContractSearchRequest::cursor("swap"),
+            PageLimits::default()
+                .with_page_size(2)
+                .with_max_empty_pages(3),
+        )
+        .expect("paginator");
+
+    let err = walk
+        .collect_all()
+        .await
+        .expect_err("an endless stream of empty pages must stop");
+
+    assert!(
+        err.to_string().contains("consecutive empty page"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        registry.requests().len(),
+        3,
+        "the walk stops instead of requesting more"
+    );
+}
+
+// ── Offset pagination (Elasticsearch endpoint, `results` + `total`) ────────────
+
+#[tokio::test]
+async fn offset_walk_uses_the_advanced_endpoint_and_stops_at_the_total() {
+    let registry = FakeRegistry::start(vec![
+        Reply::ok(&format!(
+            r#"{{"query":"swap","total":3,"limit":2,"offset":0,"took_ms":4,"backend":"elasticsearch","results":[{},{}],"facets":{{"categories":[],"networks":[],"tags":[]}}}}"#,
+            hit("aa"),
+            hit("bb")
+        )),
+        Reply::ok(&format!(
+            r#"{{"query":"swap","total":3,"limit":2,"offset":2,"took_ms":3,"backend":"elasticsearch","results":[{}],"facets":{{"categories":[],"networks":[],"tags":[]}}}}"#,
+            hit("cc")
+        )),
+    ])
+    .await;
+
+    let mut walk = registry
+        .client()
+        .search_paginator(
+            ContractSearchRequest::offset("swap"),
+            PageLimits::default().with_page_size(2),
+        )
+        .expect("paginator");
+
+    let collected = walk.collect_all().await.expect("walk should succeed");
+
+    let names: Vec<String> = collected.items.iter().map(|hit| hit.name.clone()).collect();
+    assert_eq!(names, vec!["aa", "bb", "cc"]);
+    assert_eq!(collected.total, Some(3));
+    assert_eq!(collected.stop_reason, StopReason::Exhausted);
+
+    let requests = registry.requests();
+    assert_eq!(
+        requests.len(),
+        2,
+        "the total ends the walk without a probe page"
+    );
+    assert!(
+        requests[0].contains("/api/v1/contracts/search?"),
+        "offset mode uses the advanced endpoint: {}",
+        requests[0]
+    );
+    assert!(requests[0].contains("offset=0"), "{}", requests[0]);
+    assert!(requests[1].contains("offset=2"), "{}", requests[1]);
+    assert!(
+        !requests[0].contains("cursor="),
+        "an offset walk never sends a cursor: {}",
+        requests[0]
+    );
+}
+
+#[tokio::test]
+async fn offset_walk_can_resume_from_a_given_offset() {
+    let registry = FakeRegistry::start(vec![Reply::ok(&format!(
+        r#"{{"query":"swap","total":41,"limit":2,"offset":40,"results":[{}]}}"#,
+        hit("aa")
+    ))])
+    .await;
+
+    let mut walk = registry
+        .client()
+        .search_paginator(
+            ContractSearchRequest::offset("swap").with_offset(Some(40)),
+            PageLimits::default().with_page_size(2),
+        )
+        .expect("paginator");
+
+    let page = walk
+        .next_page()
+        .await
+        .expect("page fetch")
+        .expect("a page of results");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.total, Some(41));
+    assert!(page.next.is_none(), "offset 40 + 1 item reaches total 41");
+    assert!(registry.requests()[0].contains("offset=40"));
+}
+
+// ── Cross-cutting behaviour ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_retried_page_is_emitted_exactly_once() {
+    let registry = FakeRegistry::start(vec![
+        Reply::error(
+            503,
+            r#"{"code":"SERVICE_UNAVAILABLE","message":"try again"}"#,
+        ),
+        Reply::ok(&format!(
+            r#"{{"contracts":[{},{}],"total":2,"took_ms":2}}"#,
+            hit("aa"),
+            hit("bb")
+        )),
+    ])
+    .await;
+
+    let mut walk = registry
+        .client()
+        .search_paginator(
+            ContractSearchRequest::cursor("swap"),
+            PageLimits::default().with_page_size(2),
+        )
+        .expect("paginator");
+
+    let collected = walk.collect_all().await.expect("the retry should succeed");
+
+    let names: Vec<String> = collected.items.iter().map(|hit| hit.name.clone()).collect();
+    assert_eq!(
+        names,
+        vec!["aa", "bb"],
+        "the retry does not duplicate items"
+    );
+    assert_eq!(
+        collected.pages_fetched, 1,
+        "a retried fetch is still one page"
+    );
+    assert_eq!(
+        registry.requests().len(),
+        2,
+        "the transient failure was retried"
+    );
+}
+
+#[tokio::test]
+async fn max_items_bounds_a_full_walk_and_reports_where_it_stopped() {
+    let page = format!(
+        r#"{{"contracts":[{},{}],"total":1000,"next_cursor":"tok-next"}}"#,
+        hit("aa"),
+        hit("bb")
+    );
+    let registry = FakeRegistry::start(vec![
+        Reply::ok(&page),
+        Reply::ok(&page.replace("tok-next", "tok-later")),
+        Reply::ok(&page.replace("tok-next", "tok-latest")),
+    ])
+    .await;
+
+    let mut walk = registry
+        .client()
+        .search_paginator(
+            ContractSearchRequest::cursor("swap"),
+            PageLimits::default()
+                .with_page_size(2)
+                .with_max_items(Some(4)),
+        )
+        .expect("paginator");
+
+    let collected = walk.collect_all().await.expect("walk should succeed");
+
+    assert_eq!(collected.items.len(), 4);
+    assert_eq!(collected.stop_reason, StopReason::MaxItems);
+    assert!(!collected.is_complete(), "the result set has 1000 matches");
+    assert_eq!(collected.total, Some(1000));
+    assert_eq!(
+        collected.next,
+        Some(PageCursor::Cursor("tok-later".to_string())),
+        "the walk reports where a follow-up should resume"
+    );
+    assert_eq!(registry.requests().len(), 2, "no page beyond the bound");
+}
+
+#[tokio::test]
+async fn cancelling_between_pages_keeps_what_was_already_fetched() {
+    let page = format!(
+        r#"{{"contracts":[{}],"total":100,"next_cursor":"tok-2"}}"#,
+        hit("aa")
+    );
+    let registry = FakeRegistry::start(vec![Reply::ok(&page)]).await;
+
+    let mut walk = registry
+        .client()
+        .search_paginator(
+            ContractSearchRequest::cursor("swap"),
+            PageLimits::default().with_page_size(1),
+        )
+        .expect("paginator");
+    let cancel = walk.cancel_token();
+
+    let first = walk
+        .next_page()
+        .await
+        .expect("page fetch")
+        .expect("a page of results");
+    assert_eq!(first.items.len(), 1);
+
+    cancel.cancel();
+    assert!(walk
+        .next_page()
+        .await
+        .expect("cancellation is graceful")
+        .is_none());
+    assert_eq!(walk.stop_reason(), Some(StopReason::Cancelled));
+    assert_eq!(
+        registry.requests().len(),
+        1,
+        "no request is made after cancellation"
+    );
+}
+
+#[tokio::test]
+async fn a_cursor_walk_cannot_be_combined_with_an_offset() {
+    let registry = FakeRegistry::start(Vec::new()).await;
+
+    let err = registry
+        .client()
+        .search_paginator(
+            ContractSearchRequest::new("swap", PaginationMode::Cursor).with_offset(Some(20)),
+            PageLimits::default(),
+        )
+        .expect_err("mixing the two schemes must be rejected");
+
+    assert!(err.to_string().contains("cannot be combined"), "{err}");
+    assert!(
+        registry.requests().is_empty(),
+        "the request never reaches the server"
+    );
+}

--- a/backend/registry_client/tests/redaction_tests.rs
+++ b/backend/registry_client/tests/redaction_tests.rs
@@ -1,0 +1,172 @@
+// tests/redaction_tests.rs
+//
+// Credentials must never reach a log line or an error message. These tests hunt
+// for the token in everything a consumer might plausibly print: the client, its
+// config, every error variant, and the pagination types.
+
+mod support;
+
+use std::time::Duration;
+
+use registry_client::{
+    Auth, ClientConfig, ContractSearchParams, ContractSearchRequest, PageLimits, PublishRequest,
+    RegistryClient, RetryPolicy, Secret, REDACTED,
+};
+use support::{FakeRegistry, Reply};
+
+const TOKEN: &str = "tok_live_51H8xQzZZZsecretZZZ";
+const API_KEY: &str = "key_live_do_not_log_me";
+
+fn publish_request() -> PublishRequest {
+    PublishRequest {
+        contract_id: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC".to_string(),
+        wasm_hash: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08".to_string(),
+        wasm_artifact_base64: None,
+        name: "swap-router".to_string(),
+        slug: None,
+        description: None,
+        network: registry_client::Network::Testnet,
+        category: None,
+        tags: Vec::new(),
+        source_url: None,
+        publisher_address: "GDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC".to_string(),
+        dependencies: Vec::new(),
+        is_cicd: false,
+    }
+}
+
+fn assert_no_secret(label: &str, rendered: &str) {
+    assert!(
+        !rendered.contains(TOKEN) && !rendered.contains(API_KEY),
+        "{label} leaked a credential: {rendered}"
+    );
+}
+
+#[test]
+fn a_secret_never_prints_itself() {
+    let secret = Secret::new(TOKEN);
+    assert_no_secret("Secret Debug", &format!("{secret:?}"));
+    assert_no_secret("Secret Display", &format!("{secret}"));
+    assert_eq!(format!("{secret:?}"), REDACTED);
+}
+
+#[test]
+fn config_and_client_debug_are_safe_to_log() {
+    let config = ClientConfig::new("http://registry.test").with_auth(Auth::bearer(TOKEN));
+    assert_no_secret("ClientConfig Debug", &format!("{config:?}"));
+
+    let client = RegistryClient::from_config(config).expect("client");
+    assert_no_secret("RegistryClient Debug", &format!("{client:?}"));
+    assert_no_secret("RegistryClient alt Debug", &format!("{client:#?}"));
+
+    let keyed = RegistryClient::new("http://registry.test")
+        .expect("client")
+        .with_auth(Auth::api_key("X-API-Key", API_KEY));
+    assert_no_secret("api-key client Debug", &format!("{keyed:?}"));
+}
+
+#[tokio::test]
+async fn api_errors_do_not_echo_the_credential() {
+    let registry = FakeRegistry::start(vec![
+        Reply::error(401, r#"{"code":"Unauthorized","message":"token expired"}"#),
+        Reply::error(403, r#"{"code":"Forbidden","message":"not yours"}"#),
+        Reply::error(409, r#"{"code":"ContractAlreadyExists"}"#),
+        Reply::error(
+            422,
+            r#"{"code":"ValidationError","details":{"field":"name"}}"#,
+        ),
+        Reply::error(429, r#"{"code":"RateLimited"}"#),
+        Reply::error(500, r#"{"code":"Internal"}"#),
+        Reply::ok("{ not json"),
+    ])
+    .await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url())
+            .with_auth(Auth::bearer(TOKEN))
+            .with_retry_policy(RetryPolicy::none()),
+    )
+    .expect("client");
+
+    for expected in ["401", "403", "409", "422", "429", "500", "malformed"] {
+        let err = client
+            .list_contracts(&ContractSearchParams::default())
+            .await
+            .expect_err("every scripted reply is a failure");
+
+        assert_no_secret(&format!("{expected} Display"), &err.to_string());
+        assert_no_secret(&format!("{expected} Debug"), &format!("{err:?}"));
+    }
+}
+
+#[tokio::test]
+async fn transport_and_timeout_errors_do_not_echo_the_credential() {
+    // Nothing listening on port 1: a connect failure.
+    let unreachable = RegistryClient::from_config(
+        ClientConfig::new("http://127.0.0.1:1")
+            .with_auth(Auth::bearer(TOKEN))
+            .with_retry_policy(RetryPolicy::none()),
+    )
+    .expect("client");
+    let err = unreachable
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("connection refused");
+    assert_no_secret("transport Display", &err.to_string());
+    assert_no_secret("transport Debug", &format!("{err:?}"));
+
+    let registry = FakeRegistry::start(vec![Reply::hang()]).await;
+    let slow = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url())
+            .with_auth(Auth::api_key("X-API-Key", API_KEY))
+            .with_timeout(Duration::from_millis(120))
+            .with_retry_policy(RetryPolicy::none()),
+    )
+    .expect("client");
+    let err = slow
+        .list_contracts(&ContractSearchParams::default())
+        .await
+        .expect_err("timeout");
+    assert_no_secret("timeout Display", &err.to_string());
+    assert_no_secret("timeout Debug", &format!("{err:?}"));
+}
+
+#[tokio::test]
+async fn a_paginator_does_not_carry_the_credential_into_debug_output() {
+    let registry = FakeRegistry::start(Vec::new()).await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url()).with_auth(Auth::bearer(TOKEN)),
+    )
+    .expect("client");
+
+    let walk = client
+        .search_paginator(
+            ContractSearchRequest::cursor("swap"),
+            PageLimits::default().with_page_size(5),
+        )
+        .expect("paginator");
+
+    assert_no_secret("Paginator Debug", &format!("{walk:?}"));
+}
+
+#[tokio::test]
+async fn a_failed_publish_does_not_echo_the_credential() {
+    let registry = FakeRegistry::start(vec![Reply::error(
+        409,
+        r#"{"code":"ContractAlreadyExists","message":"already registered"}"#,
+    )])
+    .await;
+    let client = RegistryClient::from_config(
+        ClientConfig::new(registry.base_url())
+            .with_auth(Auth::bearer(TOKEN))
+            .with_retry_policy(RetryPolicy::none()),
+    )
+    .expect("client");
+
+    let err = client
+        .publish_contract(&publish_request(), Some("release-1".to_string()))
+        .await
+        .expect_err("409");
+
+    assert_no_secret("publish Display", &err.to_string());
+    assert_no_secret("publish Debug", &format!("{err:?}"));
+}

--- a/backend/registry_client/tests/support/mod.rs
+++ b/backend/registry_client/tests/support/mod.rs
@@ -1,0 +1,318 @@
+// tests/support/mod.rs
+//
+// A throwaway HTTP server that answers each request with the next scripted
+// reply and records what it received, plus fixtures for the registry's typed
+// models.
+//
+// It is a few lines of tokio rather than a mocking framework so the test suite
+// stays dependency-free and runs offline.
+
+#![allow(dead_code)]
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use registry_client::{ClientConfig, RegistryClient, RetryPolicy};
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// One canned HTTP reply.
+#[derive(Clone)]
+pub struct Reply {
+    pub status: u16,
+    pub body: String,
+    pub headers: Vec<(String, String)>,
+    /// Read the request and then never answer, so the client times out.
+    pub hang: bool,
+}
+
+impl Reply {
+    pub fn ok(body: &str) -> Self {
+        Self {
+            status: 200,
+            body: body.to_string(),
+            headers: Vec::new(),
+            hang: false,
+        }
+    }
+
+    pub fn error(status: u16, body: &str) -> Self {
+        Self {
+            status,
+            body: body.to_string(),
+            headers: Vec::new(),
+            hang: false,
+        }
+    }
+
+    /// A reply that never arrives.
+    pub fn hang() -> Self {
+        Self {
+            status: 200,
+            body: String::new(),
+            headers: Vec::new(),
+            hang: true,
+        }
+    }
+
+    /// `204 No Content`, as the registry returns for deletes and test sends.
+    pub fn no_content() -> Self {
+        Self {
+            status: 204,
+            body: String::new(),
+            headers: Vec::new(),
+            hang: false,
+        }
+    }
+
+    pub fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.headers.push((name.to_string(), value.to_string()));
+        self
+    }
+}
+
+/// What the server saw.
+#[derive(Clone, Debug)]
+pub struct RecordedRequest {
+    /// e.g. `GET /api/contracts?limit=2 HTTP/1.1`
+    pub line: String,
+    /// The full request head, headers included.
+    pub head: String,
+    pub body: String,
+}
+
+impl RecordedRequest {
+    /// A request header's value, matched case-insensitively.
+    pub fn header(&self, name: &str) -> Option<String> {
+        self.head
+            .lines()
+            .skip(1)
+            .filter_map(|line| line.split_once(':'))
+            .find(|(key, _)| key.trim().eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.trim().to_string())
+    }
+
+    pub fn json(&self) -> Value {
+        serde_json::from_str(&self.body).unwrap_or(Value::Null)
+    }
+
+    /// The path with its query string.
+    pub fn target(&self) -> &str {
+        self.line.split_whitespace().nth(1).unwrap_or_default()
+    }
+
+    pub fn method(&self) -> &str {
+        self.line.split_whitespace().next().unwrap_or_default()
+    }
+}
+
+/// A local stand-in for the registry API.
+pub struct FakeRegistry {
+    base_url: String,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+}
+
+impl FakeRegistry {
+    pub async fn start(replies: Vec<Reply>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind a local port");
+        let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&requests);
+
+        tokio::spawn(async move {
+            let mut replies = replies.into_iter();
+            while let Ok((mut socket, _)) = listener.accept().await {
+                let mut buffer = Vec::new();
+                let mut chunk = [0_u8; 1024];
+
+                // Read the head.
+                let head_end = loop {
+                    match socket.read(&mut chunk).await {
+                        Ok(0) | Err(_) => break None,
+                        Ok(read) => buffer.extend_from_slice(&chunk[..read]),
+                    }
+                    if let Some(index) = find_head_end(&buffer) {
+                        break Some(index);
+                    }
+                };
+                let Some(head_end) = head_end else { continue };
+
+                let head = String::from_utf8_lossy(&buffer[..head_end]).to_string();
+                let content_length = content_length(&head);
+
+                // Read the body, if the client announced one.
+                let mut body = buffer[head_end + 4..].to_vec();
+                while body.len() < content_length {
+                    match socket.read(&mut chunk).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => body.extend_from_slice(&chunk[..read]),
+                    }
+                }
+
+                recorded
+                    .lock()
+                    .expect("record request")
+                    .push(RecordedRequest {
+                        line: head.lines().next().unwrap_or_default().to_string(),
+                        head: head.clone(),
+                        body: String::from_utf8_lossy(&body).to_string(),
+                    });
+
+                let reply = replies
+                    .next()
+                    .unwrap_or_else(|| Reply::error(500, r#"{"code":"NO_REPLY_SCRIPTED"}"#));
+
+                if reply.hang {
+                    // Hold this connection open without answering, on its own
+                    // task so the accept loop can still serve the retry that
+                    // follows the client's timeout.
+                    tokio::spawn(async move {
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                        drop(socket);
+                    });
+                    continue;
+                }
+
+                let mut extra = String::new();
+                for (name, value) in &reply.headers {
+                    extra.push_str(&format!("{name}: {value}\r\n"));
+                }
+                let payload = format!(
+                    "HTTP/1.1 {} {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n{extra}connection: close\r\n\r\n{}",
+                    reply.status,
+                    reason(reply.status),
+                    reply.body.len(),
+                    reply.body
+                );
+                let _ = socket.write_all(payload.as_bytes()).await;
+                let _ = socket.flush().await;
+            }
+        });
+
+        Self { base_url, requests }
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// A client pointed at this server, retries disabled so one call is one
+    /// request.
+    pub fn client(&self) -> RegistryClient {
+        RegistryClient::from_config(
+            ClientConfig::new(&self.base_url).with_retry_policy(RetryPolicy::none()),
+        )
+        .expect("build client")
+    }
+
+    pub fn requests(&self) -> Vec<RecordedRequest> {
+        self.requests.lock().expect("read requests").clone()
+    }
+
+    /// Just the request lines, for tests that only care about method and target.
+    pub fn request_lines(&self) -> Vec<String> {
+        self.requests()
+            .into_iter()
+            .map(|request| request.line)
+            .collect()
+    }
+}
+
+fn find_head_end(buffer: &[u8]) -> Option<usize> {
+    buffer.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn content_length(head: &str) -> usize {
+    head.lines()
+        .skip(1)
+        .filter_map(|line| line.split_once(':'))
+        .find(|(key, _)| key.trim().eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, value)| value.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+fn reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        201 => "Created",
+        204 => "No Content",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        409 => "Conflict",
+        418 => "I'm a teapot",
+        422 => "Unprocessable Entity",
+        429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
+        _ => "Unknown",
+    }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+/// A `shared::models::Contract` as the API serializes it.
+///
+/// Every field the model requires is present, so decoding this fixture also
+/// checks that the client and the backend model still agree.
+pub fn contract_body(index: usize) -> Value {
+    json!({
+        "id": format!("11111111-1111-1111-1111-{:012}", index),
+        "contract_id": format!("CA{:054}", index),
+        "wasm_hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        "name": format!("contract-{index}"),
+        "slug": format!("contract-{index}"),
+        "description": "a contract",
+        "publisher_id": "22222222-2222-2222-2222-222222222222",
+        "network": "testnet",
+        "is_verified": index.is_multiple_of(2),
+        "verification_status": "unverified",
+        "category": "DeFi",
+        "tags": [],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-02T00:00:00Z",
+        "verified_at": null,
+        "deployed_at": null,
+        "verified_by": null,
+        "verification_notes": null,
+        "last_accessed_at": null,
+        "health_score": 80,
+        "is_maintenance": false,
+        "logical_id": null,
+        "network_configs": null,
+        "organization_id": null,
+        "visibility": "public",
+        "usage_count": 3
+    })
+}
+
+/// A `PaginatedResponse<Contract>` body with `count` items out of `total`.
+pub fn contract_list_body(count: usize, total: i64) -> String {
+    contract_list_body_with_cursor(count, total, None)
+}
+
+/// The same, with a keyset continuation token.
+pub fn contract_list_body_with_cursor(
+    count: usize,
+    total: i64,
+    next_cursor: Option<&str>,
+) -> String {
+    let items: Vec<Value> = (0..count).map(contract_body).collect();
+    let mut body = json!({
+        "items": items,
+        "total": total,
+        "page": 1,
+        "per_page": count.max(1),
+        "pages": 1
+    });
+    if let Some(cursor) = next_cursor {
+        body["next_cursor"] = json!(cursor);
+    }
+    body.to_string()
+}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2784,18 +2784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
-name = "registry_client"
-version = "0.1.0"
-dependencies = [
- "futures-util",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,7 +3394,6 @@ dependencies = [
  "keyring",
  "log",
  "rand 0.8.5",
- "registry_client",
  "reqwest",
  "ripemd",
  "rustyline",
@@ -3417,6 +3404,7 @@ dependencies = [
  "sha2",
  "shared",
  "shlex",
+ "soroban-registry-client",
  "stellar-strkey 0.0.16",
  "stellar-xdr",
  "sysinfo 0.28.4",
@@ -3426,6 +3414,21 @@ dependencies = [
  "toml",
  "uuid",
  "wiremock",
+]
+
+[[package]]
+name = "soroban-registry-client"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "shared",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2784,6 +2784,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "registry_client"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3394,6 +3406,7 @@ dependencies = [
  "keyring",
  "log",
  "rand 0.8.5",
+ "registry_client",
  "reqwest",
  "ripemd",
  "rustyline",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 shared = { path = "../backend/shared" }
 contract_abi = { path = "../backend/contract_abi" }
+registry_client = { path = "../backend/registry_client" }
 clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
 tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 shared = { path = "../backend/shared" }
 contract_abi = { path = "../backend/contract_abi" }
-registry_client = { path = "../backend/registry_client" }
+soroban-registry-client = { path = "../backend/registry_client" }
 clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
 tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }

--- a/cli/src/cached_http.rs
+++ b/cli/src/cached_http.rs
@@ -32,6 +32,12 @@ fn options() -> HttpCacheOptions {
     CACHE_OPTS.get().copied().unwrap_or_default()
 }
 
+/// The per-invocation cache settings, for callers that do their own fetching —
+/// e.g. the shared registry client's cache hook in [`crate::registry`].
+pub fn cache_options() -> HttpCacheOptions {
+    options()
+}
+
 /// Perform a GET request, returning cached body when available.
 pub async fn cached_get(url: &str, query: &[(&str, String)]) -> Result<(StatusCode, String)> {
     let opts = options();

--- a/cli/src/cached_http.rs
+++ b/cli/src/cached_http.rs
@@ -48,7 +48,7 @@ pub async fn cached_get(url: &str, query: &[(&str, String)]) -> Result<(StatusCo
             if opts.verbose >= 1 {
                 eprintln!(
                     "{} cache hit (expires in {}s): {}",
-                    "◀".cyan(),
+                    "<".cyan(),
                     entry.expires_in().unwrap_or(0),
                     truncate_key(&cache_key)
                 );
@@ -82,7 +82,7 @@ pub async fn cached_get(url: &str, query: &[(&str, String)]) -> Result<(StatusCo
         if opts.verbose >= 1 {
             eprintln!(
                 "{} cached response: {}",
-                "▶".cyan(),
+                ">".cyan(),
                 truncate_key(&cache_key)
             );
         }

--- a/cli/src/cached_http.rs
+++ b/cli/src/cached_http.rs
@@ -48,7 +48,7 @@ pub async fn cached_get(url: &str, query: &[(&str, String)]) -> Result<(StatusCo
             if opts.verbose >= 1 {
                 eprintln!(
                     "{} cache hit (expires in {}s): {}",
-                    "<".cyan(),
+                    "[CACHE]".cyan(),
                     entry.expires_in().unwrap_or(0),
                     truncate_key(&cache_key)
                 );
@@ -61,7 +61,7 @@ pub async fn cached_get(url: &str, query: &[(&str, String)]) -> Result<(StatusCo
     } else if opts.verbose >= 1 {
         eprintln!(
             "{} cache bypassed: {}",
-            "↷".yellow(),
+            "[CACHE]".yellow(),
             truncate_key(&cache_key)
         );
     }
@@ -82,7 +82,7 @@ pub async fn cached_get(url: &str, query: &[(&str, String)]) -> Result<(StatusCo
         if opts.verbose >= 1 {
             eprintln!(
                 "{} cached response: {}",
-                ">".cyan(),
+                "[CACHE]".cyan(),
                 truncate_key(&cache_key)
             );
         }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2,6 +2,7 @@
 
 use crate::net::RequestBuilderExt;
 use crate::output_format;
+use registry_client::ContractSearchParams;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -172,12 +173,6 @@ pub async fn search(
 ) -> Result<()> {
     let t0 = std::time::Instant::now();
 
-    let mut params: Vec<(&str, String)> = vec![
-        ("query", query.to_string()),
-        ("limit", limit.to_string()),
-        ("offset", offset.to_string()),
-    ];
-
     // Normalize before sending so comma-separated and repeated flags produce an
     // identical request, and unknown networks fail here rather than being
     // silently dropped server-side.
@@ -185,58 +180,41 @@ pub async fn search(
     let categories =
         normalize_filter_values(&category.map(str::to_string).into_iter().collect::<Vec<_>>());
 
+    let mut params = ContractSearchParams {
+        query: Some(query.to_string()),
+        limit: Some(limit as i64),
+        offset: Some(offset as i64),
+        ..Default::default()
+    };
     if !networks.is_empty() {
-        params.push(("networks", networks.join(",")));
+        params.networks = Some(shared_networks(&networks)?);
     } else {
-        params.push(("network", network.to_string()));
+        params.network = shared_network(&network.to_string());
     }
-
     if verified_only {
-        params.push(("verified_only", "true".to_string()));
+        params.verified_only = Some(true);
     }
-
     if !categories.is_empty() {
-        params.push(("categories", categories.join(",")));
+        params.categories = Some(categories.clone());
+    }
+    if let Some(sort) = sort {
+        params.sort_by = parse_sort_by(sort);
     }
 
-    if let Some(s) = sort {
-        params.push(("sort", s.to_string()));
-    }
-
-    let url = format!("{}/api/contracts", api_url);
-    // Named `query_pairs`, not `query`: it previously shadowed the `query: &str`
-    // parameter, which the result-rendering code below still needs.
-    let query_pairs: Vec<(&str, String)> = params.iter().map(|(k, v)| (*k, v.clone())).collect();
-    let (status, body) = crate::cached_http::cached_get(&url, &query_pairs)
+    let mut page = crate::registry::client(api_url)
+        .await?
+        .list_contracts(&params)
         .await
         .context("Failed to search contracts")?;
 
-    if !status.is_success() {
-        anyhow::bail!("Search request failed with status {status}");
+    if sort.is_some_and(|value| value.trim().eq_ignore_ascii_case("name")) {
+        page.items.sort_by(|a, b| a.name.cmp(&b.name));
     }
 
-    let data: serde_json::Value = serde_json::from_str(&body).context("Invalid search response")?;
-    let items = data["items"].as_array().context("Invalid response")?;
+    let items = &page.items;
 
     if json {
-        let contracts: Vec<serde_json::Value> = items
-            .iter()
-            .map(|c| {
-                serde_json::json!({
-                    "id": c.get("id").and_then(|v| v.as_str()).unwrap_or(""),
-                    "name": c.get("name").and_then(|v| v.as_str()).unwrap_or(""),
-                    "contract_id": c.get("contract_id").and_then(|v| v.as_str()).unwrap_or(""),
-                    "network": c.get("network").and_then(|v| v.as_str()).unwrap_or(""),
-                    "category": c.get("category").and_then(|v| v.as_str()).unwrap_or(""),
-                    "is_verified": c.get("is_verified").and_then(|v| v.as_bool()).unwrap_or(false),
-                    "health_score": c.get("health_score").and_then(|v| v.as_i64()).unwrap_or(0),
-                    "created_at": c.get("created_at").and_then(|v| v.as_str()).unwrap_or(""),
-                    "tags": c.get("tags").and_then(|v| v.as_array()).map(|arr| {
-                        arr.iter().filter_map(|t| t.as_str().map(|s| s.to_string())).collect::<Vec<_>>()
-                    }).unwrap_or_default(),
-                })
-            })
-            .collect();
+        let contracts: Vec<serde_json::Value> = items.iter().map(contract_json).collect();
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -288,22 +266,20 @@ pub async fn search(
     // Compute visible column widths from raw data (before applying ANSI codes).
     let name_w = items
         .iter()
-        .filter_map(|c| c["name"].as_str())
-        .map(|s| s.chars().count())
+        .map(|contract| contract.name.chars().count())
         .max()
         .unwrap_or(0)
         .max("Name".len());
     let net_w = items
         .iter()
-        .filter_map(|c| c["network"].as_str())
-        .map(|s| s.chars().count())
+        .map(|contract| contract.network.to_string().chars().count())
         .max()
         .unwrap_or(0)
         .max("Network".len());
     let cat_w = items
         .iter()
-        .filter_map(|c| c["category"].as_str().filter(|s| !s.is_empty()))
-        .map(|s| s.chars().count())
+        .filter_map(|contract| contract.category.as_deref().filter(|value| !value.is_empty()))
+        .map(|value| value.chars().count())
         .max()
         .unwrap_or(0)
         .max("Category".len());
@@ -312,8 +288,7 @@ pub async fn search(
     let link_prefix = format!("{}/contracts/", api_url);
     let link_w = items
         .iter()
-        .filter_map(|c| c["contract_id"].as_str())
-        .map(|id| link_prefix.len() + id.len())
+        .map(|contract| link_prefix.len() + contract.contract_id.len())
         .max()
         .unwrap_or(0)
         .max("Links".len())
@@ -321,51 +296,79 @@ pub async fn search(
 
     let mut rows: Vec<Vec<String>> = Vec::new();
     for contract in items {
-        let name = crate::conversions::as_str(&contract["name"], "name")?;
-        let contract_id = crate::conversions::as_str(&contract["contract_id"], "contract_id")?;
-        let is_verified = crate::conversions::as_bool(&contract["is_verified"], "is_verified")?;
-        let net = crate::conversions::as_str(&contract["network"], "network")?;
-        let cat = contract["category"].as_str().unwrap_or("").to_string();
-        let link = format!("{}/contracts/{}", api_url, contract_id);
-
-        let name_cell = crate::table_format::highlight_match(&name, query);
-        let net_cell = net.bright_blue().to_string();
-        let cat_display = if cat.is_empty() {
-            "—".to_string()
-        } else {
-            cat
-        };
-        let cat_cell = crate::table_format::highlight_match(&cat_display, query);
-        let ver_cell = if is_verified {
+        let link = format!("{}/contracts/{}", api_url, contract.contract_id);
+        let verified = if contract.is_verified {
             "✓ Verified".green().to_string()
         } else {
             "○ Unverified".yellow().to_string()
         };
-        let link_cell = link.bright_black().to_string();
 
-        rows.push(vec![name_cell, net_cell, cat_cell, ver_cell, link_cell]);
+        rows.push(vec![
+            // Highlight where the query matched, as the pre-client renderer did.
+            crate::table_format::highlight_match(&contract.name, query),
+            contract.network.to_string(),
+            crate::table_format::highlight_match(
+                contract.category.as_deref().unwrap_or_default(),
+                query,
+            ),
+            verified,
+            link,
+        ]);
     }
 
-    let col_widths = [name_w, net_w, cat_w, ver_w, link_w];
-    let headers = ["Name", "Network", "Category", "Verified", "Links"];
-    print!(
-        "{}",
-        crate::table_format::render_table(&headers, &col_widths, &rows)
+    println!(
+        "{:<name_w$}  {:<net_w$}  {:<cat_w$}  {:<ver_w$}  {:<link_w$}",
+        "Name".bold(),
+        "Network".bold(),
+        "Category".bold(),
+        "Verified".bold(),
+        "Links".bold(),
     );
 
-    let elapsed_ms = t0.elapsed().as_millis();
+    for (row, contract) in rows.iter().zip(items) {
+        // Highlighted cells carry ANSI codes, so pad them by visible width
+        // rather than by byte length.
+        let name_pad = " ".repeat(name_w.saturating_sub(contract.name.chars().count()));
+        let category = contract.category.as_deref().unwrap_or_default();
+        let cat_pad = " ".repeat(cat_w.saturating_sub(category.chars().count()));
+        let verified_visible = if contract.is_verified {
+            "✓ Verified".chars().count()
+        } else {
+            "○ Unverified".chars().count()
+        };
+        let verified_pad = " ".repeat(ver_w.saturating_sub(verified_visible));
+
+        println!(
+            "{}{}  {:<net_w$}  {}{}  {}{}  {:<link_w$}",
+            row[0], name_pad, row[1], row[2], cat_pad, row[3], verified_pad, row[4],
+        );
+    }
+
     println!(
-        "\n{} {} result(s) for \"{}\"  |  {}ms\n",
-        "→".cyan(),
+        "\n{} {} result(s) of {} in {:.0}ms",
+        "Found".green().bold(),
         items.len(),
-        query.bold(),
-        elapsed_ms
+        page.total,
+        t0.elapsed().as_millis()
     );
+    println!();
 
     Ok(())
 }
 
-/// Analyze two contract versions or schema files for breaking changes.
+/// Map the CLI's `--sort` values onto the API's `sort_by`.
+///
+/// `name` has no server-side equivalent, so it is applied locally to the page
+/// that comes back rather than being sent and silently ignored.
+fn parse_sort_by(value: &str) -> Option<shared::models::SortBy> {
+    match value.trim().to_lowercase().as_str() {
+        "created" | "created_at" => Some(shared::models::SortBy::CreatedAt),
+        "updated" | "updated_at" => Some(shared::models::SortBy::UpdatedAt),
+        "relevance" => Some(shared::models::SortBy::Relevance),
+        _ => None,
+    }
+}
+
 pub async fn upgrade_analyze(
     api_url: &str,
     old_id: &str,
@@ -559,58 +562,66 @@ pub async fn publish(
         .await?;
     }
 
-    let client = crate::net::client();
-    let url = format!("{}/api/contracts", api_url);
+    let network = shared_network(&network.to_string()).ok_or_else(|| {
+        anyhow::anyhow!("Invalid network: {network}. Allowed values: mainnet, testnet, futurenet")
+    })?;
 
-    let mut payload = json!({
-        "contract_id": contract_id,
-        "name": name,
-        "description": description,
-        "network": network.to_string(),
-        "category": category,
-        "tags": tags,
-        "publisher_address": publisher,
-    });
-
-    if is_cicd {
-        payload["is_cicd"] = json!(true);
-    }
+    // `wasm_hash` is required by the API; the deploy and register flows compute
+    // it from the artifact. `publish` registers an already-deployed contract
+    // from metadata alone, so it sends the field empty as it always has.
+    let request = registry_client::PublishRequest {
+        contract_id: contract_id.to_string(),
+        wasm_hash: String::new(),
+        wasm_artifact_base64: None,
+        name: name.to_string(),
+        slug: None,
+        description: description.map(str::to_string),
+        network,
+        category: category.map(str::to_string),
+        tags,
+        source_url: None,
+        publisher_address: publisher.to_string(),
+        dependencies: Vec::new(),
+        is_cicd,
+    };
 
     println!("\n{}", "Publishing contract...".bold().cyan());
 
-    let response = client
-        .post(&url)
-        .json(&payload)
-        .send_with_retry()
+    // Publishing is not idempotent by itself, so the CLI supplies a key derived
+    // from the contract identity: a retried publish (or a re-run after a lost
+    // response) replays the original result instead of conflicting.
+    let idempotency_key = publish_idempotency_key(&request);
+    let contract = crate::registry::uncached_client(api_url)
+        .await?
+        .publish_contract(&request, Some(idempotency_key))
         .await
-        .context("Failed to publish contract")?;
-
-    if !response.status().is_success() {
-        let error_text = response.text().await?;
-        anyhow::bail!("Failed to publish: {}", error_text);
-    }
-
-    let contract: serde_json::Value = response.json().await?;
+        .map_err(|err| anyhow::anyhow!("Failed to publish: {err}"))?;
 
     println!("{}", "✓ Contract published successfully!".green().bold());
-    println!(
-        "\n{}: {}",
-        "Name".bold(),
-        crate::conversions::as_str(&contract["name"], "name")?
-    );
-    println!(
-        "{}: {}",
-        "ID".bold(),
-        crate::conversions::as_str(&contract["contract_id"], "contract_id")?
-    );
+    println!("\n{}: {}", "Name".bold(), contract.name);
+    println!("{}: {}", "ID".bold(), contract.contract_id);
     println!(
         "{}: {}",
         "Network".bold(),
-        crate::conversions::as_str(&contract["network"], "network")?.bright_blue()
+        contract.network.to_string().bright_blue()
     );
     println!();
 
     Ok(())
+}
+
+/// A key that is stable for the same contract identity on the same network, so
+/// re-running `publish` after a dropped response does not register twice.
+fn publish_idempotency_key(request: &registry_client::PublishRequest) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(
+        format!(
+            "{}:{}:{}",
+            request.contract_id, request.network, request.publisher_address
+        )
+        .as_bytes(),
+    );
+    format!("cli-publish-{}", hex::encode(&digest[..16]))
 }
 
 fn detect_test_command(contract_dir: &Path) -> Option<String> {
@@ -1045,60 +1056,36 @@ pub async fn contract_list(
     category: Option<String>,
     format: &str,
 ) -> Result<()> {
-    let mut query: Vec<(&str, String)> = vec![
-        ("limit", limit.to_string()),
-        ("offset", offset.to_string()),
-    ];
-
     // Normalize before sending so comma-separated `--networks`/`--category` and
     // the singular `--network` flag produce the same request shape as `search`,
     // and unknown networks fail here rather than being silently dropped server-side.
     let networks = normalize_network_filters(&networks)?;
     let categories = normalize_filter_values(&category.into_iter().collect::<Vec<_>>());
 
+    let mut params = ContractSearchParams {
+        limit: Some(limit as i64),
+        offset: Some(offset as i64),
+        ..Default::default()
+    };
     if !networks.is_empty() {
-        query.push(("networks", networks.join(",")));
+        params.networks = Some(shared_networks(&networks)?);
     } else if let Some(net) = network {
-        query.push(("network", net.to_string()));
+        params.network = shared_network(&net.to_string());
     }
-
     if !categories.is_empty() {
-        query.push(("categories", categories.join(",")));
+        params.categories = Some(categories.clone());
     }
 
-    let url = format!("{}/api/contracts", api_url.trim_end_matches('/'));
-    let (status, body) = crate::cached_http::cached_get(&url, &query)
+    let page = crate::registry::client(api_url)
+        .await?
+        .list_contracts(&params)
         .await
         .context("Failed to list contracts")?;
 
-    if !status.is_success() {
-        anyhow::bail!("API returned error: {status}");
-    }
-
-    let data: serde_json::Value = serde_json::from_str(&body).context("Invalid list response")?;
-    let items = data["items"]
-        .as_array()
-        .context("Invalid response format")?;
+    let items = &page.items;
 
     if format == "json" {
-        let contracts: Vec<serde_json::Value> = items
-            .iter()
-            .map(|c| {
-                serde_json::json!({
-                    "id": c.get("id").and_then(|v| v.as_str()).unwrap_or(""),
-                    "name": c.get("name").and_then(|v| v.as_str()).unwrap_or(""),
-                    "contract_id": c.get("contract_id").and_then(|v| v.as_str()).unwrap_or(""),
-                    "network": c.get("network").and_then(|v| v.as_str()).unwrap_or(""),
-                    "category": c.get("category").and_then(|v| v.as_str()).unwrap_or(""),
-                    "is_verified": c.get("is_verified").and_then(|v| v.as_bool()).unwrap_or(false),
-                    "health_score": c.get("health_score").and_then(|v| v.as_i64()).unwrap_or(0),
-                    "created_at": c.get("created_at").and_then(|v| v.as_str()).unwrap_or(""),
-                    "tags": c.get("tags").and_then(|v| v.as_array()).map(|arr| {
-                        arr.iter().filter_map(|t| t.as_str().map(|s| s.to_string())).collect::<Vec<_>>()
-                    }).unwrap_or_default(),
-                })
-            })
-            .collect();
+        let contracts: Vec<serde_json::Value> = items.iter().map(contract_json).collect();
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -1114,11 +1101,11 @@ pub async fn contract_list(
         for item in items {
             println!(
                 "{},{},{},{},{}",
-                item["contract_id"].as_str().unwrap_or(""),
-                item["name"].as_str().unwrap_or(""),
-                item["network"].as_str().unwrap_or(""),
-                item["is_verified"].as_bool().unwrap_or(false),
-                item["category"].as_str().unwrap_or("")
+                item.contract_id,
+                item.name,
+                item.network,
+                item.is_verified,
+                item.category.as_deref().unwrap_or("")
             );
         }
         return Ok(());
@@ -1143,10 +1130,7 @@ pub async fn contract_list(
     println!("{}", "-".repeat(100));
 
     for item in items {
-        let contract_id = item["contract_id"].as_str().unwrap_or("");
-        let name = item["name"].as_str().unwrap_or("");
-        let net = item["network"].as_str().unwrap_or("");
-        let verified = if item["is_verified"].as_bool().unwrap_or(false) {
+        let verified = if item.is_verified {
             "Yes".green()
         } else {
             "No".red()
@@ -1154,24 +1138,63 @@ pub async fn contract_list(
 
         println!(
             "{:<45} {:<25} {:<10} {:<10}",
-            contract_id,
-            name.truncate_str(23),
-            net,
+            item.contract_id,
+            item.name.truncate_str(23),
+            item.network.to_string(),
             verified
         );
     }
 
-    let total = data["total"].as_u64().unwrap_or(0);
     println!("{}", "-".repeat(100));
     println!(
         "Showing {}-{} of {} contracts",
         offset + 1,
         offset + items.len(),
-        total
+        page.total
     );
     println!();
 
     Ok(())
+}
+
+/// The JSON projection both `list` and `search` emit for a contract.
+fn contract_json(contract: &registry_client::Contract) -> serde_json::Value {
+    let tags: Vec<&str> = contract.tags.iter().map(|tag| tag.name.as_str()).collect();
+    serde_json::json!({
+        "id": contract.id.to_string(),
+        "name": contract.name,
+        "contract_id": contract.contract_id,
+        "network": contract.network.to_string(),
+        "category": contract.category.as_deref().unwrap_or(""),
+        "is_verified": contract.is_verified,
+        "health_score": contract.health_score,
+        "created_at": contract.created_at.to_rfc3339(),
+        "tags": tags,
+    })
+}
+
+/// Canonical network name to the registry's `Network`. Unknown values are
+/// rejected by `normalize_network_filters` before reaching here.
+fn shared_network(value: &str) -> Option<registry_client::Network> {
+    match value.trim().to_lowercase().as_str() {
+        "mainnet" => Some(registry_client::Network::Mainnet),
+        "testnet" => Some(registry_client::Network::Testnet),
+        "futurenet" => Some(registry_client::Network::Futurenet),
+        _ => None,
+    }
+}
+
+fn shared_networks(values: &[String]) -> Result<Vec<registry_client::Network>> {
+    values
+        .iter()
+        .map(|value| {
+            shared_network(value).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Invalid network: {value}. Allowed values: mainnet, testnet, futurenet"
+                )
+            })
+        })
+        .collect()
 }
 
 pub async fn contract_info(api_url: &str, id: &str) -> Result<()> {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -75,13 +75,13 @@ pub fn profile(
             .context("Failed to serialize profile data")?;
         fs::write(output_path, profile_json)
             .with_context(|| format!("Failed to write profile output: {}", output_path))?;
-        println!("{} Profile output written to {}", "✓".green(), output_path);
+        println!("{} Profile output written to {}", "[OK]".green(), output_path);
     }
 
     if let Some(flamegraph_path) = flamegraph {
         generate_flame_graph_file(&profile_data, flamegraph_path)
             .with_context(|| format!("Failed to generate flame graph at {}", flamegraph_path))?;
-        println!("{} Flame graph written to {}", "✓".green(), flamegraph_path);
+        println!("{} Flame graph written to {}", "[OK]".green(), flamegraph_path);
     }
 
     if let Some(baseline_path) = compare {
@@ -602,7 +602,7 @@ pub async fn publish(
         .await
         .map_err(|err| anyhow::anyhow!("Failed to publish: {err}"))?;
 
-    println!("{}", "✓ Contract published successfully!".green().bold());
+    println!("{}", "[OK] Contract published successfully!".green().bold());
     println!("\n{}: {}", "Name".bold(), contract.name);
     println!("{}: {}", "ID".bold(), contract.contract_id);
     println!(
@@ -808,7 +808,7 @@ pub async fn run_test_suite(options: TestSuiteOptions<'_>) -> Result<()> {
             .unwrap_or(0);
         println!(
             "{} Loaded mock config {} ({} service definitions)",
-            "✓".green(),
+            "[OK]".green(),
             mock_config,
             service_count
         );
@@ -864,7 +864,7 @@ pub async fn run_test_suite(options: TestSuiteOptions<'_>) -> Result<()> {
         });
         fs::write(report_output, serde_json::to_string_pretty(&report)?)
             .with_context(|| format!("Failed to write test report: {}", report_output))?;
-        println!("{} Test report written to {}", "✓".green(), report_output);
+        println!("{} Test report written to {}", "[OK]".green(), report_output);
     }
 
     if let Some(profile_output) = options.profile_output {
@@ -876,7 +876,7 @@ pub async fn run_test_suite(options: TestSuiteOptions<'_>) -> Result<()> {
         });
         fs::write(profile_output, serde_json::to_string_pretty(&profile)?)
             .with_context(|| format!("Failed to write test profile: {}", profile_output))?;
-        println!("{} Test profile written to {}", "✓".green(), profile_output);
+        println!("{} Test profile written to {}", "[OK]".green(), profile_output);
     }
 
     let teardown_result = if let Some(teardown_hook) = options.teardown_hook {
@@ -938,9 +938,9 @@ pub async fn run_contract_tests(
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     if output.status.success() {
-        println!("{} Tests passed in {:.2}s", "✓".green(), duration);
+        println!("{} Tests passed in {:.2}s", "[OK]".green(), duration);
     } else {
-        println!("{} Tests failed in {:.2}s", "✗".red(), duration);
+        println!("{} Tests failed in {:.2}s", "[ERR]".red(), duration);
 
         if !stdout.trim().is_empty() {
             println!("\n{}\n{}", "Test output:".bold(), stdout);
@@ -981,14 +981,14 @@ pub async fn run_contract_tests(
                 } else {
                     println!(
                         "  {} Threshold met ({:.2}% >= {:.2}%)",
-                        "✓".green(),
+                        "[OK]".green(),
                         percent,
                         coverage_threshold
                     );
                 }
             }
         } else {
-            println!("  {} Coverage metrics unavailable.", "⚠".yellow());
+            println!("  {} Coverage metrics unavailable.", "[WARN]".yellow());
             if require_coverage {
                 anyhow::bail!(
                     "Coverage is required but could not be collected. Install cargo-tarpaulin or provide coverage-enabled test tooling."
@@ -1408,7 +1408,7 @@ pub async fn migrate(
         );
         println!(
             "{}",
-            "✓ Migration simulation complete (dry-run).".green().bold()
+            "[OK] Migration simulation complete (dry-run).".green().bold()
         );
         return Ok(());
     }
@@ -1537,7 +1537,7 @@ pub async fn export(
     })
     .await?;
 
-    println!("{}", "✓ Export complete!".green().bold());
+    println!("{}", "[OK] Export complete!".green().bold());
     println!(
         "  {}: {}",
         "Format".bold(),
@@ -1617,7 +1617,7 @@ pub async fn import(
 
     println!(
         "{}",
-        "✓ Import complete — integrity verified!".green().bold()
+        "[OK] Import complete — integrity verified!".green().bold()
     );
     println!(
         "  {}: {}",
@@ -1672,7 +1672,7 @@ pub async fn patch_create(
 
     let patch = PatchManager::create(api_url, version, hash, severity, rollout).await?;
 
-    println!("{}", "✓ Patch created!".green().bold());
+    println!("{}", "[OK] Patch created!".green().bold());
     println!("  {}: {}", "ID".bold(), patch.id);
     println!("  {}: {}", "Target Version".bold(), patch.target_version);
     println!(
@@ -1690,7 +1690,7 @@ pub async fn patch_create(
     if matches!(patch.severity, Severity::Critical | Severity::High) {
         println!(
             "  {} {}",
-            "⚠".red(),
+            "[WARN]".red(),
             format!(
                 "{} severity — immediate action recommended",
                 severity_colored(&patch.severity)
@@ -1742,7 +1742,7 @@ pub async fn trust_score(api_url: &str, contract_id: &str, network: Network) -> 
     println!("{}", "─".repeat(56));
 
     // ── Factor breakdown ──────────────────────────────────────────────────────
-    println!("\n  {} Factor Breakdown\n", "📊".bold());
+    println!("\n  {}\n", "Factor Breakdown".bold());
 
     if let Some(factors) = data["factors"].as_array() {
         for factor in factors {
@@ -1762,7 +1762,7 @@ pub async fn trust_score(api_url: &str, contract_id: &str, network: Network) -> 
     }
 
     // ── Weight documentation ──────────────────────────────────────────────────
-    println!("\n  {} Score Weights\n", "⚖️".bold());
+    println!("\n  {}\n", "Score Weights".bold());
     if let Ok(weights) = crate::conversions::as_object(&data["weights"], "weights") {
         for (k, v) in weights {
             let max_pts = crate::conversions::as_f64(v, "weight_value")?;
@@ -1783,7 +1783,7 @@ pub async fn patch_notify(api_url: &str, patch_id: &str) -> Result<()> {
 
     println!(
         "\n{} {} patch for version {}",
-        "⚠".bold(),
+        "[WARN]".bold(),
         severity_colored(&patch.severity),
         patch.target_version.bold()
     );
@@ -1818,7 +1818,7 @@ pub async fn patch_apply(api_url: &str, contract_id: &str, patch_id: &str) -> Re
 
     let audit = PatchManager::apply(api_url, contract_id, patch_id).await?;
 
-    println!("{}", "✓ Patch applied successfully!".green().bold());
+    println!("{}", "[OK] Patch applied successfully!".green().bold());
     println!("  {}: {}", "Contract".bold(), audit.contract_id);
     println!("  {}: {}", "Patch".bold(), audit.patch_id);
     println!("  {}: {}\n", "Applied At".bold(), audit.applied_at);
@@ -1941,7 +1941,7 @@ pub async fn run_tests(
     println!("\n{}", "Test Results:".bold().green());
     println!("{}", "=".repeat(80).cyan());
 
-    let status_icon = if result.passed { "✓" } else { "✗" };
+    let status_icon = if result.passed { "[OK]" } else { "[ERR]" };
 
     println!(
         "\n{} {} {} ({:.2}ms)",
@@ -1959,7 +1959,7 @@ pub async fn run_tests(
 
     println!("\n{}", "Step Results:".bold());
     for (i, step) in result.steps.iter().enumerate() {
-        let step_icon = if step.passed { "✓" } else { "✗" };
+        let step_icon = if step.passed { "[OK]" } else { "[ERR]" };
 
         println!(
             "  {}. {} {} ({:.2}ms)",
@@ -1992,7 +1992,7 @@ pub async fn run_tests(
         println!("  Coverage: {:.2}%", result.coverage.coverage_percent);
 
         if result.coverage.coverage_percent < 80.0 {
-            println!("  {} Low coverage detected!", "⚠".yellow());
+            println!("  {} Low coverage detected!", "[WARN]".yellow());
         }
     }
 
@@ -2001,7 +2001,7 @@ pub async fn run_tests(
         test_framework::generate_junit_xml(&[result.clone()], Path::new(junit_path))?;
         println!(
             "\n{} JUnit XML report exported to: {}",
-            "✓".green(),
+            "[OK]".green(),
             junit_path
         );
     }
@@ -2009,7 +2009,7 @@ pub async fn run_tests(
     if total_time.as_secs() > 5 {
         println!(
             "\n{} Test execution took {:.2}s (target: <5s)",
-            "⚠".yellow(),
+            "[WARN]".yellow(),
             total_time.as_secs_f64()
         );
     }
@@ -2263,7 +2263,7 @@ pub fn incident_trigger(contract_id: &str, severity_str: &str) -> Result<()> {
     if mgr.is_halted(contract_id) {
         println!(
             "\n  {} {}",
-            "⚡ CIRCUIT BREAKER ENGAGED —".red().bold(),
+            "CIRCUIT BREAKER ENGAGED —".red().bold(),
             format!("contract {} is now halted", contract_id).red()
         );
     }
@@ -2373,7 +2373,7 @@ pub async fn config_set(
 
     println!(
         "{}",
-        "✓ Configuration published successfully!".green().bold()
+        "[OK] Configuration published successfully!".green().bold()
     );
     println!("  {}: {}", "Environment".bold(), environment);
     println!(
@@ -2473,7 +2473,7 @@ pub async fn config_rollback(
 
     println!(
         "{}",
-        "✓ Configuration rolled back successfully!".green().bold()
+        "[OK] Configuration rolled back successfully!".green().bold()
     );
     println!("  {}: {}", "Environment".bold(), environment);
     println!(
@@ -3070,7 +3070,7 @@ pub fn incident_update(incident_id_str: &str, state_str: &str) -> Result<()> {
     ) {
         println!(
             "\n  {} {}",
-            "✓".green(),
+            "[OK]".green(),
             "Circuit breaker cleared — registry interactions for this contract resumed.".green()
         );
     }
@@ -3125,7 +3125,7 @@ pub async fn scan_deps(
     let findings = crate::conversions::as_array(&report["findings"], "findings")?;
 
     if findings.is_empty() {
-        println!("{}", "✓ No vulnerabilities found!".green().bold());
+        println!("{}", "[OK] No vulnerabilities found!".green().bold());
         return Ok(());
     }
 
@@ -3401,7 +3401,7 @@ pub async fn validate_call(
     if valid {
         println!(
             "\n{} {}",
-            "✓".green().bold(),
+            "[OK]".green().bold(),
             "Call is valid!".green().bold()
         );
 
@@ -3427,12 +3427,12 @@ pub async fn validate_call(
                 println!("\n{}", "Warnings:".bold().yellow());
                 for warning in warnings {
                     let msg = crate::conversions::as_str(&warning["message"], "message")?;
-                    println!("  {} {}", "⚠".yellow(), msg);
+                    println!("  {} {}", "[WARN]".yellow(), msg);
                 }
             }
         }
     } else {
-        println!("\n{} {}", "✗".red().bold(), "Call is invalid!".red().bold());
+        println!("\n{} {}", "[ERR]".red().bold(), "Call is invalid!".red().bold());
 
         // Show errors
         if let Some(errors) = data["errors"].as_array() {
@@ -3445,13 +3445,13 @@ pub async fn validate_call(
                 if let Some(f) = field {
                     println!(
                         "  {} [{}] {}: {}",
-                        "✗".red(),
+                        "[ERR]".red(),
                         code.bright_black(),
                         f.bold(),
                         msg
                     );
                 } else {
-                    println!("  {} [{}] {}", "✗".red(), code.bright_black(), msg);
+                    println!("  {} [{}] {}", "[ERR]".red(), code.bright_black(), msg);
                 }
 
                 if let Some(expected) = error["expected"].as_str() {
@@ -3509,7 +3509,7 @@ pub async fn generate_bindings(
         fs::write(output_path, &bindings)?;
         println!(
             "\n{} {} bindings written to: {}",
-            "✓".green().bold(),
+            "[OK]".green().bold(),
             language,
             output_path
         );
@@ -3882,7 +3882,7 @@ pub fn doc(contract_path: &str, output: &str) -> Result<()> {
     );
 
     fs::write(output, content)?;
-    println!("{} Documentation saved to: {}", "✓".green(), output);
+    println!("{} Documentation saved to: {}", "[OK]".green(), output);
 
     Ok(())
 }
@@ -4012,7 +4012,7 @@ pub fn openapi(contract_path: &str, output: &str, format: &str) -> Result<()> {
             let yaml = contract_abi::to_yaml(&doc).map_err(|e| anyhow::anyhow!("{}", e))?;
             let yaml_path = output.trim_end_matches(".pdf").to_string() + ".yaml";
             fs::write(&yaml_path, &yaml)?;
-            println!("{} Wrote {}", "✓".green(), yaml_path);
+            println!("{} Wrote {}", "[OK]".green(), yaml_path);
             return Ok(());
         }
         _ => anyhow::bail!(
@@ -4021,7 +4021,7 @@ pub fn openapi(contract_path: &str, output: &str, format: &str) -> Result<()> {
         ),
     };
     fs::write(output, content)?;
-    println!("{} Documentation saved to: {}", "✓".green(), output);
+    println!("{} Documentation saved to: {}", "[OK]".green(), output);
     Ok(())
 }
 
@@ -4031,7 +4031,7 @@ pub fn sla_record(id: &str, uptime: f64, latency: f64, error_rate: f64) -> Resul
     println!("Uptime: {:.2}%", uptime);
     println!("Latency: {:.2}ms", latency);
     println!("Error Rate: {:.2}%", error_rate);
-    println!("{} SLA metrics recorded", "✓".green());
+    println!("{} SLA metrics recorded", "[OK]".green());
 
     Ok(())
 }
@@ -4067,7 +4067,7 @@ pub async fn snapshot_create(api_url: &str, contract_id: &str) -> Result<()> {
 
     let snapshot: serde_json::Value = response.json().await?;
 
-    println!("{}", "✓ Snapshot created successfully!".green().bold());
+    println!("{}", "[OK] Snapshot created successfully!".green().bold());
     println!(
         "  {}: {}",
         "ID".bold(),
@@ -4326,7 +4326,7 @@ pub async fn stats(
 
     if let Some(path) = output {
         fs::write(path, &output_str)?;
-        println!("{} Stats written to {}", "✓".green(), path);
+        println!("{} Stats written to {}", "[OK]".green(), path);
     } else {
         println!("{}", output_str);
     }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2,9 +2,9 @@
 
 use crate::net::RequestBuilderExt;
 use crate::output_format;
-use registry_client::ContractSearchParams;
 use anyhow::{Context, Result};
 use colored::Colorize;
+use registry_client::ContractSearchParams;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_yaml;
@@ -278,13 +278,18 @@ pub async fn search(
         .max("Network".len());
     let cat_w = items
         .iter()
-        .filter_map(|contract| contract.category.as_deref().filter(|value| !value.is_empty()))
+        .filter_map(|contract| {
+            contract
+                .category
+                .as_deref()
+                .filter(|value| !value.is_empty())
+        })
         .map(|value| value.chars().count())
         .max()
         .unwrap_or(0)
         .max("Category".len());
-    // "○ Unverified" is the longest possible verified cell value (12 visible chars).
-    let ver_w = "○ Unverified".chars().count();
+    // "Unverified" is the longest possible verified cell value.
+    let ver_w = "Unverified".chars().count();
     let link_prefix = format!("{}/contracts/", api_url);
     let link_w = items
         .iter()
@@ -298,9 +303,9 @@ pub async fn search(
     for contract in items {
         let link = format!("{}/contracts/{}", api_url, contract.contract_id);
         let verified = if contract.is_verified {
-            "✓ Verified".green().to_string()
+            "Verified".green().to_string()
         } else {
-            "○ Unverified".yellow().to_string()
+            "Unverified".yellow().to_string()
         };
 
         rows.push(vec![
@@ -332,9 +337,9 @@ pub async fn search(
         let category = contract.category.as_deref().unwrap_or_default();
         let cat_pad = " ".repeat(cat_w.saturating_sub(category.chars().count()));
         let verified_visible = if contract.is_verified {
-            "✓ Verified".chars().count()
+            "Verified".chars().count()
         } else {
-            "○ Unverified".chars().count()
+            "Unverified".chars().count()
         };
         let verified_pad = " ".repeat(ver_w.saturating_sub(verified_visible));
 
@@ -1509,7 +1514,6 @@ pub async fn migrate(
     Ok(())
 }
 
-
 pub async fn export(
     api_url: &str,
     id: Option<&str>,
@@ -2074,7 +2078,11 @@ mod tests {
             &["defi".to_string(), "token".to_string()],
             VALID_PUBLISHER,
         );
-        assert!(result.is_ok(), "Expected valid inputs to pass: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "Expected valid inputs to pass: {:?}",
+            result
+        );
     }
 
     #[test]
@@ -2089,7 +2097,11 @@ mod tests {
         );
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("contract_id"), "Error should mention contract_id: {}", msg);
+        assert!(
+            msg.contains("contract_id"),
+            "Error should mention contract_id: {}",
+            msg
+        );
     }
 
     #[test]
@@ -2104,7 +2116,11 @@ mod tests {
         );
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("name is required"), "Error should mention name: {}", msg);
+        assert!(
+            msg.contains("name is required"),
+            "Error should mention name: {}",
+            msg
+        );
     }
 
     #[test]
@@ -2119,7 +2135,11 @@ mod tests {
         );
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("publisher"), "Error should mention publisher: {}", msg);
+        assert!(
+            msg.contains("publisher"),
+            "Error should mention publisher: {}",
+            msg
+        );
     }
 
     #[test]
@@ -2134,7 +2154,11 @@ mod tests {
         );
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("category"), "Error should mention category: {}", msg);
+        assert!(
+            msg.contains("category"),
+            "Error should mention category: {}",
+            msg
+        );
     }
 
     #[test]
@@ -2156,12 +2180,12 @@ mod tests {
     #[test]
     fn validate_publish_inputs_collects_multiple_errors() {
         let result = validate_publish_inputs(
-            "bad",            // invalid contract_id
-            "",               // empty name
+            "bad", // invalid contract_id
+            "",    // empty name
             Network::Testnet,
             None,
             &[],
-            "bad-publisher",  // invalid publisher
+            "bad-publisher", // invalid publisher
         );
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -2175,7 +2199,7 @@ mod tests {
     async fn publish_dry_run_does_not_send_request() {
         // dry_run should succeed without a running backend
         let result = super::publish(
-            "http://localhost:0",   // unreachable URL
+            "http://localhost:0", // unreachable URL
             VALID_CONTRACT_ID,
             "My Contract",
             Some("A test contract"),
@@ -2186,7 +2210,11 @@ mod tests {
             true,
         )
         .await;
-        assert!(result.is_ok(), "Dry-run should succeed without backend: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "Dry-run should succeed without backend: {:?}",
+            result
+        );
     }
 
     #[tokio::test]
@@ -2203,7 +2231,10 @@ mod tests {
             true,
         )
         .await;
-        assert!(result.is_err(), "Dry-run should still catch validation errors");
+        assert!(
+            result.is_err(),
+            "Dry-run should still catch validation errors"
+        );
     }
 }
 pub fn incident_trigger(contract_id: &str, severity_str: &str) -> Result<()> {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -75,13 +75,21 @@ pub fn profile(
             .context("Failed to serialize profile data")?;
         fs::write(output_path, profile_json)
             .with_context(|| format!("Failed to write profile output: {}", output_path))?;
-        println!("{} Profile output written to {}", "[OK]".green(), output_path);
+        println!(
+            "{} Profile output written to {}",
+            "[OK]".green(),
+            output_path
+        );
     }
 
     if let Some(flamegraph_path) = flamegraph {
         generate_flame_graph_file(&profile_data, flamegraph_path)
             .with_context(|| format!("Failed to generate flame graph at {}", flamegraph_path))?;
-        println!("{} Flame graph written to {}", "[OK]".green(), flamegraph_path);
+        println!(
+            "{} Flame graph written to {}",
+            "[OK]".green(),
+            flamegraph_path
+        );
     }
 
     if let Some(baseline_path) = compare {
@@ -864,7 +872,11 @@ pub async fn run_test_suite(options: TestSuiteOptions<'_>) -> Result<()> {
         });
         fs::write(report_output, serde_json::to_string_pretty(&report)?)
             .with_context(|| format!("Failed to write test report: {}", report_output))?;
-        println!("{} Test report written to {}", "[OK]".green(), report_output);
+        println!(
+            "{} Test report written to {}",
+            "[OK]".green(),
+            report_output
+        );
     }
 
     if let Some(profile_output) = options.profile_output {
@@ -876,7 +888,11 @@ pub async fn run_test_suite(options: TestSuiteOptions<'_>) -> Result<()> {
         });
         fs::write(profile_output, serde_json::to_string_pretty(&profile)?)
             .with_context(|| format!("Failed to write test profile: {}", profile_output))?;
-        println!("{} Test profile written to {}", "[OK]".green(), profile_output);
+        println!(
+            "{} Test profile written to {}",
+            "[OK]".green(),
+            profile_output
+        );
     }
 
     let teardown_result = if let Some(teardown_hook) = options.teardown_hook {
@@ -1408,7 +1424,9 @@ pub async fn migrate(
         );
         println!(
             "{}",
-            "[OK] Migration simulation complete (dry-run).".green().bold()
+            "[OK] Migration simulation complete (dry-run)."
+                .green()
+                .bold()
         );
         return Ok(());
     }
@@ -2473,7 +2491,9 @@ pub async fn config_rollback(
 
     println!(
         "{}",
-        "[OK] Configuration rolled back successfully!".green().bold()
+        "[OK] Configuration rolled back successfully!"
+            .green()
+            .bold()
     );
     println!("  {}: {}", "Environment".bold(), environment);
     println!(
@@ -3432,7 +3452,11 @@ pub async fn validate_call(
             }
         }
     } else {
-        println!("\n{} {}", "[ERR]".red().bold(), "Call is invalid!".red().bold());
+        println!(
+            "\n{} {}",
+            "[ERR]".red().bold(),
+            "Call is invalid!".red().bold()
+        );
 
         // Show errors
         if let Some(errors) = data["errors"].as_array() {

--- a/cli/src/contract_audit.rs
+++ b/cli/src/contract_audit.rs
@@ -124,7 +124,7 @@ pub async fn run(
         write_lockfile(lockfile_path, &updated)?;
         println!(
             "\n{} Lockfile updated at {}",
-            "✓".green(),
+            "[OK]".green(),
             lockfile_path.display()
         );
     }
@@ -142,9 +142,7 @@ pub async fn run(
 /// Generate an initial lockfile from a list of contract IDs.
 async fn run_init(api_url: &str, lockfile_path: &str, contract_ids: &[String]) -> Result<()> {
     if contract_ids.is_empty() {
-        anyhow::bail!(
-            "No contract IDs provided. Use --contracts <ID1,ID2,...> with --init."
-        );
+        anyhow::bail!("No contract IDs provided. Use --contracts <ID1,ID2,...> with --init.");
     }
 
     let path = Path::new(lockfile_path);
@@ -171,11 +169,11 @@ async fn run_init(api_url: &str, lockfile_path: &str, contract_ids: &[String]) -
         }
         match fetch_contract_meta(&client, api_url, id).await {
             Ok(entry) => {
-                println!("  {} {}", "✓".green(), id);
+                println!("  {} {}", "[OK]".green(), id);
                 contracts.insert(id.to_string(), entry);
             }
             Err(err) => {
-                eprintln!("  {} {} — {}", "✗".red(), id, err);
+                eprintln!("  {} {} — {}", "[ERR]".red(), id, err);
             }
         }
     }
@@ -194,7 +192,7 @@ async fn run_init(api_url: &str, lockfile_path: &str, contract_ids: &[String]) -
     write_lockfile(path, &lockfile)?;
     println!(
         "\n{} Lockfile created at {} with {} contract(s)",
-        "✓".green(),
+        "[OK]".green(),
         path.display(),
         lockfile.contracts.len()
     );
@@ -353,11 +351,7 @@ async fn fetch_contract_meta(
         anyhow::bail!("contract {} not found in registry", contract_id);
     }
     if !status.is_success() {
-        anyhow::bail!(
-            "registry returned {} for contract {}",
-            status,
-            contract_id
-        );
+        anyhow::bail!("registry returned {} for contract {}", status, contract_id);
     }
 
     let body: Value = resp
@@ -377,12 +371,8 @@ pub fn entry_from_api_response(contract_id: &str, value: &Value) -> LockEntry {
             .unwrap_or("")
             .to_string()
     };
-    let opt_field = |key: &str| -> Option<String> {
-        value
-            .get(key)
-            .and_then(Value::as_str)
-            .map(String::from)
-    };
+    let opt_field =
+        |key: &str| -> Option<String> { value.get(key).and_then(Value::as_str).map(String::from) };
 
     let api_contract_id = str_field("contract_id");
     LockEntry {
@@ -412,8 +402,7 @@ pub fn read_lockfile(path: &Path) -> Result<Lockfile> {
 
 /// Serialize and write a lockfile to disk.
 pub fn write_lockfile(path: &Path, lockfile: &Lockfile) -> Result<()> {
-    let json = serde_json::to_string_pretty(lockfile)
-        .context("Failed to serialize lockfile")?;
+    let json = serde_json::to_string_pretty(lockfile).context("Failed to serialize lockfile")?;
     fs::write(path, json)
         .with_context(|| format!("Failed to write lockfile: {}", path.display()))?;
     Ok(())
@@ -442,15 +431,12 @@ fn render_text_report(report: &DriftReport) {
         "Contract Drift Audit Report".bold(),
         "═".repeat(40)
     );
-    println!(
-        "  Contracts audited: {}",
-        report.audited.to_string().bold()
-    );
+    println!("  Contracts audited: {}", report.audited.to_string().bold());
 
     if !report.has_drift {
         println!(
             "\n  {} No drift detected. Local lockfile is in sync with the registry.",
-            "✓".green()
+            "[OK]".green()
         );
         return;
     }
@@ -652,10 +638,7 @@ mod tests {
 
         assert_eq!(parsed.version, 1);
         assert_eq!(parsed.contracts.len(), 1);
-        assert_eq!(
-            parsed.contracts["CABC123"].version,
-            "1.0.0"
-        );
+        assert_eq!(parsed.contracts["CABC123"].version, "1.0.0");
     }
 
     #[test]

--- a/cli/src/contract_deprecate.rs
+++ b/cli/src/contract_deprecate.rs
@@ -96,7 +96,13 @@ pub async fn run(
 
     // 3. Show state diff and confirm
     if !yes {
-        render_state_diff(address, reason, replacement, &contract_info, &signing_address);
+        render_state_diff(
+            address,
+            reason,
+            replacement,
+            &contract_info,
+            &signing_address,
+        );
         if !prompt_confirmation()? {
             println!("{}", "Deprecation cancelled.".yellow());
             return Ok(());
@@ -206,11 +212,7 @@ pub async fn run(
         if let Some(guide) = migration_guide {
             println!("  {}: {}", "Migration Guide".bold(), guide);
         }
-        println!(
-            "  {}: {} days",
-            "Grace Period".bold(),
-            grace_period_days
-        );
+        println!("  {}: {} days", "Grace Period".bold(), grace_period_days);
         println!(
             "  {}: {}",
             "Signed By".bold(),
@@ -330,10 +332,17 @@ pub async fn rollback(
         });
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
-        println!("\n{}", "Contract rollback completed successfully!".green().bold());
+        println!(
+            "\n{}",
+            "Contract rollback completed successfully!".green().bold()
+        );
         println!("  {}: {}", "Contract".bold(), address.cyan());
         println!("  {}: {}", "Reason".bold(), reason);
-        println!("  {}: {}", "Signed By".bold(), signing_address.bright_magenta());
+        println!(
+            "  {}: {}",
+            "Signed By".bold(),
+            signing_address.bright_magenta()
+        );
         println!();
     }
 
@@ -490,9 +499,18 @@ fn render_state_diff(
 
     println!("\n{}", "Contract Deprecation Preview".bold().cyan());
     println!("{}", "═".repeat(50).cyan());
-    println!("  {}: {} ({})", "Contract".bold(), address.cyan(), name.dimmed());
+    println!(
+        "  {}: {} ({})",
+        "Contract".bold(),
+        address.cyan(),
+        name.dimmed()
+    );
     println!("  {}: {}", "Network".bold(), network);
-    println!("  {}: {}", "Signed By".bold(), signing_address.bright_magenta());
+    println!(
+        "  {}: {}",
+        "Signed By".bold(),
+        signing_address.bright_magenta()
+    );
 
     println!("\n  {}", "State Change:".bold().yellow());
     println!(
@@ -501,17 +519,9 @@ fn render_state_diff(
         current_status.green(),
         "deprecated".red()
     );
-    println!(
-        "    {} (none) → {}",
-        "Reason:".bold(),
-        reason
-    );
+    println!("    {} (none) → {}", "Reason:".bold(), reason);
     if let Some(repl) = replacement {
-        println!(
-            "    {} (none) → {}",
-            "Replacement:".bold(),
-            repl.cyan()
-        );
+        println!("    {} (none) → {}", "Replacement:".bold(), repl.cyan());
     }
     println!("{}\n", "═".repeat(50).cyan());
 }
@@ -539,9 +549,18 @@ fn render_rollback_preview(
 
     println!("\n{}", "Contract Rollback Preview".bold().cyan());
     println!("{}", "═".repeat(50).cyan());
-    println!("  {}: {} ({})", "Contract".bold(), address.cyan(), name.dimmed());
+    println!(
+        "  {}: {} ({})",
+        "Contract".bold(),
+        address.cyan(),
+        name.dimmed()
+    );
     println!("  {}: {}", "Network".bold(), network);
-    println!("  {}: {}", "Signed By".bold(), signing_address.bright_magenta());
+    println!(
+        "  {}: {}",
+        "Signed By".bold(),
+        signing_address.bright_magenta()
+    );
 
     println!("\n  {}", "State Change:".bold().yellow());
     println!(
@@ -550,21 +569,14 @@ fn render_rollback_preview(
         current_status.red(),
         "active".green()
     );
-    println!(
-        "    {} (none) → {}",
-        "Reason:".bold(),
-        reason
-    );
+    println!("    {} (none) → {}", "Reason:".bold(), reason);
     println!("{}\n", "═".repeat(50).cyan());
 }
 
 /// Prompt the user for yes/no confirmation.
 fn prompt_confirmation() -> Result<bool> {
     use std::io::{self, Write};
-    print!(
-        "  {} ",
-        "Proceed with deprecation? [y/N]".bold()
-    );
+    print!("  {} ", "Proceed with deprecation? [y/N]".bold());
     io::stdout().flush()?;
     let mut input = String::new();
     io::stdin().read_line(&mut input)?;
@@ -693,7 +705,10 @@ mod tests {
 
         let sig1 = sign_deprecation(&p1, &signing_key);
         let sig2 = sign_deprecation(&p2, &signing_key);
-        assert_ne!(sig1, sig2, "Different nonces must produce different signatures");
+        assert_ne!(
+            sig1, sig2,
+            "Different nonces must produce different signatures"
+        );
     }
 
     // ── Timestamp validation tests ───────────────────────────────────────
@@ -736,7 +751,11 @@ mod tests {
         let result = decode_private_key("not-valid-base64!!!");
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("base64"), "Error should mention base64: {}", err);
+        assert!(
+            err.contains("base64"),
+            "Error should mention base64: {}",
+            err
+        );
     }
 
     #[test]
@@ -745,7 +764,11 @@ mod tests {
         let result = decode_private_key(&too_short);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("32 bytes"), "Error should mention key length: {}", err);
+        assert!(
+            err.contains("32 bytes"),
+            "Error should mention key length: {}",
+            err
+        );
     }
 
     // ── Stellar address derivation ───────────────────────────────────────

--- a/cli/src/contract_interfaces.rs
+++ b/cli/src/contract_interfaces.rs
@@ -15,7 +15,11 @@ use shared::interface_fingerprint::{fingerprint_spec, EntryKind, InterfaceFinger
 
 /// `soroban-registry contract interfaces --wasm <path> [--json]`
 pub async fn run_local(wasm_path: &str, json: bool) -> Result<()> {
-    log::debug!("contract interfaces (local) | wasm={} json={}", wasm_path, json);
+    log::debug!(
+        "contract interfaces (local) | wasm={} json={}",
+        wasm_path,
+        json
+    );
 
     let path = std::path::Path::new(wasm_path);
     if !path.exists() {
@@ -89,6 +93,10 @@ fn print_group(
     for entry in entries {
         println!("  {} {}", "•".cyan(), entry.name.bold());
         println!("      {}", entry.signature.bright_black());
-        println!("      {} {}", "fingerprint:".dimmed(), entry.fingerprint.dimmed());
+        println!(
+            "      {} {}",
+            "fingerprint:".dimmed(),
+            entry.fingerprint.dimmed()
+        );
     }
 }

--- a/cli/src/contract_register.rs
+++ b/cli/src/contract_register.rs
@@ -398,6 +398,9 @@ async fn resolve_drafts(
             request: PublishRequest {
                 contract_id,
                 wasm_hash,
+                // This flow registers already-deployed contracts from metadata,
+                // so there is no artifact to upload alongside the hash.
+                wasm_artifact_base64: None,
                 name,
                 slug,
                 description,

--- a/cli/src/contract_search.rs
+++ b/cli/src/contract_search.rs
@@ -10,9 +10,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use colored::Colorize;
-use registry_client::{
-    ContractHit, PageCollection, PageCursor, PaginationMode, RegistryClient, StopReason,
-};
+use registry_client::{ContractHit, PageCollection, PageCursor, PaginationMode, StopReason};
 
 use crate::search_pagination::{build_limits, build_request, resolve_mode, SearchOptions};
 
@@ -21,11 +19,8 @@ pub async fn run(api_url: &str, options: SearchOptions) -> Result<()> {
     let request = build_request(&options, mode)?;
     let limits = build_limits(&options);
 
-    let token = crate::auth::access_token_for_requests(api_url).await?;
-    let client =
-        RegistryClient::with_http_client(api_url, crate::net::client()).with_bearer_token(token);
-
-    let mut walk = client
+    let mut walk = crate::registry::uncached_client(api_url)
+        .await?
         .search_paginator(request, limits)
         .map_err(|err| anyhow!("Failed to search contracts: {err}"))?;
 

--- a/cli/src/contract_search.rs
+++ b/cli/src/contract_search.rs
@@ -1,0 +1,255 @@
+//! `soroban-registry contract search` — paginated contract search.
+//!
+//! Pagination is handled by the shared `registry_client` crate, so this command
+//! never manages continuation tokens itself: it picks a mode, sets safety
+//! bounds, and renders whatever the walk produced. `--all` walks every page
+//! within `--max-items` / `--max-pages`, and Ctrl-C stops the walk and prints
+//! what was already fetched.
+//!
+//! The flag-to-request logic lives in [`crate::search_pagination`].
+
+use anyhow::{anyhow, Context, Result};
+use colored::Colorize;
+use registry_client::{
+    ContractHit, PageCollection, PageCursor, PaginationMode, RegistryClient, StopReason,
+};
+
+use crate::search_pagination::{build_limits, build_request, resolve_mode, SearchOptions};
+
+pub async fn run(api_url: &str, options: SearchOptions) -> Result<()> {
+    let mode = resolve_mode(&options)?;
+    let request = build_request(&options, mode)?;
+    let limits = build_limits(&options);
+
+    let token = crate::auth::access_token_for_requests(api_url).await?;
+    let client =
+        RegistryClient::with_http_client(api_url, crate::net::client()).with_bearer_token(token);
+
+    let mut walk = client
+        .search_paginator(request, limits)
+        .map_err(|err| anyhow!("Failed to search contracts: {err}"))?;
+
+    // Ctrl-C ends a multi-page walk cleanly, keeping the pages already fetched,
+    // instead of tearing the process down mid-render.
+    if options.all {
+        let cancel = walk.cancel_token();
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                cancel.cancel();
+            }
+        });
+    }
+
+    let collected = walk
+        .collect_all()
+        .await
+        .context("Failed to search contracts")?;
+
+    if options.json {
+        print_json(&options, mode, &collected)?;
+    } else {
+        print_human(api_url, &options, mode, &collected);
+    }
+
+    Ok(())
+}
+
+// ── Output ────────────────────────────────────────────────────────────────────
+
+/// How the walk ended, from the command's point of view.
+///
+/// Without `--all` the walk is deliberately one page long, so the paginator's
+/// internal page bound is reported as `single_page` rather than as a bound the
+/// user set.
+fn stop_reason_label(
+    options: &SearchOptions,
+    collected: &PageCollection<ContractHit>,
+) -> &'static str {
+    if !options.all && collected.stop_reason == StopReason::MaxPages {
+        return "single_page";
+    }
+    collected.stop_reason.as_str()
+}
+
+fn print_json(
+    options: &SearchOptions,
+    mode: PaginationMode,
+    collected: &PageCollection<ContractHit>,
+) -> Result<()> {
+    let contracts: Vec<serde_json::Value> = collected
+        .items
+        .iter()
+        .map(|hit| {
+            serde_json::json!({
+                "id": hit.id,
+                "contract_id": hit.contract_id,
+                "name": hit.name,
+                "description": hit.description,
+                "network": hit.network,
+                "category": hit.category,
+                "is_verified": hit.is_verified,
+                "is_deprecated": hit.is_deprecated,
+                "deprecation_status": hit.deprecation_status,
+                "relevance_score": hit.relevance_score,
+            })
+        })
+        .collect();
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "query": options.query,
+            "contracts": contracts,
+            "count": contracts.len(),
+            "pagination": {
+                "mode": mode.as_str(),
+                "page_size": options.limit,
+                "pages_fetched": collected.pages_fetched,
+                "total": collected.total,
+                "complete": collected.is_complete(),
+                "stop_reason": stop_reason_label(options, collected),
+                "cancelled": collected.stop_reason == StopReason::Cancelled,
+                "next_cursor": collected.next.as_ref().and_then(PageCursor::as_cursor),
+                "next_offset": collected.next.as_ref().and_then(PageCursor::as_offset),
+                "max_items": options.all.then(|| options.effective_max_items()),
+                "max_pages": options.all.then(|| options.effective_max_pages()),
+            }
+        }))?
+    );
+
+    Ok(())
+}
+
+fn print_human(
+    api_url: &str,
+    options: &SearchOptions,
+    mode: PaginationMode,
+    collected: &PageCollection<ContractHit>,
+) {
+    println!("\n{}", "Search Results:".bold().cyan());
+    println!("{}", "=".repeat(80).cyan());
+
+    let mut filters: Vec<String> = Vec::new();
+    if let Some(networks) = options.networks.as_deref() {
+        filters.push(format!("networks: {networks}"));
+    }
+    if let Some(category) = options.category.as_deref() {
+        filters.push(format!("category: {category}"));
+    }
+    if let Some(tags) = options.tags.as_deref() {
+        filters.push(format!("tags: {tags}"));
+    }
+    if options.verified_only {
+        filters.push("verified only".to_string());
+    }
+    if !filters.is_empty() {
+        println!(
+            "  {} {}\n",
+            "Active filters:".bold(),
+            filters.join(" | ").bright_blue()
+        );
+    }
+
+    if collected.items.is_empty() {
+        println!("{}", "No contracts found matching your query.".yellow());
+        print_pagination_footer(options, mode, collected);
+        return;
+    }
+
+    for hit in &collected.items {
+        let verified = if hit.is_verified {
+            " ✓ verified".green().to_string()
+        } else {
+            String::new()
+        };
+        let deprecated = if hit.is_deprecated {
+            " ⚠ deprecated".yellow().to_string()
+        } else {
+            String::new()
+        };
+
+        println!(" {}{}{}", hit.name.bold(), verified, deprecated);
+        println!(
+            "   {}",
+            hit.description.as_deref().unwrap_or("No description")
+        );
+        println!(
+            "   {} {} | {} {}",
+            "Network:".dimmed(),
+            hit.network,
+            "Category:".dimmed(),
+            hit.category.as_deref().unwrap_or("unknown")
+        );
+        println!(
+            "   {} {}/contracts/{}",
+            "Link:".dimmed(),
+            api_url,
+            hit.contract_id
+        );
+        println!();
+    }
+
+    print_pagination_footer(options, mode, collected);
+}
+
+fn print_pagination_footer(
+    options: &SearchOptions,
+    mode: PaginationMode,
+    collected: &PageCollection<ContractHit>,
+) {
+    let of_total = match collected.total {
+        Some(total) => format!(" of {total} match(es)"),
+        None => String::new(),
+    };
+
+    println!(
+        "  {} {} result(s){} · {} page(s) · {} pagination",
+        "Showing".bold(),
+        collected.items.len(),
+        of_total,
+        collected.pages_fetched,
+        mode
+    );
+
+    // Bound notices only make sense for a `--all` walk: a single-page search
+    // stops after one page by design.
+    match collected.stop_reason {
+        StopReason::Cancelled => println!(
+            "  {}",
+            "Cancelled — showing the pages fetched before interruption.".yellow()
+        ),
+        StopReason::MaxItems if options.all => println!(
+            "  {}",
+            format!(
+                "Stopped at the --max-items bound ({}).",
+                options.effective_max_items()
+            )
+            .yellow()
+        ),
+        StopReason::MaxPages if options.all => println!(
+            "  {}",
+            format!(
+                "Stopped at the --max-pages bound ({}).",
+                options.effective_max_pages()
+            )
+            .yellow()
+        ),
+        StopReason::Exhausted | StopReason::MaxItems | StopReason::MaxPages => {}
+    }
+
+    // Say exactly how to continue, so nobody has to hand-roll continuation state.
+    match collected.next.as_ref() {
+        Some(PageCursor::Cursor(token)) => println!(
+            "  {} {}",
+            "Next page:".dimmed(),
+            format!("--cursor {token}").bright_blue()
+        ),
+        Some(PageCursor::Offset { offset }) => println!(
+            "  {} {}",
+            "Next page:".dimmed(),
+            format!("--offset {offset}").bright_blue()
+        ),
+        None => {}
+    }
+    println!();
+}

--- a/cli/src/contract_search.rs
+++ b/cli/src/contract_search.rs
@@ -153,12 +153,12 @@ fn print_human(
 
     for hit in &collected.items {
         let verified = if hit.is_verified {
-            " ✓ verified".green().to_string()
+            " [verified]".green().to_string()
         } else {
             String::new()
         };
         let deprecated = if hit.is_deprecated {
-            " ⚠ deprecated".yellow().to_string()
+            " [deprecated]".yellow().to_string()
         } else {
             String::new()
         };
@@ -198,7 +198,7 @@ fn print_pagination_footer(
     };
 
     println!(
-        "  {} {} result(s){} · {} page(s) · {} pagination",
+        "  {} {} result(s){} | {} page(s) | {} pagination",
         "Showing".bold(),
         collected.items.len(),
         of_total,

--- a/cli/src/contract_snapshot.rs
+++ b/cli/src/contract_snapshot.rs
@@ -67,8 +67,9 @@ pub async fn run_export(
 
     // Confirm the registry signed what it sent us. Catches a misconfigured or
     // truncated response at export time rather than at audit time.
-    verify_snapshot(&snapshot, None, None)
-        .map_err(|e| anyhow::anyhow!("the registry returned a snapshot that fails its own signature check: {e}"))?;
+    verify_snapshot(&snapshot, None, None).map_err(|e| {
+        anyhow::anyhow!("the registry returned a snapshot that fails its own signature check: {e}")
+    })?;
 
     let pretty = serde_json::to_string_pretty(&snapshot)
         .context("failed to serialize the snapshot for writing")?;
@@ -156,7 +157,10 @@ pub async fn run_verify(
                 println!("  contract:    {}", snapshot.payload.contract.contract_id);
                 println!("  name:        {}", snapshot.payload.contract.name);
                 println!("  network:     {}", snapshot.payload.contract.network);
-                println!("  verified:    {}", snapshot.payload.verification.is_verified);
+                println!(
+                    "  verified:    {}",
+                    snapshot.payload.verification.is_verified
+                );
                 println!("  exported at: {}", snapshot.payload.exported_at);
                 println!("  signed by:   {}", snapshot.signature.key_fingerprint);
 
@@ -293,9 +297,7 @@ mod tests {
         let parsed: ContractSnapshot = serde_json::from_str(&raw).unwrap();
 
         assert!(verify_snapshot(&parsed, None, None).is_ok());
-        assert!(
-            verify_snapshot(&parsed, Some(&parsed.signature.key_fingerprint), None).is_ok()
-        );
+        assert!(verify_snapshot(&parsed, Some(&parsed.signature.key_fingerprint), None).is_ok());
     }
 
     /// Editing the file on disk must be caught.
@@ -324,7 +326,10 @@ mod tests {
 
     #[test]
     fn error_kinds_are_stable() {
-        assert_eq!(error_kind(&SnapshotError::SignatureMismatch), "signature_mismatch");
+        assert_eq!(
+            error_kind(&SnapshotError::SignatureMismatch),
+            "signature_mismatch"
+        );
         assert_eq!(
             error_kind(&SnapshotError::UntrustedKey {
                 expected: "a".into(),

--- a/cli/src/contract_update.rs
+++ b/cli/src/contract_update.rs
@@ -1,11 +1,9 @@
 //! `soroban-registry contract update` — update contract metadata (#828).
 
 use crate::contract_deploy::{upload_icon_to_backend, validate_and_process_icon};
-use crate::net::RequestBuilderExt;
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::io::{self, Write};
 
 #[derive(Debug, Clone, Serialize)]
@@ -18,6 +16,29 @@ struct MetadataPatch {
     category: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tags: Option<Vec<String>>,
+}
+
+impl MetadataPatch {
+    /// The registry's own request type. `user_id` is server-derived from the
+    /// caller's session, so the CLI never sets it.
+    fn to_request(&self) -> registry_client::UpdateContractMetadataRequest {
+        registry_client::UpdateContractMetadataRequest {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            category: self.category.clone(),
+            tags: self.tags.clone(),
+            user_id: None,
+        }
+    }
+}
+
+/// A key that is identical for the same patch applied to the same contract, so
+/// a retried update collapses into one version-history entry instead of two.
+fn metadata_idempotency_key(contract_id: &str, patch: &MetadataPatch) -> String {
+    use sha2::{Digest, Sha256};
+    let canonical = serde_json::to_string(patch).unwrap_or_default();
+    let digest = Sha256::digest(format!("{contract_id}:{canonical}").as_bytes());
+    format!("cli-metadata-{}", hex::encode(&digest[..16]))
 }
 
 #[derive(Debug, Deserialize)]
@@ -108,26 +129,15 @@ pub async fn run(args: UpdateArgs<'_>) -> Result<()> {
         }
     }
 
-    let url = format!(
-        "{}/api/contracts/{}/metadata",
-        args.api_url.trim_end_matches('/'),
-        current.id
-    );
-    let client = crate::net::client();
-    let response = client
-        .patch(&url)
-        .json(&patch)
-        .send_with_retry()
+    // A metadata update appends a version-history entry, so it is only retried
+    // under an idempotency key derived from the contract and the exact patch.
+    let idempotency_key = metadata_idempotency_key(&current.id, &patch);
+    let updated = crate::registry::uncached_client(args.api_url)
+        .await?
+        .update_contract_metadata(&current.id, &patch.to_request(), Some(idempotency_key))
         .await
-        .with_context(|| format!("PATCH {url}"))?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        bail!("Metadata update failed ({status}): {body}");
-    }
-
-    let updated: Value = response.json().await.context("Invalid update response")?;
+        .map_err(|err| anyhow::anyhow!("Metadata update failed: {err}"))?;
+    let updated = serde_json::to_value(&updated).context("Invalid update response")?;
 
     if let Some(icon_path) = &args.icon {
         let icon_data = validate_and_process_icon(icon_path)?;
@@ -151,30 +161,31 @@ pub async fn run(args: UpdateArgs<'_>) -> Result<()> {
     Ok(())
 }
 
+/// Read the contract through the shared client, so a missing contract, an
+/// expired session, and a server fault stay distinguishable.
 async fn fetch_contract(api_url: &str, address: &str) -> Result<ContractRecord> {
-    let url = format!(
-        "{}/api/contracts/{}",
-        api_url.trim_end_matches('/'),
-        address
-    );
-    let client = crate::net::client();
-    let response = client
-        .get(&url)
-        .send_with_retry()
+    let response = crate::registry::uncached_client(api_url)
+        .await?
+        .get_contract(address)
         .await
-        .with_context(|| format!("GET {url}"))?;
+        .map_err(|err| match err {
+            registry_client::Error::NotFound(_) => anyhow::anyhow!("Contract not found: {address}"),
+            other => anyhow::anyhow!("Failed to fetch contract: {other}"),
+        })?;
 
-    if response.status() == reqwest::StatusCode::NOT_FOUND {
-        bail!("Contract not found: {address}");
-    }
-    if !response.status().is_success() {
-        bail!("Failed to fetch contract ({})", response.status());
-    }
-
-    response
-        .json::<ContractRecord>()
-        .await
-        .context("Failed to parse contract response")
+    let contract = response.contract;
+    Ok(ContractRecord {
+        id: contract.id.to_string(),
+        contract_id: contract.contract_id,
+        name: contract.name,
+        description: contract.description,
+        category: contract.category,
+        tags: contract
+            .tags
+            .into_iter()
+            .map(|tag| TagRecord { name: tag.name })
+            .collect(),
+    })
 }
 
 fn current_tags(contract: &ContractRecord) -> Vec<String> {

--- a/cli/src/contract_update.rs
+++ b/cli/src/contract_update.rs
@@ -85,7 +85,7 @@ pub async fn run(args: UpdateArgs<'_>) -> Result<()> {
     if args.homepage.is_some() {
         eprintln!(
             "{} Homepage updates are not yet supported by the registry API; the field will be ignored.",
-            "⚠".yellow()
+            "[WARN]".yellow()
         );
     }
 
@@ -153,7 +153,7 @@ pub async fn run(args: UpdateArgs<'_>) -> Result<()> {
     } else {
         println!(
             "\n{} Contract metadata updated successfully.",
-            "✔".green().bold()
+            "[OK]".green().bold()
         );
         println!("  Version history is preserved automatically by the registry.");
     }

--- a/cli/src/contract_verify.rs
+++ b/cli/src/contract_verify.rs
@@ -114,7 +114,7 @@ async fn verify_single_contract(
     if !no_cache {
         if let Ok(Some(cached)) = cache::get(address, network) {
             if !json {
-                println!("{} Loaded from cache", "◀".cyan());
+                println!("{} Loaded from cache", "[CACHE]".cyan());
             }
 
             let result = serde_json::from_value::<VerificationResult>(cached.result.clone())
@@ -247,9 +247,9 @@ async fn run_batch(
 
                     if !json {
                         let status = if result.is_verified {
-                            "✓".green()
+                            "[OK]".green()
                         } else {
-                            "✗".red()
+                            "[ERR]".red()
                         };
                         println!("{}", status);
                     }
@@ -258,7 +258,7 @@ async fn run_batch(
             }
             Err(e) => {
                 if !json {
-                    println!("{}", "✗".red());
+                    println!("{}", "[ERR]".red());
                 }
                 batch_errors.push(format!("Failed to verify {}: {}", address, e));
             }
@@ -378,7 +378,7 @@ async fn fetch_contract(
             print_header();
             println!(
                 "{} Contract {} not found in the {} registry.",
-                "✗".red().bold(),
+                "[ERR]".red().bold(),
                 address.bright_black(),
                 network.bright_blue()
             );
@@ -747,12 +747,12 @@ fn print_human(result: &VerificationResult, detail: &Option<Value>) {
 
     // ── Verification status ──────────────────────────────────────────────────
     let (icon, status_label) = match result.verification_status.as_str() {
-        "verified" => ("✔".green().bold(), "VERIFIED".green().bold()),
+        "verified" => ("[OK]".green().bold(), "VERIFIED".green().bold()),
         "pending" | "processing" | "in_progress" => {
-            ("●".yellow().bold(), "PENDING".yellow().bold())
+            ("[WAIT]".yellow().bold(), "PENDING".yellow().bold())
         }
-        "failed" => ("✘".red().bold(), "FAILED".red().bold()),
-        _ => ("✘".red().bold(), "UNVERIFIED".red().bold()),
+        "failed" => ("[ERR]".red().bold(), "FAILED".red().bold()),
+        _ => ("[ERR]".red().bold(), "UNVERIFIED".red().bold()),
     };
 
     println!("  {} Verification Status: {}", icon, status_label);
@@ -764,14 +764,14 @@ fn print_human(result: &VerificationResult, detail: &Option<Value>) {
     if !result.errors.is_empty() {
         println!("\n  {}", "Errors".bold().red());
         for error in &result.errors {
-            println!("  {} {}", "✗".red().bold(), error);
+            println!("  {} {}", "[ERR]".red().bold(), error);
         }
     }
 
     if !result.warnings.is_empty() {
         println!("\n  {}", "Warnings".bold().yellow());
         for warning in &result.warnings {
-            println!("  {} {}", "⚠".yellow().bold(), warning);
+            println!("  {} {}", "[WARN]".yellow().bold(), warning);
         }
     }
 
@@ -845,8 +845,8 @@ fn print_human(result: &VerificationResult, detail: &Option<Value>) {
 
         let audit_passed = d["audit"]["passed"].as_bool();
         match audit_passed {
-            Some(true) => println!("  {} {}", "✔".green(), "Audit passed".green().bold()),
-            Some(false) => println!("  {} {}", "✘".red(), "Audit failed".red().bold()),
+            Some(true) => println!("  {} {}", "[OK]".green(), "Audit passed".green().bold()),
+            Some(false) => println!("  {} {}", "[ERR]".red(), "Audit failed".red().bold()),
             None => println!("  {}", "No audit record".dimmed()),
         }
 
@@ -869,13 +869,13 @@ fn print_human(result: &VerificationResult, detail: &Option<Value>) {
     if result.is_verified && scan_status != "critical" {
         println!(
             "  {} Contract {} is verified and safe to interact with.\n",
-            "✔".green().bold(),
+            "[OK]".green().bold(),
             result.address.bold()
         );
     } else if !result.is_verified {
         println!(
             "  {} Contract {} is NOT verified — proceed with caution.\n",
-            "⚠".yellow().bold(),
+            "[WARN]".yellow().bold(),
             result.address.bold()
         );
         println!(
@@ -886,7 +886,7 @@ fn print_human(result: &VerificationResult, detail: &Option<Value>) {
     } else {
         println!(
             "  {} Contract {} has security issues — review findings above.\n",
-            "✘".red().bold(),
+            "[ERR]".red().bold(),
             result.address.bold()
         );
     }
@@ -930,7 +930,11 @@ struct Check {
 pub async fn run_local(wasm_path: &str, verbose: bool, json: bool) -> Result<()> {
     use sha2::{Digest, Sha256};
 
-    log::debug!("contract verify (local) | wasm={} verbose={}", wasm_path, verbose);
+    log::debug!(
+        "contract verify (local) | wasm={} verbose={}",
+        wasm_path,
+        verbose
+    );
 
     // 1. Read the file, with actionable errors for the common failure modes.
     let path = std::path::Path::new(wasm_path);
@@ -978,8 +982,9 @@ pub async fn run_local(wasm_path: &str, verbose: bool, json: bool) -> Result<()>
     checks.push(Check {
         ok: validation.function_count > 0,
         label: format!("Exports {} function(s)", validation.export_functions.len()),
-        hint: (validation.function_count == 0)
-            .then(|| "The module defines no functions; it cannot be a usable contract.".to_string()),
+        hint: (validation.function_count == 0).then(|| {
+            "The module defines no functions; it cannot be a usable contract.".to_string()
+        }),
     });
 
     // Env metadata is advisory: warn but do not fail.
@@ -1031,9 +1036,9 @@ pub async fn run_local(wasm_path: &str, verbose: bool, json: bool) -> Result<()>
     println!("\n{}", "Checks:".bold());
     for check in &checks {
         if check.ok {
-            println!("  {} {}", "✓".green().bold(), check.label);
+            println!("  {} {}", "[OK]".green().bold(), check.label);
         } else {
-            println!("  {} {}", "✗".red().bold(), check.label.red());
+            println!("  {} {}", "[ERR]".red().bold(), check.label.red());
             if let Some(hint) = &check.hint {
                 println!("    {} {}", "→".yellow(), hint.yellow());
             }
@@ -1048,7 +1053,10 @@ pub async fn run_local(wasm_path: &str, verbose: bool, json: bool) -> Result<()>
         println!("  {:<22}{}", "Function count:", validation.function_count);
         println!("  {:<22}{}", "Table count:", validation.table_count);
         println!("  {:<22}{} page(s)", "Memory:", validation.memory_pages);
-        println!("  {:<22}{}", "Data section entries:", validation.data_section_size);
+        println!(
+            "  {:<22}{}",
+            "Data section entries:", validation.data_section_size
+        );
         println!(
             "  {:<22}{}",
             "Custom sections:",
@@ -1076,13 +1084,13 @@ pub async fn run_local(wasm_path: &str, verbose: bool, json: bool) -> Result<()>
     if passed {
         println!(
             "{} contract is valid and ready to publish",
-            "✓ PASS —".green().bold()
+            "[OK] PASS —".green().bold()
         );
         Ok(())
     } else {
         println!(
             "{} {} error(s)",
-            "✗ FAIL —".red().bold(),
+            "[ERR] FAIL —".red().bold(),
             hard_errors.len()
         );
         anyhow::bail!("local verification failed");

--- a/cli/src/contracts.rs
+++ b/cli/src/contracts.rs
@@ -245,9 +245,9 @@ fn print_table(contracts: &[ContractListItem]) {
     // Rows
     for contract in contracts {
         let verified = if contract.is_verified {
-            "[OK]".green().to_string()
+            "yes".green().to_string()
         } else {
-            "[ERR]".red().to_string()
+            "no".red().to_string()
         };
 
         let health_color = match contract.health_score {
@@ -377,9 +377,9 @@ pub async fn info(api_url: &str, id: &str, json_output: bool) -> Result<()> {
     }
 
     let status_str = if is_verified {
-        "[OK] Verified".green()
+        "Verified".green()
     } else {
-        "○ Unverified".yellow()
+        "Unverified".yellow()
     };
     println!("{:<15} {}", "Status:".bold(), status_str);
 

--- a/cli/src/contracts.rs
+++ b/cli/src/contracts.rs
@@ -245,9 +245,9 @@ fn print_table(contracts: &[ContractListItem]) {
     // Rows
     for contract in contracts {
         let verified = if contract.is_verified {
-            "✓".green().to_string()
+            "[OK]".green().to_string()
         } else {
-            "✗".red().to_string()
+            "[ERR]".red().to_string()
         };
 
         let health_color = match contract.health_score {
@@ -377,7 +377,7 @@ pub async fn info(api_url: &str, id: &str, json_output: bool) -> Result<()> {
     }
 
     let status_str = if is_verified {
-        "✓ Verified".green()
+        "[OK] Verified".green()
     } else {
         "○ Unverified".yellow()
     };

--- a/cli/src/contracts.rs
+++ b/cli/src/contracts.rs
@@ -1,8 +1,6 @@
-use crate::net::RequestBuilderExt;
 use crate::output_format::{self, OutputFormat};
 use anyhow::{Context, Result};
 use colored::Colorize;
-use reqwest::StatusCode;
 use serde_json::json;
 use std::cmp::Ordering;
 
@@ -333,25 +331,23 @@ fn print_yaml(contracts: &[ContractListItem]) {
 pub async fn info(api_url: &str, id: &str, json_output: bool) -> Result<()> {
     let t0 = std::time::Instant::now();
 
-    let url = format!("{}/api/contracts/{}", api_url, id);
-    let query = vec![
-        ("include_stats", "true".to_string()),
-        ("include_versions", "true".to_string()),
-        ("include_abi", "true".to_string()),
-    ];
-
-    let (status, body) = crate::cached_http::cached_get(&url, &query)
+    // The document is kept untyped: `--json` passes the server's response
+    // through verbatim, so fields the registry adds later are not dropped.
+    let data: serde_json::Value = crate::registry::client(api_url)
+        .await?
+        .send_json(
+            registry_client::RequestSpec::get(format!("/api/contracts/{id}"))
+                .query_pair("include_stats", "true")
+                .query_pair("include_versions", "true")
+                .query_pair("include_abi", "true"),
+        )
         .await
-        .context("Failed to connect to the registry API")?;
-
-    if status == StatusCode::NOT_FOUND {
-        anyhow::bail!("Contract not found for address or slug: {}", id.bold());
-    } else if !status.is_success() {
-        anyhow::bail!("Failed to fetch contract info: HTTP {status}");
-    }
-
-    let data: serde_json::Value =
-        serde_json::from_str(&body).context("Invalid JSON response from server")?;
+        .map_err(|err| match err {
+            registry_client::Error::NotFound(_) => {
+                anyhow::anyhow!("Contract not found for address or slug: {}", id.bold())
+            }
+            other => anyhow::anyhow!("Failed to fetch contract info: {other}"),
+        })?;
 
     if json_output {
         println!("{}", serde_json::to_string_pretty(&data)?);
@@ -457,33 +453,21 @@ pub async fn run_details(
     network: &str,
     json_output: bool,
 ) -> Result<()> {
-    let url = format!("{}/api/contracts/{}?network={}", api_url, address, network);
-    log::debug!("Fetching contract details from: {}", url);
+    log::debug!("Fetching contract details for {address} on {network}");
 
-    let client = crate::net::client();
-    let response = client
-        .get(&url)
-        .send_with_retry()
+    let contract: serde_json::Value = crate::registry::client(api_url)
+        .await?
+        .send_json(
+            registry_client::RequestSpec::get(format!("/api/contracts/{address}"))
+                .query_pair("network", network),
+        )
         .await
-        .context("Failed to fetch contract details from API")?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        if status == StatusCode::NOT_FOUND {
-            anyhow::bail!("Contract not found for address: {}", address.bold());
-        }
-        let body = response.text().await.unwrap_or_default();
-        anyhow::bail!(
-            "Failed to fetch contract details: HTTP {} - {}",
-            status,
-            body
-        );
-    }
-
-    let contract: serde_json::Value = response
-        .json()
-        .await
-        .context("Failed to parse contract response")?;
+        .map_err(|err| match err {
+            registry_client::Error::NotFound(_) => {
+                anyhow::anyhow!("Contract not found for address: {}", address.bold())
+            }
+            other => anyhow::anyhow!("Failed to fetch contract details: {other}"),
+        })?;
 
     if json_output {
         println!("{}", serde_json::to_string_pretty(&contract)?);

--- a/cli/src/events.rs
+++ b/cli/src/events.rs
@@ -149,7 +149,7 @@ pub async fn query_events(
         std::fs::write(path, csv)?;
         println!(
             "{} Exported {} events to {}",
-            "✓".green(),
+            "[OK]".green(),
             events.len(),
             path
         );
@@ -221,19 +221,12 @@ pub async fn inspect_event_stats(
     let output_str = match format {
         "json" => format_event_stats_json(&stats)?,
         "table" => format_event_stats_table(&stats),
-        _ => anyhow::bail!(
-            "Invalid format: {}. Use 'table' or 'json'",
-            format
-        ),
+        _ => anyhow::bail!("Invalid format: {}. Use 'table' or 'json'", format),
     };
 
     if let Some(path) = output {
         std::fs::write(path, &output_str)?;
-        println!(
-            "{} Event stats exported to {}",
-            "✓".green(),
-            path
-        );
+        println!("{} Event stats exported to {}", "[OK]".green(), path);
     } else {
         println!("{}", output_str);
     }
@@ -258,7 +251,10 @@ fn format_event_stats_json(stats: &EventStats) -> Result<String> {
 fn format_event_stats_table(stats: &EventStats) -> String {
     let mut output = String::new();
 
-    output.push_str(&format!("\n{}\n", "Contract Event Statistics".bold().cyan()));
+    output.push_str(&format!(
+        "\n{}\n",
+        "Contract Event Statistics".bold().cyan()
+    ));
     output.push_str(&format!("{}\n", "=".repeat(80).cyan()));
 
     output.push_str(&format!(
@@ -266,7 +262,11 @@ fn format_event_stats_table(stats: &EventStats) -> String {
         "Contract ID".bold(),
         stats.contract_id.bright_black()
     ));
-    output.push_str(&format!("  {}: {}\n", "Total Events".bold(), stats.total_events));
+    output.push_str(&format!(
+        "  {}: {}\n",
+        "Total Events".bold(),
+        stats.total_events
+    ));
     output.push_str(&format!(
         "  {}: {}\n",
         "Unique Topics".bold(),
@@ -316,4 +316,3 @@ fn format_event_stats_table(stats: &EventStats) -> String {
 
     output
 }
-

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2,4 +2,5 @@ pub mod cache;
 pub mod diagnostic;
 pub mod notification;
 pub mod profiler;
+pub mod search_pagination;
 pub mod table_format;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,6 +60,7 @@ mod package_signing;
 mod patch;
 mod plugins;
 mod profiler;
+mod registry;
 mod release_notes;
 mod shell;
 mod sla;
@@ -2879,6 +2880,8 @@ async fn main() -> Result<()> {
         no_cache: cli.no_cache,
         verbose: cli.verbose,
     });
+    // The shared registry client picks up the same resolved timeout.
+    registry::init(cli.timeout);
 
     // ── Initialise logger ─────────────────────────────────────────────────────
     // -v counts; each level raises verbosity by one step.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -34,6 +34,7 @@ mod contract_interaction;
 mod contract_interfaces;
 mod contract_register;
 mod contract_risk;
+mod contract_search;
 mod contract_update;
 mod contract_verify;
 mod contracts;
@@ -76,6 +77,7 @@ mod wizard;
 mod diagnostic;
 mod output_format;
 mod search;
+mod search_pagination;
 
 use anyhow::Result;
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
@@ -1811,6 +1813,69 @@ pub enum KeysCommands {
 /// Sub-commands for the `contract` group (#522)
 #[derive(Debug, Subcommand)]
 pub enum ContractCommands {
+    /// Search the registry, one page at a time or across every page
+    ///
+    /// Pagination is handled for you: `--all` walks pages until the result set
+    /// runs out or a safety bound is reached, and never loops on a bad
+    /// continuation token. Cursor and offset parameters cannot be combined.
+    ///
+    /// Usage: soroban-registry contract search <QUERY> [--all] [--max-items <N>]
+    ///        [--pagination <cursor|offset>] [--cursor <TOKEN> | --offset <N>]
+    Search {
+        /// Search query
+        query: String,
+
+        /// Filter by network (comma-separated: mainnet,testnet,futurenet)
+        #[arg(long)]
+        networks: Option<String>,
+
+        /// Filter by category (comma-separated: DeFi,NFT)
+        #[arg(long)]
+        category: Option<String>,
+
+        /// Filter by tag (comma-separated: defi,amm)
+        #[arg(long)]
+        tags: Option<String>,
+
+        /// Only show verified contracts
+        #[arg(long)]
+        verified_only: bool,
+
+        /// Results per page (1-100)
+        #[arg(long, default_value = "20")]
+        limit: u32,
+
+        /// Start at this row offset. Offset pagination only — cannot be
+        /// combined with --cursor.
+        #[arg(long, conflicts_with = "cursor")]
+        offset: Option<u64>,
+
+        /// Resume from a continuation token returned by a previous run. Cursor
+        /// pagination only — the token is opaque and must not be edited.
+        #[arg(long)]
+        cursor: Option<String>,
+
+        /// Pagination mode: cursor (stable, no skips or duplicates) or offset
+        /// (relevance ordered). Defaults to cursor for --all, offset otherwise.
+        #[arg(long, value_name = "MODE")]
+        pagination: Option<String>,
+
+        /// Fetch every page, up to --max-items / --max-pages
+        #[arg(long)]
+        all: bool,
+
+        /// Maximum items to fetch with --all (default 1000)
+        #[arg(long)]
+        max_items: Option<u64>,
+
+        /// Maximum pages to fetch with --all (default 100)
+        #[arg(long)]
+        max_pages: Option<u64>,
+
+        /// Output as JSON, including pagination metadata
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Export a signed, offline-verifiable snapshot of a contract (#1116)
     ///
@@ -4177,6 +4242,50 @@ pub async fn dispatch_command(
         },
         // ── Contract verify command (#522) ───────────────────────────────────
         Commands::Contract { action } => match action {
+            ContractCommands::Search {
+                query,
+                networks,
+                category,
+                tags,
+                verified_only,
+                limit,
+                offset,
+                cursor,
+                pagination,
+                all,
+                max_items,
+                max_pages,
+                json,
+            } => {
+                log::debug!(
+                    "Command: contract search | query={:?} all={} limit={} offset={:?} cursor={} pagination={:?}",
+                    query,
+                    all,
+                    limit,
+                    offset,
+                    cursor.is_some(),
+                    pagination
+                );
+                contract_search::run(
+                    &cli.api_url,
+                    search_pagination::SearchOptions {
+                        query,
+                        networks,
+                        category,
+                        tags,
+                        verified_only,
+                        limit,
+                        offset,
+                        cursor,
+                        pagination,
+                        all,
+                        max_items,
+                        max_pages,
+                        json,
+                    },
+                )
+                .await?;
+            }
             ContractCommands::Register { file, batch, json } => {
                 log::debug!(
                     "Command: contract register | file={:?} batch={} json={}",
@@ -5037,12 +5146,6 @@ pub async fn dispatch_command(
             EnvCommands::Switch { environment } => {
                 log::debug!("Command: env switch | environment={}", environment);
                 env::switch_env(&environment)?;
-            }
-        },
-        Commands::Publisher { action } => match action {
-            PublisherCommands::Doctor { json } => {
-                log::debug!("Command: publisher doctor | json={}", json);
-                publisher::doctor(&cli.api_url, json).await?;
             }
         },
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,16 +3,16 @@
 mod analytics;
 mod analyze;
 mod api_key;
-mod auth;
 mod audit_command;
+mod auth;
 mod backup;
-mod batch_ops;
 mod batch_audit;
 mod batch_deploy;
 mod batch_export;
 mod batch_import;
 mod batch_migrate;
 mod batch_notify;
+mod batch_ops;
 mod batch_register;
 mod batch_update;
 mod batch_verify;
@@ -28,13 +28,13 @@ mod contract_audit;
 mod contract_dependency;
 mod contract_deploy;
 mod contract_deprecate;
-mod contract_snapshot;
 mod contract_highlight;
 mod contract_interaction;
 mod contract_interfaces;
 mod contract_register;
 mod contract_risk;
 mod contract_search;
+mod contract_snapshot;
 mod contract_update;
 mod contract_verify;
 mod contracts;
@@ -4511,7 +4511,11 @@ pub async fn dispatch_command(
                 format,
                 summary,
             } => {
-                log::debug!("Command: contract dependency | address={} depth={}", address, depth);
+                log::debug!(
+                    "Command: contract dependency | address={} depth={}",
+                    address,
+                    depth
+                );
                 let fmt = crate::output_format::validate_format(&format)
                     .unwrap_or(crate::output_format::OutputFormat::Table);
                 contract_dependency::run(&cli.api_url, &address, depth, fmt, summary).await?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3050,15 +3050,15 @@ pub async fn dispatch_command(
                 }
                 PluginConfigCommands::Set { name, json } => {
                     plugins::set_plugin_config_json(&name, &json)?;
-                    println!("{} Updated config for {}", "✓".green(), name.bold());
+                    println!("{} Updated config for {}", "[OK]".green(), name.bold());
                 }
                 PluginConfigCommands::Disable { name } => {
                     plugins::set_plugin_enabled(&name, false)?;
-                    println!("{} Disabled {}", "✓".green(), name.bold());
+                    println!("{} Disabled {}", "[OK]".green(), name.bold());
                 }
                 PluginConfigCommands::Enable { name } => {
                     plugins::set_plugin_enabled(&name, true)?;
-                    println!("{} Enabled {}", "✓".green(), name.bold());
+                    println!("{} Enabled {}", "[OK]".green(), name.bold());
                 }
             },
         },

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -1,0 +1,185 @@
+//! Building the shared registry client from CLI globals.
+//!
+//! Every command that talks to the registry goes through here, so the CLI has
+//! exactly one interpretation of authentication, timeouts, retries, pagination
+//! tokens, and API errors — the same one any other consumer of
+//! `soroban-registry-client` gets.
+
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use anyhow::Result;
+use colored::Colorize;
+use registry_client::{ClientConfig, RegistryClient, ResponseCache, RetryPolicy};
+
+/// Identifies this CLI to the registry, so server-side metrics can tell CLI
+/// traffic from SDK traffic.
+pub fn user_agent() -> String {
+    format!("soroban-registry-cli/{}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Per-invocation client settings, set once from the root parser.
+#[derive(Debug, Clone, Copy)]
+pub struct ClientSettings {
+    pub timeout: Duration,
+}
+
+impl Default for ClientSettings {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+static SETTINGS: OnceLock<ClientSettings> = OnceLock::new();
+
+/// Record the resolved global `--timeout` for later client construction.
+pub fn init(timeout_secs: Option<u64>) {
+    let settings = match timeout_secs.filter(|secs| *secs > 0) {
+        Some(secs) => ClientSettings {
+            timeout: Duration::from_secs(secs),
+        },
+        None => ClientSettings::default(),
+    };
+    let _ = SETTINGS.set(settings);
+}
+
+fn settings() -> ClientSettings {
+    SETTINGS.get().copied().unwrap_or_default()
+}
+
+/// The CLI's on-disk HTTP cache, exposed to the client as a cache hook.
+///
+/// Keys are composed exactly as [`crate::cache::http_cache_key`] composes them,
+/// so a response fetched through the client and one fetched through
+/// [`crate::cached_http`] share a cache entry.
+struct CliResponseCache {
+    options: crate::cached_http::HttpCacheOptions,
+}
+
+impl CliResponseCache {
+    fn disk_key(key: &str) -> String {
+        format!("GET:{key}")
+    }
+}
+
+impl ResponseCache for CliResponseCache {
+    fn get(&self, key: &str) -> Option<String> {
+        if self.options.no_cache {
+            if self.options.verbose >= 1 {
+                eprintln!("{} cache bypassed: {}", "↷".yellow(), truncate(key));
+            }
+            return None;
+        }
+
+        match crate::cache::get_http_entry(&Self::disk_key(key)) {
+            Ok(Some(entry)) => {
+                if self.options.verbose >= 1 {
+                    eprintln!(
+                        "{} cache hit (expires in {}s): {}",
+                        "◀".cyan(),
+                        entry.expires_in().unwrap_or(0),
+                        truncate(key)
+                    );
+                }
+                Some(entry.body)
+            }
+            Ok(None) => None,
+            // A broken cache must never fail a command; fall through to the network.
+            Err(err) => {
+                log::debug!("HTTP cache read failed: {err}");
+                None
+            }
+        }
+    }
+
+    fn put(&self, key: &str, body: &str) {
+        if self.options.no_cache {
+            return;
+        }
+        if let Err(err) = crate::cache::set_http_entry(&Self::disk_key(key), body) {
+            log::debug!("HTTP cache write failed: {err}");
+        } else if self.options.verbose >= 1 {
+            eprintln!("{} cached response: {}", "▶".cyan(), truncate(key));
+        }
+    }
+}
+
+fn truncate(key: &str) -> String {
+    if key.len() <= 80 {
+        key.to_string()
+    } else {
+        format!("{}…", &key[..77])
+    }
+}
+
+fn base_config(api_url: &str) -> ClientConfig {
+    ClientConfig::new(api_url)
+        .with_timeout(settings().timeout)
+        .with_user_agent(user_agent())
+        // Reads are retried; mutations only when the call supplies an
+        // idempotency key (see registry_client::RetryPolicy).
+        .with_retry_policy(RetryPolicy::default())
+}
+
+/// A client carrying the stored session credential, if the user is logged in.
+///
+/// Reads are served from the CLI's HTTP cache when one is warm, honouring
+/// `--no-cache`.
+pub async fn client(api_url: &str) -> Result<RegistryClient> {
+    let token = crate::auth::access_token_for_requests(api_url).await?;
+    let cache = Arc::new(CliResponseCache {
+        options: crate::cached_http::cache_options(),
+    });
+
+    Ok(RegistryClient::from_config(base_config(api_url))?
+        .with_bearer_token(token)
+        .with_response_cache(cache))
+}
+
+/// A client that always goes to the network, for reads whose freshness matters
+/// and for anything that mutates.
+pub async fn uncached_client(api_url: &str) -> Result<RegistryClient> {
+    let token = crate::auth::access_token_for_requests(api_url).await?;
+    Ok(RegistryClient::from_config(base_config(api_url))?.with_bearer_token(token))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_user_agent_names_the_cli_and_its_version() {
+        let agent = user_agent();
+        assert!(agent.starts_with("soroban-registry-cli/"), "{agent}");
+        assert!(agent.len() > "soroban-registry-cli/".len(), "{agent}");
+    }
+
+    #[test]
+    fn cache_keys_match_the_cli_http_cache_scheme() {
+        let composed = "http://registry.test/api/contracts?limit=20";
+        assert_eq!(
+            CliResponseCache::disk_key(composed),
+            crate::cache::http_cache_key(
+                "http://registry.test/api/contracts",
+                &[("limit", "20".to_string())]
+            ),
+            "the client and cached_http must share cache entries"
+        );
+    }
+
+    #[test]
+    fn a_zero_or_missing_timeout_falls_back_to_the_default() {
+        // `init` is process-global, so assert on the pure mapping instead.
+        assert_eq!(ClientSettings::default().timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn long_cache_keys_are_truncated_for_logging() {
+        let key = "x".repeat(200);
+        let rendered = truncate(&key);
+        assert!(rendered.chars().count() <= 81, "{}", rendered.len());
+        assert!(rendered.ends_with('…'));
+    }
+}

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -68,7 +68,7 @@ impl ResponseCache for CliResponseCache {
     fn get(&self, key: &str) -> Option<String> {
         if self.options.no_cache {
             if self.options.verbose >= 1 {
-                eprintln!("{} cache bypassed: {}", "↷".yellow(), truncate(key));
+                eprintln!("{} bypassed: {}", "[cache]".yellow(), truncate(key));
             }
             return None;
         }
@@ -77,8 +77,8 @@ impl ResponseCache for CliResponseCache {
             Ok(Some(entry)) => {
                 if self.options.verbose >= 1 {
                     eprintln!(
-                        "{} cache hit (expires in {}s): {}",
-                        "◀".cyan(),
+                        "{} hit (expires in {}s): {}",
+                        "[cache]".cyan(),
                         entry.expires_in().unwrap_or(0),
                         truncate(key)
                     );
@@ -101,7 +101,7 @@ impl ResponseCache for CliResponseCache {
         if let Err(err) = crate::cache::set_http_entry(&Self::disk_key(key), body) {
             log::debug!("HTTP cache write failed: {err}");
         } else if self.options.verbose >= 1 {
-            eprintln!("{} cached response: {}", "▶".cyan(), truncate(key));
+            eprintln!("{} stored: {}", "[cache]".cyan(), truncate(key));
         }
     }
 }

--- a/cli/src/search_pagination.rs
+++ b/cli/src/search_pagination.rs
@@ -1,0 +1,292 @@
+//! Pagination decisions for `contract search`.
+//!
+//! Turning command-line flags into a `registry_client` request and a set of
+//! safety bounds is pure logic, kept separate from the command's HTTP and
+//! rendering code in [`crate::contract_search`] so it can be tested directly.
+
+use anyhow::{anyhow, Result};
+use registry_client::{ContractSearchRequest, PageLimits, PaginationMode};
+use std::collections::HashSet;
+use std::str::FromStr;
+
+/// Item budget for `--all` when the caller does not pick one. `--all` is always
+/// bounded: an unbounded walk over a registry that is still being written to
+/// need never terminate.
+pub const DEFAULT_ALL_MAX_ITEMS: u64 = 1_000;
+/// Page budget for `--all` when the caller does not pick one.
+pub const DEFAULT_ALL_MAX_PAGES: u64 = 100;
+
+/// Networks the registry accepts as filter values.
+const KNOWN_NETWORKS: [&str; 3] = ["mainnet", "testnet", "futurenet"];
+
+/// Everything `contract search` accepts.
+#[derive(Debug, Clone)]
+pub struct SearchOptions {
+    pub query: String,
+    pub networks: Option<String>,
+    pub category: Option<String>,
+    pub tags: Option<String>,
+    pub verified_only: bool,
+    /// Items per page.
+    pub limit: u32,
+    /// Starting offset — offset pagination only.
+    pub offset: Option<u64>,
+    /// Continuation token — cursor pagination only.
+    pub cursor: Option<String>,
+    /// `cursor` or `offset`; inferred when absent.
+    pub pagination: Option<String>,
+    pub all: bool,
+    pub max_items: Option<u64>,
+    pub max_pages: Option<u64>,
+    pub json: bool,
+}
+
+impl SearchOptions {
+    /// The `--max-items` bound a `--all` walk runs under.
+    pub fn effective_max_items(&self) -> u64 {
+        self.max_items.unwrap_or(DEFAULT_ALL_MAX_ITEMS)
+    }
+
+    /// The `--max-pages` bound a `--all` walk runs under.
+    pub fn effective_max_pages(&self) -> u64 {
+        self.max_pages.unwrap_or(DEFAULT_ALL_MAX_PAGES)
+    }
+}
+
+/// Pick the pagination scheme.
+///
+/// An explicit `--pagination` always wins. Otherwise: a `--cursor` implies a
+/// cursor walk, an `--offset` implies an offset walk, `--all` defaults to cursor
+/// pagination (stable under concurrent writes, so a full walk cannot skip or
+/// repeat rows), and a single page defaults to offset pagination (relevance
+/// ordered, which is what a one-shot search should show).
+pub fn resolve_mode(options: &SearchOptions) -> Result<PaginationMode> {
+    if let Some(mode) = options.pagination.as_deref() {
+        return PaginationMode::from_str(mode).map_err(|err| anyhow!("{err}"));
+    }
+    if options.cursor.is_some() {
+        return Ok(PaginationMode::Cursor);
+    }
+    if options.offset.is_some() {
+        return Ok(PaginationMode::Offset);
+    }
+    Ok(if options.all {
+        PaginationMode::Cursor
+    } else {
+        PaginationMode::Offset
+    })
+}
+
+/// Build the client request, rejecting anything the registry could only serve
+/// by silently dropping a filter or a page boundary.
+pub fn build_request(
+    options: &SearchOptions,
+    mode: PaginationMode,
+) -> Result<ContractSearchRequest> {
+    let request = ContractSearchRequest::new(options.query.clone(), mode)
+        .with_networks(normalize_networks(options.networks.as_deref())?)
+        .with_categories(split_filter(options.category.as_deref()))
+        .with_tags(split_filter(options.tags.as_deref()))
+        .with_verified_only(options.verified_only)
+        .with_cursor(options.cursor.clone())
+        .with_offset(options.offset);
+
+    // Surfaces mixed cursor/offset pagination (and an empty query) before any
+    // request is sent.
+    request
+        .validate()
+        .map_err(|err| anyhow!("Failed to search contracts: {err}"))?;
+
+    Ok(request)
+}
+
+/// Safety bounds for the walk. Without `--all` this is exactly one page, which
+/// keeps single-page behaviour identical to a plain search.
+pub fn build_limits(options: &SearchOptions) -> PageLimits {
+    if !options.all {
+        return PageLimits::single_page(options.limit);
+    }
+
+    PageLimits::default()
+        .with_page_size(options.limit)
+        .with_max_items(Some(options.effective_max_items()))
+        .with_max_pages(Some(options.effective_max_pages()))
+}
+
+/// Canonicalise and de-duplicate network filters, rejecting unknown values here
+/// rather than letting the server silently drop them.
+pub fn normalize_networks(networks: Option<&str>) -> Result<Vec<String>> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+
+    for value in split_filter(networks) {
+        let canonical = value.to_lowercase();
+        if !KNOWN_NETWORKS.contains(&canonical.as_str()) {
+            anyhow::bail!(
+                "Invalid network: {value}. Allowed values: {}",
+                KNOWN_NETWORKS.join(", ")
+            );
+        }
+        if seen.insert(canonical.clone()) {
+            normalized.push(canonical);
+        }
+    }
+
+    Ok(normalized)
+}
+
+/// Split a comma-separated filter, trimming blanks.
+pub fn split_filter(value: Option<&str>) -> Vec<String> {
+    value
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|part| !part.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options() -> SearchOptions {
+        SearchOptions {
+            query: "swap".to_string(),
+            networks: None,
+            category: None,
+            tags: None,
+            verified_only: false,
+            limit: 20,
+            offset: None,
+            cursor: None,
+            pagination: None,
+            all: false,
+            max_items: None,
+            max_pages: None,
+            json: false,
+        }
+    }
+
+    #[test]
+    fn a_single_page_search_defaults_to_offset_pagination() {
+        assert_eq!(resolve_mode(&options()).unwrap(), PaginationMode::Offset);
+    }
+
+    #[test]
+    fn all_defaults_to_stable_cursor_pagination() {
+        let mut opts = options();
+        opts.all = true;
+        assert_eq!(resolve_mode(&opts).unwrap(), PaginationMode::Cursor);
+    }
+
+    #[test]
+    fn an_explicit_mode_wins() {
+        let mut opts = options();
+        opts.all = true;
+        opts.pagination = Some("offset".to_string());
+        assert_eq!(resolve_mode(&opts).unwrap(), PaginationMode::Offset);
+
+        opts.pagination = Some("nonsense".to_string());
+        assert!(resolve_mode(&opts).is_err());
+    }
+
+    #[test]
+    fn a_cursor_or_offset_flag_selects_the_matching_mode() {
+        let mut opts = options();
+        opts.cursor = Some("token".to_string());
+        assert_eq!(resolve_mode(&opts).unwrap(), PaginationMode::Cursor);
+
+        let mut opts = options();
+        opts.offset = Some(40);
+        assert_eq!(resolve_mode(&opts).unwrap(), PaginationMode::Offset);
+    }
+
+    #[test]
+    fn a_cursor_cannot_be_combined_with_an_offset() {
+        let mut opts = options();
+        opts.cursor = Some("token".to_string());
+        opts.offset = Some(40);
+
+        let err = build_request(&opts, PaginationMode::Cursor)
+            .expect_err("mixed pagination must be rejected");
+        assert!(err.to_string().contains("cannot be combined"), "{err}");
+    }
+
+    #[test]
+    fn cursor_mode_rejects_an_offset_even_without_a_cursor() {
+        let mut opts = options();
+        opts.pagination = Some("cursor".to_string());
+        opts.offset = Some(40);
+
+        let mode = resolve_mode(&opts).unwrap();
+        assert!(build_request(&opts, mode).is_err());
+    }
+
+    #[test]
+    fn a_single_page_search_fetches_exactly_one_page() {
+        let limits = build_limits(&options());
+        assert_eq!(limits.max_pages, Some(1));
+        assert_eq!(limits.max_items, None);
+        assert_eq!(limits.page_size, 20);
+    }
+
+    #[test]
+    fn all_is_always_bounded() {
+        let mut opts = options();
+        opts.all = true;
+        let limits = build_limits(&opts);
+        assert_eq!(limits.max_items, Some(DEFAULT_ALL_MAX_ITEMS));
+        assert_eq!(limits.max_pages, Some(DEFAULT_ALL_MAX_PAGES));
+
+        opts.max_items = Some(25);
+        opts.max_pages = Some(3);
+        let limits = build_limits(&opts);
+        assert_eq!(limits.max_items, Some(25));
+        assert_eq!(limits.max_pages, Some(3));
+    }
+
+    #[test]
+    fn network_filters_are_canonicalised_and_deduplicated() {
+        let networks = normalize_networks(Some(" testnet, MAINNET ,testnet")).unwrap();
+        assert_eq!(networks, vec!["testnet", "mainnet"]);
+    }
+
+    #[test]
+    fn an_unknown_network_filter_is_rejected_locally() {
+        let err = normalize_networks(Some("testnet,not-a-network"))
+            .expect_err("unknown networks must fail before the request");
+        assert!(err.to_string().contains("not-a-network"));
+    }
+
+    #[test]
+    fn filter_lists_are_split_and_trimmed() {
+        assert_eq!(
+            split_filter(Some("DeFi, NFT ,,lending")),
+            vec!["DeFi", "NFT", "lending"]
+        );
+        assert!(split_filter(None).is_empty());
+    }
+
+    #[test]
+    fn an_empty_query_is_rejected_before_any_request() {
+        let mut opts = options();
+        opts.query = "  ".to_string();
+        assert!(build_request(&opts, PaginationMode::Offset).is_err());
+    }
+
+    #[test]
+    fn tag_filters_route_to_the_full_text_endpoint() {
+        let mut opts = options();
+        opts.tags = Some("defi,amm".to_string());
+        let request = build_request(&opts, PaginationMode::Offset).expect("valid request");
+        assert_eq!(
+            request.effective_endpoint(),
+            registry_client::SearchEndpoint::FullText,
+            "only /api/search filters by tag"
+        );
+        assert_eq!(request.tags, vec!["defi", "amm"]);
+    }
+}

--- a/cli/tests/contract_search_integration.rs
+++ b/cli/tests/contract_search_integration.rs
@@ -1,0 +1,579 @@
+// tests/contract_search_integration.rs
+//
+// End-to-end tests for `soroban-registry contract search`: the real binary is
+// run against a mock registry, so these cover the whole path — flag parsing,
+// pagination mode selection, continuation handling, safety bounds and the JSON
+// pagination metadata.
+
+use std::process::{Command, Output};
+
+use serde_json::{json, Value};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const BINARY: &str = env!("CARGO_BIN_EXE_soroban-registry");
+
+/// Run the CLI against `api_url` and return its output.
+async fn run_cli(api_url: &str, args: &[&str]) -> Output {
+    let mut command = Command::new(BINARY);
+    command
+        .arg("--api-url")
+        .arg(api_url)
+        .arg("contract")
+        .arg("search");
+    command.args(args);
+
+    // The mock server needs the runtime while the child process runs, so do the
+    // blocking wait off the async worker.
+    tokio::task::spawn_blocking(move || command.output().expect("failed to run the CLI"))
+        .await
+        .expect("CLI task panicked")
+}
+
+fn stdout_json(output: &Output) -> Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).unwrap_or_else(|err| {
+        panic!(
+            "expected JSON on stdout ({err}).\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn hit(name: &str) -> Value {
+    json!({
+        "id": format!("11111111-1111-1111-1111-1111111111{:02}", name.len()),
+        "contract_id": format!("CA{}", name.to_uppercase()),
+        "name": name,
+        "description": format!("{name} contract"),
+        "category": "DeFi",
+        "network": "testnet",
+        "is_verified": true,
+        "is_deprecated": false,
+        "deprecation_status": "active",
+        "relevance_score": 0.5
+    })
+}
+
+// ── Flag surface ──────────────────────────────────────────────────────────────
+
+#[test]
+fn help_documents_the_pagination_flags() {
+    let output = Command::new(BINARY)
+        .args(["contract", "search", "--help"])
+        .output()
+        .expect("failed to run the CLI");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for flag in [
+        "--all",
+        "--max-items",
+        "--max-pages",
+        "--cursor",
+        "--offset",
+        "--pagination",
+        "--json",
+    ] {
+        assert!(stdout.contains(flag), "help should document {flag}");
+    }
+}
+
+#[test]
+fn a_cursor_and_an_offset_cannot_be_passed_together() {
+    let output = Command::new(BINARY)
+        .args([
+            "contract", "search", "swap", "--cursor", "token", "--offset", "20",
+        ])
+        .output()
+        .expect("failed to run the CLI");
+
+    assert!(
+        !output.status.success(),
+        "mixed pagination must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unknown_network_filter_fails_before_any_request() {
+    let server = MockServer::start().await;
+
+    let output = run_cli(
+        &server.uri(),
+        &["swap", "--networks", "testnet,not-a-network", "--json"],
+    )
+    .await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not-a-network"),
+        "unexpected stderr: {stderr}"
+    );
+    assert!(
+        server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty(),
+        "no request should reach the registry"
+    );
+}
+
+// ── Single page (unchanged one-page behaviour) ─────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_single_page_search_makes_one_offset_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/contracts/search"))
+        .and(query_param("offset", "0"))
+        .and(query_param("limit", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "query": "swap",
+            "total": 5,
+            "limit": 2,
+            "offset": 0,
+            "took_ms": 3,
+            "backend": "elasticsearch",
+            "results": [hit("aa"), hit("bb")],
+            "facets": {"categories": [], "networks": [], "tags": []}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["swap", "--limit", "2", "--json"]).await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body = stdout_json(&output);
+    assert_eq!(body["count"], 2);
+    assert_eq!(body["pagination"]["mode"], "offset");
+    assert_eq!(body["pagination"]["pages_fetched"], 1);
+    assert_eq!(body["pagination"]["total"], 5);
+    assert_eq!(body["pagination"]["complete"], false);
+    assert_eq!(body["pagination"]["stop_reason"], "single_page");
+    assert_eq!(body["pagination"]["next_offset"], 2);
+    assert!(body["pagination"]["next_cursor"].is_null());
+    assert!(
+        body["pagination"]["max_items"].is_null(),
+        "bounds only apply to --all"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_cursor_page_can_be_resumed_from_a_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", "tok-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("cc")],
+            "total": 3,
+            "took_ms": 1
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["swap", "--cursor", "tok-2", "--json"]).await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body = stdout_json(&output);
+    assert_eq!(body["count"], 1);
+    assert_eq!(body["pagination"]["mode"], "cursor");
+    assert_eq!(body["pagination"]["complete"], true);
+    assert_eq!(body["pagination"]["stop_reason"], "exhausted");
+}
+
+// ── `--all` walks ─────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn all_walks_every_page_to_the_end_of_the_result_set() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", ""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("aa"), hit("bb")],
+            "total": 3,
+            "next_cursor": "tok-2"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", "tok-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("cc")],
+            "total": 3
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["swap", "--all", "--limit", "2", "--json"]).await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body = stdout_json(&output);
+    let names: Vec<&str> = body["contracts"]
+        .as_array()
+        .expect("contracts array")
+        .iter()
+        .map(|hit| hit["name"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["aa", "bb", "cc"],
+        "pages arrive in server order"
+    );
+    assert_eq!(body["count"], 3);
+    assert_eq!(
+        body["pagination"]["mode"], "cursor",
+        "--all defaults to cursor pagination"
+    );
+    assert_eq!(body["pagination"]["pages_fetched"], 2);
+    assert_eq!(body["pagination"]["total"], 3);
+    assert_eq!(body["pagination"]["complete"], true);
+    assert_eq!(body["pagination"]["stop_reason"], "exhausted");
+    assert!(body["pagination"]["next_cursor"].is_null());
+    assert_eq!(
+        body["pagination"]["max_items"], 1000,
+        "--all is bounded by default"
+    );
+    assert_eq!(body["pagination"]["max_pages"], 100);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn all_stops_at_max_items_and_reports_where_to_resume() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", ""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("aa"), hit("bb")],
+            "total": 500,
+            "next_cursor": "tok-2"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", "tok-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("cc")],
+            "total": 500,
+            "next_cursor": "tok-3"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "swap",
+            "--all",
+            "--limit",
+            "2",
+            "--max-items",
+            "3",
+            "--json",
+        ],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body = stdout_json(&output);
+    assert_eq!(body["count"], 3, "the item bound is respected exactly");
+    assert_eq!(body["pagination"]["stop_reason"], "max_items");
+    assert_eq!(body["pagination"]["complete"], false);
+    assert_eq!(body["pagination"]["total"], 500);
+    assert_eq!(body["pagination"]["max_items"], 3);
+    assert_eq!(
+        body["pagination"]["next_cursor"], "tok-3",
+        "a bounded walk says where to resume"
+    );
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        2,
+        "no page is fetched beyond the bound"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn all_stops_at_max_pages() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", ""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("aa")],
+            "total": 500,
+            "next_cursor": "tok-2"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "swap",
+            "--all",
+            "--limit",
+            "1",
+            "--max-pages",
+            "1",
+            "--json",
+        ],
+    )
+    .await;
+
+    assert!(output.status.success());
+    let body = stdout_json(&output);
+    assert_eq!(body["count"], 1);
+    assert_eq!(body["pagination"]["pages_fetched"], 1);
+    assert_eq!(body["pagination"]["stop_reason"], "max_pages");
+    assert_eq!(body["pagination"]["max_pages"], 1);
+    assert_eq!(body["pagination"]["next_cursor"], "tok-2");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_repeated_cursor_fails_instead_of_looping() {
+    let server = MockServer::start().await;
+    // Every request answers with the same continuation token.
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("aa")],
+            "total": 500,
+            "next_cursor": "stuck"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["swap", "--all", "--limit", "1", "--json"]).await;
+
+    assert!(
+        !output.status.success(),
+        "a looping server must fail loudly"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("repeated a pagination cursor"),
+        "unexpected stderr: {stderr}"
+    );
+    // Two requests: the first page, then the one that revealed the repeat.
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        2
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_malformed_cursor_reports_the_registry_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "code": "INVALID_CURSOR",
+            "message": "The provided pagination cursor is invalid"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["swap", "--cursor", "garbage", "--json"]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("INVALID_CURSOR"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_pages_with_a_continuation_token_do_not_loop_forever() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", ""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [],
+            "total": 9,
+            "next_cursor": "tok-a"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", "tok-a"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [],
+            "total": 9,
+            "next_cursor": "tok-b"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", "tok-b"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [],
+            "total": 9,
+            "next_cursor": "tok-c"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["swap", "--all", "--limit", "2", "--json"]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("consecutive empty page"),
+        "unexpected stderr: {stderr}"
+    );
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        3,
+        "the walk stops rather than requesting more empty pages"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn filters_are_normalised_and_repeated_on_every_page() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("networks", "testnet,mainnet"))
+        .and(query_param("categories", "DeFi,NFT"))
+        .and(query_param("tags", "amm"))
+        .and(query_param("verified_only", "true"))
+        .and(query_param("cursor", ""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("aa")],
+            "total": 2,
+            "next_cursor": "tok-2"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("networks", "testnet,mainnet"))
+        .and(query_param("categories", "DeFi,NFT"))
+        .and(query_param("tags", "amm"))
+        .and(query_param("verified_only", "true"))
+        .and(query_param("cursor", "tok-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("bb")],
+            "total": 2
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "swap",
+            "--all",
+            "--limit",
+            "1",
+            "--networks",
+            " TESTNET , mainnet ,testnet",
+            "--category",
+            "DeFi, NFT",
+            "--tags",
+            "amm",
+            "--verified-only",
+            "--json",
+        ],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body = stdout_json(&output);
+    assert_eq!(body["count"], 2);
+    assert_eq!(body["pagination"]["complete"], true);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_explicit_pagination_mode_overrides_the_default() {
+    let server = MockServer::start().await;
+    // Cursor mode forced for a single page: the full-text endpoint is used and an
+    // empty cursor opens the walk.
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", ""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("aa")],
+            "total": 1
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &["swap", "--pagination", "cursor", "--limit", "1", "--json"],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(stdout_json(&output)["pagination"]["mode"], "cursor");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn human_output_shows_pagination_metadata() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("cursor", ""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contracts": [hit("aa")],
+            "total": 42,
+            "next_cursor": "tok-2"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &["swap", "--all", "--limit", "1", "--max-items", "1"],
+    )
+    .await;
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("of 42 match(es)"), "stdout: {stdout}");
+    assert!(stdout.contains("cursor pagination"), "stdout: {stdout}");
+    assert!(stdout.contains("--max-items bound (1)"), "stdout: {stdout}");
+    assert!(stdout.contains("--cursor tok-2"), "stdout: {stdout}");
+}

--- a/cli/tests/registry_client_integration.rs
+++ b/cli/tests/registry_client_integration.rs
@@ -1,0 +1,531 @@
+// tests/registry_client_integration.rs
+//
+// The CLI call sites migrated onto `soroban-registry-client`: list, search,
+// metadata read/update, and publish. The real binary runs against a mock
+// registry, so these cover what the client sends (path, query, body, headers)
+// and how the typed error taxonomy reaches the user.
+
+use std::process::{Command, Output};
+
+use serde_json::{json, Value};
+use wiremock::matchers::{body_json_string, method, path, query_param};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+const BINARY: &str = env!("CARGO_BIN_EXE_soroban-registry");
+
+/// Run the CLI against `api_url`, always bypassing the on-disk cache so one run
+/// means one request.
+async fn run_cli(api_url: &str, args: &[&str]) -> Output {
+    let mut command = Command::new(BINARY);
+    command.arg("--api-url").arg(api_url).arg("--no-cache");
+    command.args(args);
+
+    tokio::task::spawn_blocking(move || command.output().expect("failed to run the CLI"))
+        .await
+        .expect("CLI task panicked")
+}
+
+fn stdout_json(output: &Output) -> Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).unwrap_or_else(|err| {
+        panic!(
+            "expected JSON on stdout ({err}).\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+/// A `Contract` as the registry serializes it.
+fn contract(index: usize) -> Value {
+    json!({
+        "id": format!("11111111-1111-1111-1111-{:012}", index),
+        "contract_id": format!("CA{:054}", index),
+        "wasm_hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        "name": format!("contract-{index}"),
+        "slug": format!("contract-{index}"),
+        "description": "a contract",
+        "publisher_id": "22222222-2222-2222-2222-222222222222",
+        "network": "testnet",
+        "is_verified": index % 2 == 0,
+        "verification_status": "unverified",
+        "category": "DeFi",
+        "tags": [{"id": "33333333-3333-3333-3333-333333333333", "name": "amm", "color": "#3b82f6"}],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-02T00:00:00Z",
+        "verified_at": null,
+        "deployed_at": null,
+        "verified_by": null,
+        "verification_notes": null,
+        "last_accessed_at": null,
+        "health_score": 80,
+        "is_maintenance": false,
+        "logical_id": null,
+        "network_configs": null,
+        "organization_id": null,
+        "visibility": "public",
+        "usage_count": 3
+    })
+}
+
+fn contract_page(count: usize, total: i64) -> Value {
+    json!({
+        "items": (0..count).map(contract).collect::<Vec<_>>(),
+        "total": total,
+        "page": 1,
+        "per_page": count.max(1),
+        "pages": 1
+    })
+}
+
+// ── list ──────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_json_output_is_built_from_typed_models() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .and(query_param("limit", "2"))
+        .and(query_param("offset", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contract_page(2, 9)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["list", "--limit", "2", "--format", "json"]).await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body = stdout_json(&output);
+    assert_eq!(body["count"], 2);
+    assert_eq!(body["contracts"][0]["name"], "contract-0");
+    assert_eq!(body["contracts"][0]["network"], "testnet");
+    assert_eq!(body["contracts"][0]["tags"][0], "amm");
+    assert_eq!(body["contracts"][0]["health_score"], 80);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_sends_normalised_filters_as_typed_query_params() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .and(query_param("networks", "testnet,mainnet"))
+        .and(query_param("categories", "DeFi"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contract_page(1, 1)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "list",
+            "--networks",
+            " TESTNET , mainnet ",
+            "--category",
+            "DeFi",
+            "--format",
+            "json",
+        ],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_table_output_reports_the_server_total() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contract_page(2, 41)))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["list", "--limit", "2"]).await;
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Contract Registry"), "{stdout}");
+    assert!(stdout.contains("of 41 contracts"), "{stdout}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_surfaces_an_unauthorized_response_clearly() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "code": "Unauthorized",
+            "message": "Session expired",
+            "request_id": "req-77"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["list"]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Failed to list contracts"), "{stderr}");
+    assert!(
+        stderr.contains("Unauthorized") || stderr.contains("Session expired"),
+        "the server's own error should reach the user: {stderr}"
+    );
+    assert!(
+        stderr.contains("req-77"),
+        "request id aids support: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_still_rejects_an_invalid_network_locally() {
+    let server = MockServer::start().await;
+
+    let output = run_cli(&server.uri(), &["list", "--networks", "bogusnet"]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Invalid network"), "{stderr}");
+    assert!(!stderr.contains("Failed to list contracts"), "{stderr}");
+    assert!(
+        server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty(),
+        "nothing should reach the registry"
+    );
+}
+
+// ── search ────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_sends_the_query_and_filters() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .and(query_param("query", "swap"))
+        .and(query_param("verified_only", "true"))
+        .and(query_param("categories", "DeFi"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contract_page(2, 2)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "search",
+            "swap",
+            "--verified-only",
+            "--category",
+            "DeFi",
+            "--json",
+        ],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(stdout_json(&output)["count"], 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_maps_sort_updated_onto_the_api_sort_field() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .and(query_param("sort_by", "updated_at"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contract_page(1, 1)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &["search", "swap", "--sort", "updated", "--json"],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_reports_a_server_fault_without_losing_its_context() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .respond_with(ResponseTemplate::new(503).set_body_json(json!({
+            "code": "ServiceUnavailable",
+            "message": "database down"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["search", "swap"]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Failed to search contracts"), "{stderr}");
+    assert!(
+        stderr.contains("registry unavailable") || stderr.contains("503"),
+        "{stderr}"
+    );
+}
+
+// ── metadata ──────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_metadata_update_reads_then_patches_with_an_idempotency_key() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/contracts/CA000000000000000000000000000000000000000000000000000001",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contract(1)))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("PATCH"))
+        .and(path(
+            "/api/contracts/11111111-1111-1111-1111-000000000001/metadata",
+        ))
+        // The client sends the API's own request type, so unchanged fields go
+        // out as explicit nulls; the handler treats null and absent alike.
+        .and(body_json_string(
+            r#"{"name":"renamed","description":null,"category":null,"tags":null,"user_id":null}"#,
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contract(1)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "contract",
+            "update",
+            "CA000000000000000000000000000000000000000000000000000001",
+            "--name",
+            "renamed",
+            "--yes",
+            "--json",
+        ],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let patch = server
+        .received_requests()
+        .await
+        .expect("requests")
+        .into_iter()
+        .find(|request: &Request| request.method.as_str() == "PATCH")
+        .expect("a PATCH was sent");
+    let key = patch
+        .headers
+        .get("idempotency-key")
+        .expect("metadata updates carry an idempotency key")
+        .to_str()
+        .expect("ascii");
+    assert!(key.starts_with("cli-metadata-"), "{key}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_missing_contract_is_reported_as_not_found() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts/CAMISSING"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "code": "NotFound",
+            "message": "no such contract"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &["contract", "update", "CAMISSING", "--name", "x", "--yes"],
+    )
+    .await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Contract not found: CAMISSING"), "{stderr}");
+}
+
+// ── publish ───────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn publish_posts_the_typed_request_with_an_idempotency_key() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/contracts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contract(4)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "publish",
+            "--contract-id",
+            "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+            "--name",
+            "swap-router",
+            "--publisher",
+            "GDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+            "--network",
+            "testnet",
+            "--category",
+            "DeFi",
+            "--tags",
+            "amm,dex",
+            "--skip-tests",
+        ],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("published successfully"), "{stdout}");
+
+    let request = server
+        .received_requests()
+        .await
+        .expect("requests")
+        .into_iter()
+        .next()
+        .expect("a POST was sent");
+    let body: Value = serde_json::from_slice(&request.body).expect("json body");
+    assert_eq!(
+        body["contract_id"],
+        "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+    );
+    assert_eq!(body["network"], "testnet");
+    assert_eq!(body["tags"], json!(["amm", "dex"]));
+
+    let key = request
+        .headers
+        .get("idempotency-key")
+        .expect("a publish must carry an idempotency key so a retry cannot double-register")
+        .to_str()
+        .expect("ascii");
+    assert!(key.starts_with("cli-publish-"), "{key}");
+    assert!(request.headers.get("user-agent").is_some());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn publish_reports_a_conflict_with_the_server_code() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/contracts"))
+        .respond_with(ResponseTemplate::new(409).set_body_json(json!({
+            "code": "ContractAlreadyExists",
+            "message": "already registered"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "publish",
+            "--contract-id",
+            "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+            "--name",
+            "swap-router",
+            "--publisher",
+            "GDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+            "--skip-tests",
+        ],
+    )
+    .await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Failed to publish"), "{stderr}");
+    assert!(stderr.contains("ContractAlreadyExists"), "{stderr}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_failing_publish_is_attempted_once_per_run() {
+    let server = MockServer::start().await;
+    // Every attempt fails with a retryable status; the publish must not be
+    // repeated within a single run beyond the idempotency-key allowance.
+    Mock::given(method("POST"))
+        .and(path("/api/contracts"))
+        .respond_with(
+            ResponseTemplate::new(503).set_body_json(json!({"code": "ServiceUnavailable"})),
+        )
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "publish",
+            "--contract-id",
+            "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+            "--name",
+            "swap-router",
+            "--publisher",
+            "GDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+            "--skip-tests",
+        ],
+    )
+    .await;
+
+    assert!(!output.status.success());
+    let attempts = server.received_requests().await.unwrap_or_default().len();
+    assert!(
+        (1..=3).contains(&attempts),
+        "a keyed publish may retry, but stays bounded: {attempts}"
+    );
+    let keys: Vec<String> = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|request| {
+            request
+                .headers
+                .get("idempotency-key")
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string)
+        })
+        .collect();
+    assert_eq!(
+        keys.len(),
+        attempts,
+        "every attempt carries the key, so the registry can dedupe"
+    );
+    assert!(
+        keys.windows(2).all(|pair| pair[0] == pair[1]),
+        "the key must not change between attempts: {keys:?}"
+    );
+}

--- a/cli/tests/registry_client_integration.rs
+++ b/cli/tests/registry_client_integration.rs
@@ -529,3 +529,117 @@ async fn a_failing_publish_is_attempted_once_per_run() {
         "the key must not change between attempts: {keys:?}"
     );
 }
+
+// ── contract reads (info / contract details) ──────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn info_passes_the_server_document_through_verbatim() {
+    let server = MockServer::start().await;
+    // A field the client's typed models do not know about must survive `--json`.
+    let mut body = contract(7);
+    body["stats"] = json!({"deployments_count": 12, "interactions_count": 340});
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/contracts/CA000000000000000000000000000000000000000000000000000007",
+        ))
+        .and(query_param("include_stats", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "info",
+            "CA000000000000000000000000000000000000000000000000000007",
+            "--json",
+        ],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let rendered = stdout_json(&output);
+    assert_eq!(rendered["name"], "contract-7");
+    assert_eq!(
+        rendered["stats"]["deployments_count"], 12,
+        "unknown fields must not be dropped by the client"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn info_reports_a_missing_contract_clearly() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts/CAMISSING"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "code": "ContractNotFound",
+            "message": "No contract found"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["info", "CAMISSING"]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Contract not found for address or slug"),
+        "{stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn contract_details_sends_the_network_filter_and_identifies_the_cli() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/contracts/CA000000000000000000000000000000000000000000000000000005",
+        ))
+        .and(query_param("network", "testnet"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contract(5)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "contract",
+            "details",
+            "CA000000000000000000000000000000000000000000000000000005",
+            "--network",
+            "testnet",
+            "--json",
+        ],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let request = server
+        .received_requests()
+        .await
+        .expect("requests")
+        .into_iter()
+        .next()
+        .expect("a GET was sent");
+    let user_agent = request
+        .headers
+        .get("user-agent")
+        .expect("every request identifies the caller")
+        .to_str()
+        .expect("ascii");
+    assert!(
+        user_agent.starts_with("soroban-registry-cli/"),
+        "{user_agent}"
+    );
+}

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -95,11 +95,14 @@ removed elsewhere in the result set.
   infinite scroll): use **cursor** pagination.
 - **Relevance-ranked results or jump-to-page UIs**: use **offset** pagination.
 
-## Client-side pagination (`registry_client`)
+## Client-side pagination (`soroban-registry-client`)
 
 Everything above is the HTTP contract. Consumers should not implement it by
-hand: the `registry_client` crate (`backend/registry_client`) wraps both modes
-in one typed abstraction, and the CLI's `contract search` command uses it.
+hand: the `soroban-registry-client` crate (`backend/registry_client`, imported
+as `registry_client`) wraps both modes in one typed abstraction, and the CLI
+uses it for search, list, metadata and publish. See
+[registry-client.md](./registry-client.md) for the rest of that crate —
+configuration, authentication, retries, idempotency and the error taxonomy.
 
 ```rust
 use registry_client::{ContractSearchRequest, PageLimits, RegistryClient};

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -8,9 +8,9 @@ contract for both.
 
 | Endpoint | Offset | Cursor |
 | --- | --- | --- |
-| `GET /api/contracts` (list) | ✅ | ✅ |
-| `GET /api/search` (full-text) | ✅ | ✅ |
-| `GET /api/v1/contracts/search` (advanced) | ✅ | ✅ (served by PostgreSQL) |
+| `GET /api/contracts` (list) | yes | yes |
+| `GET /api/search` (full-text) | yes | yes |
+| `GET /api/v1/contracts/search` (advanced) | yes | yes (served by PostgreSQL) |
 
 ## Offset pagination (default)
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -94,3 +94,99 @@ removed elsewhere in the result set.
 - **Stable iteration over a full result set** (exports, syncing, "load more"
   infinite scroll): use **cursor** pagination.
 - **Relevance-ranked results or jump-to-page UIs**: use **offset** pagination.
+
+## Client-side pagination (`registry_client`)
+
+Everything above is the HTTP contract. Consumers should not implement it by
+hand: the `registry_client` crate (`backend/registry_client`) wraps both modes
+in one typed abstraction, and the CLI's `contract search` command uses it.
+
+```rust
+use registry_client::{ContractSearchRequest, PageLimits, RegistryClient};
+
+let client = RegistryClient::new("http://localhost:3001")?;
+let request = ContractSearchRequest::cursor("swap").with_networks(["testnet"]);
+
+let mut walk = client.search_paginator(
+    request,
+    PageLimits::default().with_page_size(50).with_max_items(Some(1_000)),
+)?;
+
+while let Some(page) = walk.next_page().await? {
+    for hit in page.items {
+        println!("{} ({:?} of {:?})", hit.name, page.total, walk.total());
+    }
+}
+```
+
+A walk is also available as a stream: `Paginator::pages()` yields
+`RegistryPage<T>` values and `Paginator::items()` flattens them into items (pin
+the stream, e.g. with `Box::pin`, before polling it). `Paginator::collect_all()`
+returns a `PageCollection` with the items, the server total, the pages fetched,
+and why the walk stopped.
+
+### What the abstraction guarantees
+
+| Guarantee | Behaviour |
+| --- | --- |
+| Cursors stay opaque | Tokens are compared and echoed back byte-for-byte; the client never decodes or constructs one. |
+| Modes never mix | `PaginationMode` is explicit. A cursor combined with an offset is rejected before a request is sent. |
+| No infinite loops | A repeated cursor, an offset that fails to advance, or repeated empty-but-continuable pages all end the walk with a specific error. |
+| No silent wraparound | `offset + page_len` is overflow-checked on every page. |
+| Retries never duplicate | Transport retries happen inside one page fetch, and a failed fetch leaves the walk untouched, so retrying re-requests the same page. |
+| Bounds by default | `max_pages` defaults to a finite value, and `max_items` caps what a walk emits. Stopping at a bound reports the continuation to resume from. |
+| Cancellation | A `CancelToken` stops a walk between pages or mid-request, keeping the pages already emitted. |
+| Totals preserved | `total` is surfaced verbatim whenever the endpoint reports it. |
+| Ordering preserved | Items are never re-sorted, so the endpoint's ordering guarantee is what you observe. |
+
+Cursor mode talks to `GET /api/search`; offset mode talks to
+`GET /api/v1/contracts/search` (tag filters force `GET /api/search`, the only
+search endpoint that supports them).
+
+### CLI
+
+```bash
+# One page, relevance ordered (unchanged single-page behaviour)
+soroban-registry contract search swap --limit 20
+
+# Every page, cursor paginated, bounded at 1000 items
+soroban-registry contract search swap --all --max-items 1000
+
+# Explicit mode, resuming from a token a previous run printed
+soroban-registry contract search swap --pagination cursor --cursor eyJ0aW1lc3Rh…
+
+# Machine-readable output, including pagination metadata
+soroban-registry contract search swap --all --max-items 500 --json
+```
+
+`--all` is always bounded (defaults: `--max-items 1000`, `--max-pages 100`) and
+Ctrl-C stops the walk and prints what was already fetched. `--cursor` and
+`--offset` are mutually exclusive. Without `--pagination`, `--all` uses cursor
+pagination and a single page uses offset pagination.
+
+`--json` output carries a `pagination` object:
+
+```json
+{
+  "query": "swap",
+  "contracts": [],
+  "count": 1000,
+  "pagination": {
+    "mode": "cursor",
+    "page_size": 50,
+    "pages_fetched": 20,
+    "total": 4213,
+    "complete": false,
+    "stop_reason": "max_items",
+    "cancelled": false,
+    "next_cursor": "eyJ0aW1lc3Rh…",
+    "next_offset": null,
+    "max_items": 1000,
+    "max_pages": 100
+  }
+}
+```
+
+`stop_reason` is one of `exhausted`, `max_items`, `max_pages`, `cancelled`, or
+`single_page` (a search run without `--all`). When it is not `exhausted`,
+`next_cursor`/`next_offset` say where a follow-up run should resume.

--- a/docs/registry-client.md
+++ b/docs/registry-client.md
@@ -40,7 +40,7 @@ let client = RegistryClient::from_config(
 | `auth` | `Auth::None` | `Auth::bearer(token)` or `Auth::api_key(header, value)`. |
 | `timeout` | 30s | Applied per attempt, not per call. |
 | `user_agent` | `soroban-registry-client/<version>` | Identifies the SDK to the registry. |
-| `retry` | 3 attempts, 250 ms → ×3 backoff, honours `Retry-After` | See [Retries](#retries). |
+| `retry` | 3 attempts, 250 ms initial backoff, x3 growth, honours `Retry-After` | See [Retries](#retries). |
 
 `RegistryClient::with_http_client` takes your own `reqwest::Client` when you
 need custom TLS, proxies or pooling. Cloning a client is cheap and shares the

--- a/docs/registry-client.md
+++ b/docs/registry-client.md
@@ -1,0 +1,271 @@
+# `soroban-registry-client`
+
+A typed Rust client for the Soroban Registry HTTP API, in
+[`backend/registry_client`](../backend/registry_client). Request construction,
+authentication, retries, pagination, response decoding and error mapping live
+here rather than in any one consumer, so the CLI, CI integrations, publisher
+automation and third-party tools all share one interpretation of pagination
+tokens, authentication failures, conflict responses and structured API errors.
+
+The crate is named `soroban-registry-client`; the library it exposes is
+`registry_client`:
+
+```toml
+[dependencies]
+soroban-registry-client = { path = "../backend/registry_client" }
+```
+
+```rust
+use registry_client::RegistryClient;
+```
+
+## Configuring a client
+
+```rust
+use std::time::Duration;
+use registry_client::{Auth, ClientConfig, RegistryClient, RetryPolicy};
+
+let client = RegistryClient::from_config(
+    ClientConfig::new("https://registry.example")
+        .with_auth(Auth::bearer(std::env::var("REGISTRY_TOKEN")?))
+        .with_timeout(Duration::from_secs(15))
+        .with_user_agent("my-tool/1.0")
+        .with_retry_policy(RetryPolicy::attempts(5)),
+)?;
+```
+
+| Knob | Default | Notes |
+| --- | --- | --- |
+| `base_url` | — | Trailing slashes are trimmed. |
+| `auth` | `Auth::None` | `Auth::bearer(token)` or `Auth::api_key(header, value)`. |
+| `timeout` | 30s | Applied per attempt, not per call. |
+| `user_agent` | `soroban-registry-client/<version>` | Identifies the SDK to the registry. |
+| `retry` | 3 attempts, 250 ms → ×3 backoff, honours `Retry-After` | See [Retries](#retries). |
+
+`RegistryClient::with_http_client` takes your own `reqwest::Client` when you
+need custom TLS, proxies or pooling. Cloning a client is cheap and shares the
+connection pool; `with_*` on a clone does not disturb the original.
+
+## Searching
+
+```rust
+use registry_client::{ContractSearchRequest, PageLimits, RegistryClient};
+
+let client = RegistryClient::new("https://registry.example")?;
+
+// One page.
+let page = client
+    .search_page(&ContractSearchRequest::offset("swap"), None, 20)
+    .await?;
+println!("{} of {:?} matches", page.items.len(), page.total);
+
+// Every page, bounded at 1000 items.
+let mut walk = client.search_paginator(
+    ContractSearchRequest::cursor("swap")
+        .with_networks(["testnet"])
+        .with_categories(["DeFi"])
+        .with_verified_only(true),
+    PageLimits::default().with_page_size(50).with_max_items(Some(1_000)),
+)?;
+while let Some(page) = walk.next_page().await? {
+    for hit in page.items {
+        println!("{} — {}", hit.name, hit.contract_id);
+    }
+}
+```
+
+Listing works the same way, with the API's own filter type and full `Contract`
+models:
+
+```rust
+use registry_client::{ContractSearchParams, PageLimits, PaginationMode};
+
+let page = client
+    .list_contracts(&ContractSearchParams {
+        limit: Some(20),
+        verified_only: Some(true),
+        ..Default::default()
+    })
+    .await?;
+
+let mut walk = client.list_paginator(
+    ContractSearchParams::default(),
+    PaginationMode::Cursor,
+    PageLimits::default().with_max_items(Some(5_000)),
+)?;
+let all = walk.collect_all().await?;
+```
+
+Cursor and offset pagination are distinct typed representations
+(`PageCursor::Cursor` vs `PageCursor::Offset`), cursors stay opaque, and the two
+can never be combined — see [pagination.md](./pagination.md) for the full set of
+guarantees.
+
+## Publishing
+
+```rust
+use registry_client::{Network, PublishRequest};
+
+let request = PublishRequest {
+    contract_id: "CDLZ…".to_string(),
+    wasm_hash: "9f86d081…".to_string(),
+    wasm_artifact_base64: None,
+    name: "swap-router".to_string(),
+    slug: None,
+    description: Some("AMM router".to_string()),
+    network: Network::Testnet,
+    category: Some("DeFi".to_string()),
+    tags: vec!["amm".to_string()],
+    source_url: None,
+    publisher_address: "GDLZ…".to_string(),
+    dependencies: Vec::new(),
+    is_cicd: true,
+};
+
+// The key makes a lost response safe to retry: the registry replays the
+// original result instead of registering the contract twice.
+let contract = client
+    .publish_contract(&request, Some("release-1.4.2".to_string()))
+    .await?;
+println!("published {}", contract.contract_id);
+```
+
+Other mutating calls take the same optional key: `update_contract_metadata`,
+`submit_contract_verification`, `deprecate_contract`, `trigger_dependency_scan`,
+`create_ownership_transfer`, `confirm_ownership_transfer`, and the webhook
+methods.
+
+## Endpoint groups
+
+| Group | Methods |
+| --- | --- |
+| Contracts | `list_contracts`, `list_paginator`, `get_contract`, `get_contract_metadata`, `update_contract_metadata`, `publish_contract`, `search_page`, `search_paginator` |
+| Verification | `submit_contract_verification`, `contract_verification_status`, `contract_verification_history` |
+| Deprecation | `deprecation_info`, `deprecate_contract`, `undeprecate_contract` |
+| Vulnerabilities | `dependency_scan_report`, `trigger_dependency_scan`, `vulnerability_assessment` |
+| Ownership transfer | `create_ownership_transfer`, `list_ownership_transfers`, `get_ownership_transfer`, `confirm_ownership_transfer`, `ownership_transfer_logs` (provenance chain) |
+| Webhooks | `list_webhooks`, `create_webhook`, `delete_webhook`, `webhook_deliveries`, `test_webhook`, `retry_webhook_delivery` |
+| Snapshots | `contract_snapshot`, `registry_signing_key` |
+
+Request and response types come from `backend/shared` wherever the backend
+defines them (`Contract`, `PublishRequest`, `PaginatedResponse<T>`,
+`DeprecationInfo`, `OwnershipTransfer`, `ContractSnapshot`, …). Where a type
+lives in the API crate instead, the client mirrors it with the same wire shape
+(`ContractVerifyRequest`, `WebhookDelivery`, `RegistrySigningKey`).
+
+For an endpoint the crate does not wrap yet, the escape hatch shares all of the
+same behaviour:
+
+```rust
+use registry_client::RequestSpec;
+
+let tags: Vec<String> = client.get_json("/api/contracts/tags").await?;
+let report: serde_json::Value = client
+    .send_json(RequestSpec::get("/api/contracts/trending").query_pair("limit", "10"))
+    .await?;
+```
+
+## Errors
+
+Failure modes stay distinct instead of collapsing into "request failed":
+
+| Variant | When | `is_transient()` |
+| --- | --- | --- |
+| `Unauthorized` | 401 — expired or missing credentials | no |
+| `Forbidden` | 403 — authenticated but not allowed | no |
+| `NotFound` | 404 | no |
+| `Validation` | 400 / 422 | no |
+| `Conflict` | 409 | no |
+| `IdempotencyInProgress` | 409 `IdempotencyKeyInProgress` — same key still running | yes |
+| `RateLimited` | 429, with `retry_after` | yes |
+| `Upstream` | 5xx | yes |
+| `Timeout` | the attempt exceeded `timeout` | yes |
+| `Transport` | connect/send failure | yes |
+| `MalformedResponse` | 2xx body the client cannot decode | no |
+| `Cancelled` | the caller's `CancelToken` fired | no |
+| `Pagination` | a walk could not continue safely | no |
+
+Every response-derived variant carries the server's `code`, `message`,
+structured `details`, request id and `Retry-After`:
+
+```rust
+match client.publish_contract(&request, None).await {
+    Ok(contract) => println!("published {}", contract.contract_id),
+    Err(err) if err.is_auth() => eprintln!("log in again: {err}"),
+    Err(err) if err.code() == Some("ContractAlreadyExists") => {
+        eprintln!("already registered: {:?}", err.error_details());
+    }
+    Err(err) if err.is_transient() => {
+        eprintln!("try later{}", match err.retry_after() {
+            Some(after) => format!(" (after {}s)", after.as_secs()),
+            None => String::new(),
+        });
+    }
+    Err(err) => return Err(err.into()),
+}
+```
+
+## Retries
+
+`RetryPolicy` is explicit and configurable:
+
+- **Safe methods** (`GET`/`HEAD`/`OPTIONS`) are retried on transport faults,
+  timeouts, 408, 429 and 5xx.
+- **Mutations are retried only when the call supplies an idempotency key.** A
+  keyless publish is attempted exactly once, so it can never register twice.
+  `RetryPolicy::with_retry_idempotent_mutations(false)` disables even that.
+- `Retry-After` wins over the computed backoff, up to `max_retry_after`
+  (default 60s). A longer one is surfaced as `Error::RateLimited` rather than
+  blocking the call.
+- `RetryPolicy::none()` disables retrying entirely.
+
+## Cancellation
+
+```rust
+use registry_client::CancelToken;
+
+let cancel = CancelToken::new();
+let client = client.with_cancel_token(cancel.clone());
+
+tokio::spawn(async move {
+    tokio::signal::ctrl_c().await.ok();
+    cancel.cancel();
+});
+```
+
+In-flight requests fail with `Error::Cancelled`; a `Paginator` stops between
+pages and keeps what it already emitted.
+
+## Secrets
+
+Bearer tokens, API keys and webhook signing secrets are held in `Secret`, whose
+`Debug`/`Display` print `<redacted>`. Errors never carry request headers. So
+logging a client, a config, a paginator or an error cannot leak a credential:
+
+```rust
+let client = RegistryClient::new(url)?.with_bearer_token(Some(token));
+println!("{client:?}"); // …auth: Bearer(<redacted>)…
+```
+
+A newly created webhook's signing secret is moved out of the loggable model into
+`CreatedWebhook::secret`; reach it deliberately with `Secret::expose`.
+
+## Response cache hook
+
+Consumers with their own cache can serve safe reads from it:
+
+```rust
+use registry_client::ResponseCache;
+
+struct MyCache;
+impl ResponseCache for MyCache {
+    fn get(&self, key: &str) -> Option<String> { /* … */ None }
+    fn put(&self, key: &str, body: &str) { /* … */ }
+}
+
+let client = client.with_response_cache(std::sync::Arc::new(MyCache));
+```
+
+Only cacheable `GET`s are looked up or stored; mutations always go to the
+network. The CLI plugs its on-disk HTTP cache in this way, which is what keeps
+`--no-cache` working across commands.

--- a/tagging-service/src/middleware/errorHandler.ts
+++ b/tagging-service/src/middleware/errorHandler.ts
@@ -1,5 +1,11 @@
 import { NextFunction, Request, Response } from "express";
-import { AppError, ErrorCategory, ErrorCode, isAppError, toErrorResponse } from "../errors.js";
+import {
+  AppError,
+  ErrorCategory,
+  ErrorCode,
+  isAppError,
+  toErrorResponse,
+} from "../errors.js";
 import { logger } from "../logger.js";
 
 function getClientIp(req: Request): string {
@@ -37,7 +43,10 @@ export function errorHandler(
         path: req.path,
         clientIp: getClientIp(req),
         details: err.details,
-        cause: err.cause instanceof Error ? { message: err.cause.message, stack: err.cause.stack } : undefined,
+        cause:
+          err.cause instanceof Error
+            ? { message: err.cause.message, stack: err.cause.stack }
+            : undefined,
       },
       `[${err.errorCode}] ${err.message}`,
     );
@@ -74,7 +83,11 @@ export function errorHandler(
   });
 }
 
-export function notFoundHandler(req: Request, res: Response, _next: NextFunction): void {
+export function notFoundHandler(
+  req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
   const requestId =
     (req.headers["x-request-id"] as string) ||
     (req.headers["x-correlation-id"] as string) ||


### PR DESCRIPTION
This pull request introduces a new Rust crate, `soroban-registry-client`, which provides a strongly-typed, async client for the Soroban Registry HTTP API. The client exposes convenient methods for interacting with the registry's endpoints, covering contract verification, ownership transfers, deprecation, vulnerability scanning, webhooks, and contract snapshots. The client is designed for ergonomic and robust integration, with request/response types aligned with backend models and support for idempotency and error handling.

The most important changes are:

**New crate and workspace integration:**

* Added `registry_client` to the Cargo workspace and created the new `soroban-registry-client` crate, including its dependencies and library setup. (`backend/Cargo.toml`, `backend/registry_client/Cargo.toml`) [[1]](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1L2-R10) [[2]](diffhunk://#diff-c5f86f2577ac60454009aad6191bbd276403f09cebc851009bc06a405cd2760dR1-R26)

**API endpoint coverage:**

* Implemented modular, domain-grouped endpoint bindings in `src/api/`, each as inherent methods on `RegistryClient`. Groups include contracts, deprecation, ownership, snapshots, verification, vulnerabilities, and webhooks. (`backend/registry_client/src/api/mod.rs`)

**Domain-specific API implementations:**

* Contract Verification: Added request/response types and methods for submitting contract builds, checking verification status, and retrieving history. (`backend/registry_client/src/api/verification.rs`)
* Ownership Transfers: Added methods for initiating, listing, confirming, and logging ownership transfers. (`backend/registry_client/src/api/ownership.rs`)
* Deprecation, Snapshots, Vulnerabilities, and Webhooks: Added methods for managing contract deprecation, retrieving signed contract snapshots, running dependency scans, and configuring webhooks with delivery logs and redelivery. (`backend/registry_client/src/api/deprecation.rs`, `backend/registry_client/src/api/snapshots.rs`, `backend/registry_client/src/api/vulnerabilities.rs`, `backend/registry_client/src/api/webhooks.rs`) [[1]](diffhunk://#diff-f58f908f3aff0e022a2e57c5a411e14fcb3017c0ec9ba8b747e668918e33ec88R1-R45) [[2]](diffhunk://#diff-ff2f73a41e19822dd0e8cfd4accfb8e2b411ce9118fd0ae664185a76284884f5R1-R39) [[3]](diffhunk://#diff-56e5a5acb30b74a44ddafc86ceba012cb59a4c2138ecf91853f48a951057dc21R1-R46) [[4]](diffhunk://#diff-6000936e43f317dd9318e682dd25b3c58cd77817bbfdff126bbe2f90acbc937fR1-R124)## Summary

<!-- Provide a concise description of what this PR does and why it's needed. -->





closes #1141 