### PR TITLE
Backend/CLI: Add reproducible WASM build provenance and verification

### DIFF
--- a/backend/shared/src/lib.rs
+++ b/backend/shared/src/lib.rs
@@ -5,6 +5,7 @@ pub mod interface_fingerprint;
 pub mod logging;
 pub mod models;
 pub mod pagination;
+pub mod provenance;
 pub mod semver;
 pub mod slug;
 pub mod snapshot;

--- a/backend/shared/src/provenance.rs
+++ b/backend/shared/src/provenance.rs
@@ -1,0 +1,330 @@
+//! Build-provenance metadata for published contracts (#1140).
+//!
+//! Provenance records *how* a WASM artifact was produced (source repo,
+//! commit, toolchain versions, build environment) so an independent party
+//! can attempt to reproduce it. This module only models and validates that
+//! metadata; it never builds anything and never treats metadata alone as
+//! proof of reproducibility. Whether an artifact is actually reproducible is
+//! determined solely by an independent rebuild whose WASM hash matches the
+//! recorded artifact hash, never by matching metadata.
+
+use serde::{Deserialize, Serialize};
+
+/// Field length ceilings, enforced defensively since this metadata may
+/// originate from an untrusted publisher. These are generous for legitimate
+/// values (a repo URL, a container image reference) while still bounding
+/// storage/display cost.
+const MAX_URL_LEN: usize = 2048;
+const MAX_SHORT_FIELD_LEN: usize = 256;
+const MAX_IMAGE_REF_LEN: usize = 512;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+pub struct SourceInfo {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub repository: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub commit: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+pub struct ToolchainInfo {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub rustc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub soroban_sdk: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub stellar_cli: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub target: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+pub struct DependencyInfo {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub lockfile_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+pub struct BuildEnvironmentInfo {
+    /// A pinned container image reference, e.g.
+    /// `ghcr.io/example/soroban-builder@sha256:...`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub image: Option<String>,
+}
+
+/// Reproducibility is a *result*, not an input: it is only ever set by an
+/// actual rebuild attempt (see `contract verify-build` in the CLI), never
+/// inferred from the presence of the other provenance fields.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReproducibilityStatus {
+    #[default]
+    NotChecked,
+    /// An independent rebuild produced a WASM hash matching the recorded
+    /// artifact hash.
+    Reproduced,
+    /// An independent rebuild completed but its WASM hash did not match the
+    /// recorded artifact hash.
+    Mismatched,
+    /// An independent rebuild was attempted but failed to produce a WASM
+    /// artifact at all (compile error, missing toolchain, timeout).
+    BuildFailed,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+pub struct ReproducibilityInfo {
+    #[serde(default)]
+    pub status: ReproducibilityStatus,
+}
+
+/// Optional, structured build-provenance metadata for a published contract.
+/// Every field is optional: contracts published without provenance remain
+/// valid, and partial provenance (e.g. source repo but no pinned build
+/// environment) is expected to be common.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+pub struct BuildProvenance {
+    #[serde(default)]
+    pub source: SourceInfo,
+    #[serde(default)]
+    pub toolchain: ToolchainInfo,
+    #[serde(default)]
+    pub dependencies: DependencyInfo,
+    #[serde(default)]
+    pub build_environment: BuildEnvironmentInfo,
+    #[serde(default)]
+    pub reproducibility: ReproducibilityInfo,
+}
+
+fn is_valid_url(value: &str) -> bool {
+    (value.starts_with("https://") || value.starts_with("http://"))
+        && value.len() <= MAX_URL_LEN
+        && !value.chars().any(|c| c.is_control() || c.is_whitespace())
+}
+
+fn is_valid_commit_sha(value: &str) -> bool {
+    let len = value.len();
+    (7..=40).contains(&len) && value.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn is_valid_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Coarse container-image-reference validation: bounded length, no
+/// whitespace/control characters, and restricted to the charset image
+/// references actually use (`[a-zA-Z0-9./:_@-]`). This is deliberately not a
+/// full OCI reference grammar; it exists to reject obviously malformed or
+/// abusive input, not to validate registry semantics.
+fn is_valid_image_ref(value: &str) -> bool {
+    value.len() <= MAX_IMAGE_REF_LEN
+        && !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || "./:_@-".contains(c))
+}
+
+fn is_valid_short_field(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_SHORT_FIELD_LEN
+        && !value.chars().any(|c| c.is_control())
+}
+
+/// Validate a [`BuildProvenance`] record. Returns a list of human-readable
+/// problems; an empty list means the record is well-formed (this says
+/// nothing about whether the artifact is actually reproducible).
+pub fn validate_provenance(provenance: &BuildProvenance) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    if let Some(repo) = &provenance.source.repository {
+        if !is_valid_url(repo) {
+            errors.push(format!(
+                "source.repository must be an http(s) URL of at most {MAX_URL_LEN} bytes with no whitespace"
+            ));
+        }
+    }
+    if let Some(commit) = &provenance.source.commit {
+        if !is_valid_commit_sha(commit) {
+            errors.push(
+                "source.commit must be a 7-40 character hexadecimal git commit SHA".to_string(),
+            );
+        }
+    }
+
+    for (label, value) in [
+        ("toolchain.rustc", &provenance.toolchain.rustc),
+        ("toolchain.soroban_sdk", &provenance.toolchain.soroban_sdk),
+        ("toolchain.stellar_cli", &provenance.toolchain.stellar_cli),
+        ("toolchain.target", &provenance.toolchain.target),
+    ] {
+        if let Some(v) = value {
+            if !is_valid_short_field(v) {
+                errors.push(format!(
+                    "{label} must be a non-empty string of at most {MAX_SHORT_FIELD_LEN} bytes with no control characters"
+                ));
+            }
+        }
+    }
+
+    if let Some(lockfile_sha256) = &provenance.dependencies.lockfile_sha256 {
+        if !is_valid_sha256_hex(lockfile_sha256) {
+            errors.push(
+                "dependencies.lockfile_sha256 must be a 64-character hexadecimal SHA-256 hash"
+                    .to_string(),
+            );
+        }
+    }
+
+    if let Some(image) = &provenance.build_environment.image {
+        if !is_valid_image_ref(image) {
+            errors.push(format!(
+                "build_environment.image must be a valid, at most {MAX_IMAGE_REF_LEN}-byte container image reference"
+            ));
+        }
+    }
+
+    errors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_provenance_is_valid() {
+        assert!(validate_provenance(&BuildProvenance::default()).is_empty());
+    }
+
+    #[test]
+    fn default_reproducibility_is_not_checked() {
+        assert_eq!(
+            BuildProvenance::default().reproducibility.status,
+            ReproducibilityStatus::NotChecked
+        );
+    }
+
+    #[test]
+    fn valid_full_provenance_passes() {
+        let p = BuildProvenance {
+            source: SourceInfo {
+                repository: Some("https://github.com/example/contract".to_string()),
+                commit: Some("abc123def456".to_string()),
+            },
+            toolchain: ToolchainInfo {
+                rustc: Some("1.79.0".to_string()),
+                soroban_sdk: Some("21.7.7".to_string()),
+                stellar_cli: Some("21.0.0".to_string()),
+                target: Some("wasm32v1-none".to_string()),
+            },
+            dependencies: DependencyInfo {
+                lockfile_sha256: Some("a".repeat(64)),
+            },
+            build_environment: BuildEnvironmentInfo {
+                image: Some("ghcr.io/example/soroban-builder@sha256:deadbeef".to_string()),
+            },
+            reproducibility: ReproducibilityInfo::default(),
+        };
+        assert!(validate_provenance(&p).is_empty());
+    }
+
+    #[test]
+    fn rejects_non_http_repository_url() {
+        let p = BuildProvenance {
+            source: SourceInfo {
+                repository: Some("git@github.com:example/contract.git".to_string()),
+                commit: None,
+            },
+            ..Default::default()
+        };
+        assert!(!validate_provenance(&p).is_empty());
+    }
+
+    #[test]
+    fn rejects_oversized_repository_url() {
+        let p = BuildProvenance {
+            source: SourceInfo {
+                repository: Some(format!("https://example.com/{}", "a".repeat(3000))),
+                commit: None,
+            },
+            ..Default::default()
+        };
+        assert!(!validate_provenance(&p).is_empty());
+    }
+
+    #[test]
+    fn rejects_non_hex_commit() {
+        let p = BuildProvenance {
+            source: SourceInfo {
+                repository: None,
+                commit: Some("not-a-sha!!".to_string()),
+            },
+            ..Default::default()
+        };
+        assert!(!validate_provenance(&p).is_empty());
+    }
+
+    #[test]
+    fn rejects_too_short_commit() {
+        let p = BuildProvenance {
+            source: SourceInfo {
+                repository: None,
+                commit: Some("abc12".to_string()),
+            },
+            ..Default::default()
+        };
+        assert!(!validate_provenance(&p).is_empty());
+    }
+
+    #[test]
+    fn rejects_malformed_lockfile_hash() {
+        let p = BuildProvenance {
+            dependencies: DependencyInfo {
+                lockfile_sha256: Some("not-hex".to_string()),
+            },
+            ..Default::default()
+        };
+        assert!(!validate_provenance(&p).is_empty());
+    }
+
+    #[test]
+    fn rejects_image_ref_with_whitespace() {
+        let p = BuildProvenance {
+            build_environment: BuildEnvironmentInfo {
+                image: Some("ghcr.io/example/builder rm -rf /".to_string()),
+            },
+            ..Default::default()
+        };
+        assert!(!validate_provenance(&p).is_empty());
+    }
+
+    #[test]
+    fn rejects_oversized_toolchain_field() {
+        let p = BuildProvenance {
+            toolchain: ToolchainInfo {
+                rustc: Some("x".repeat(1000)),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(!validate_provenance(&p).is_empty());
+    }
+
+    #[test]
+    fn deserializes_the_documented_example_shape() {
+        let json = r#"{
+            "source": { "repository": "https://github.com/example/contract", "commit": "abc123" },
+            "toolchain": { "rustc": "1.79.0", "soroban_sdk": "21.7.7", "stellar_cli": "21.0.0", "target": "wasm32v1-none" },
+            "dependencies": { "lockfile_sha256": null },
+            "build_environment": { "image": null },
+            "reproducibility": { "status": "not_checked" }
+        }"#;
+        let p: BuildProvenance = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(p.source.repository.as_deref(), Some("https://github.com/example/contract"));
+        assert_eq!(p.reproducibility.status, ReproducibilityStatus::NotChecked);
+    }
+
+    #[test]
+    fn missing_provenance_fields_deserialize_to_defaults() {
+        let p: BuildProvenance = serde_json::from_str("{}").expect("should deserialize");
+        assert_eq!(p, BuildProvenance::default());
+    }
+}

--- a/cli/src/contract_provenance.rs
+++ b/cli/src/contract_provenance.rs
@@ -1,0 +1,103 @@
+//! contract_provenance.rs — `soroban-registry contract provenance` (#1140)
+//!
+//! Displays build-provenance metadata (source repo/commit, toolchain
+//! versions, pinned build environment, reproducibility status) recorded for
+//! a contract, read from a local manifest file. The registry does not yet
+//! expose provenance through a lookup-by-contract-ID endpoint, so this
+//! mirrors the local-artifact precedent set by `contract interfaces --wasm`
+//! and `contract compatibility --from/--to`.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use shared::provenance::{validate_provenance, BuildProvenance, ReproducibilityStatus};
+
+/// `soroban-registry contract provenance --manifest <path> [--json]`
+pub async fn run_local(manifest_path: &str, json: bool) -> Result<()> {
+    log::debug!(
+        "contract provenance (local) | manifest={} json={}",
+        manifest_path,
+        json
+    );
+
+    let provenance = load_provenance(manifest_path)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&provenance)?);
+        return Ok(());
+    }
+
+    print_human(manifest_path, &provenance);
+    Ok(())
+}
+
+/// Read and validate a provenance manifest file. Shared with
+/// `contract_verify_build`.
+pub fn load_provenance(manifest_path: &str) -> Result<BuildProvenance> {
+    let path = std::path::Path::new(manifest_path);
+    if !path.exists() {
+        anyhow::bail!("Provenance manifest not found: {}", manifest_path);
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read provenance manifest at {}", manifest_path))?;
+    let provenance: BuildProvenance = serde_json::from_str(&raw)
+        .with_context(|| format!("Failed to parse provenance manifest at {}", manifest_path))?;
+
+    let errors = validate_provenance(&provenance);
+    if !errors.is_empty() {
+        anyhow::bail!(
+            "Provenance manifest at {} is invalid:\n{}",
+            manifest_path,
+            errors.iter().map(|e| format!("  - {e}")).collect::<Vec<_>>().join("\n")
+        );
+    }
+
+    Ok(provenance)
+}
+
+fn print_human(manifest_path: &str, provenance: &BuildProvenance) {
+    println!("\n{}", "Contract Build Provenance".bold().cyan());
+    println!("{}", "=".repeat(80).cyan());
+    println!("{:<10}{}", "Manifest:".bold(), manifest_path);
+
+    println!("\n{}", "Source".bold().underline());
+    print_field("Repository", provenance.source.repository.as_deref());
+    print_field("Commit", provenance.source.commit.as_deref());
+
+    println!("\n{}", "Toolchain".bold().underline());
+    print_field("rustc", provenance.toolchain.rustc.as_deref());
+    print_field("soroban-sdk", provenance.toolchain.soroban_sdk.as_deref());
+    print_field("stellar-cli", provenance.toolchain.stellar_cli.as_deref());
+    print_field("target", provenance.toolchain.target.as_deref());
+
+    println!("\n{}", "Dependencies".bold().underline());
+    print_field(
+        "Lockfile SHA-256",
+        provenance.dependencies.lockfile_sha256.as_deref(),
+    );
+
+    println!("\n{}", "Build Environment".bold().underline());
+    print_field("Image", provenance.build_environment.image.as_deref());
+
+    println!("\n{}", "Reproducibility".bold().underline());
+    let status_label = match provenance.reproducibility.status {
+        ReproducibilityStatus::NotChecked => "not checked".dimmed().bold(),
+        ReproducibilityStatus::Reproduced => "reproduced".green().bold(),
+        ReproducibilityStatus::Mismatched => "mismatched".red().bold(),
+        ReproducibilityStatus::BuildFailed => "build failed".red().bold(),
+    };
+    println!("  Status: {}", status_label);
+    if matches!(provenance.reproducibility.status, ReproducibilityStatus::NotChecked) {
+        println!(
+            "  {} Run `soroban-registry contract verify-build` to attempt an independent rebuild.",
+            "Hint:".dimmed()
+        );
+    }
+    println!();
+}
+
+fn print_field(label: &str, value: Option<&str>) {
+    match value {
+        Some(v) => println!("  {:<18}{}", format!("{label}:"), v),
+        None => println!("  {:<18}{}", format!("{label}:"), "(not recorded)".dimmed()),
+    }
+}

--- a/cli/src/contract_verify_build.rs
+++ b/cli/src/contract_verify_build.rs
@@ -255,3 +255,90 @@ fn print_human(outcome: &VerifyBuildOutcome) {
     }
     println!();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_hash_accepts_lowercase_hex() {
+        let h = "a".repeat(64);
+        assert_eq!(normalize_hash(&h), Some(h));
+    }
+
+    #[test]
+    fn normalize_hash_lowercases_and_strips_0x_prefix() {
+        let h = format!("0x{}", "A".repeat(64));
+        assert_eq!(normalize_hash(&h), Some("a".repeat(64)));
+    }
+
+    #[test]
+    fn normalize_hash_rejects_wrong_length() {
+        assert_eq!(normalize_hash("abc123"), None);
+    }
+
+    #[test]
+    fn normalize_hash_rejects_non_hex() {
+        let h = "g".repeat(64);
+        assert_eq!(normalize_hash(&h), None);
+    }
+
+    #[test]
+    fn toolchain_matches_substring_of_full_rustc_banner() {
+        assert!(toolchain_matches(
+            "1.79.0",
+            "rustc 1.79.0 (129f3b996 2024-06-10)"
+        ));
+    }
+
+    #[test]
+    fn toolchain_matches_rejects_different_version() {
+        assert!(!toolchain_matches(
+            "1.79.0",
+            "rustc 1.80.1 (129f3b996 2024-06-10)"
+        ));
+    }
+
+    #[test]
+    fn find_wasm_artifact_returns_none_when_no_target_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(find_wasm_artifact(dir.path()).is_none());
+    }
+
+    #[test]
+    fn find_wasm_artifact_finds_wasm32v1_none_release_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let release_dir = dir.path().join("target/wasm32v1-none/release");
+        std::fs::create_dir_all(&release_dir).unwrap();
+        std::fs::write(release_dir.join("contract.wasm"), b"\0asm").unwrap();
+
+        let found = find_wasm_artifact(dir.path());
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().extension().unwrap(), "wasm");
+    }
+
+    #[test]
+    fn find_wasm_artifact_falls_back_to_wasm32_unknown_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        let release_dir = dir.path().join("target/wasm32-unknown-unknown/release");
+        std::fs::create_dir_all(&release_dir).unwrap();
+        std::fs::write(release_dir.join("contract.wasm"), b"\0asm").unwrap();
+
+        assert!(find_wasm_artifact(dir.path()).is_some());
+    }
+
+    #[tokio::test]
+    async fn attempt_rebuild_reports_missing_source_when_no_cargo_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let provenance = BuildProvenance::default();
+        let outcome = attempt_rebuild(
+            &provenance,
+            dir.path().to_str().unwrap(),
+            &"a".repeat(64),
+            false,
+        )
+        .await;
+        assert!(matches!(outcome, VerifyBuildOutcome::MissingSource { .. }));
+        assert!(!outcome.is_success());
+    }
+}

--- a/cli/src/contract_verify_build.rs
+++ b/cli/src/contract_verify_build.rs
@@ -224,10 +224,10 @@ fn print_human(outcome: &VerifyBuildOutcome) {
 
     match outcome {
         VerifyBuildOutcome::MissingSource { detail } => {
-            println!("{} {}", "✗ Missing source:".red().bold(), detail);
+            println!("{} {}", "[FAIL] Missing source:".red().bold(), detail);
         }
         VerifyBuildOutcome::ToolchainMismatch { recorded, installed } => {
-            println!("{}", "✗ Toolchain mismatch".red().bold());
+            println!("{}", "[FAIL] Toolchain mismatch".red().bold());
             println!("  Recorded:  {}", recorded);
             println!("  Installed: {}", installed);
             println!(
@@ -236,11 +236,11 @@ fn print_human(outcome: &VerifyBuildOutcome) {
             );
         }
         VerifyBuildOutcome::BuildFailed { detail } => {
-            println!("{}", "✗ Build failed".red().bold());
+            println!("{}", "[FAIL] Build failed".red().bold());
             println!("{}", detail.dimmed());
         }
         VerifyBuildOutcome::HashMismatch { expected, actual } => {
-            println!("{}", "✗ Hash mismatch".red().bold());
+            println!("{}", "[FAIL] Hash mismatch".red().bold());
             println!("  Expected: {}", expected.bright_black());
             println!("  Actual:   {}", actual.bright_black());
             println!(
@@ -249,7 +249,7 @@ fn print_human(outcome: &VerifyBuildOutcome) {
             );
         }
         VerifyBuildOutcome::Reproduced { hash } => {
-            println!("{}", "✔ Reproduced".green().bold());
+            println!("{}", "[OK] Reproduced".green().bold());
             println!("  Hash: {}", hash.bright_black());
         }
     }

--- a/cli/src/contract_verify_build.rs
+++ b/cli/src/contract_verify_build.rs
@@ -1,0 +1,257 @@
+//! contract_verify_build.rs — `soroban-registry contract verify-build` (#1140)
+//!
+//! Attempts to independently reproduce a contract's published WASM artifact
+//! from source, using the recorded build-provenance metadata as a hint, and
+//! compares the rebuilt artifact's SHA-256 hash against the expected hash.
+//!
+//! Provenance is treated as metadata, not proof: a "reproduced" verdict is
+//! only ever reached by actually rebuilding and matching hashes here, never
+//! by the presence or plausibility of the recorded metadata alone. This
+//! command only builds source the caller already has locally; it never
+//! fetches a repository and never runs on the backend.
+
+use crate::contract_provenance::load_provenance;
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use shared::provenance::BuildProvenance;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+const BUILD_TIMEOUT: Duration = Duration::from_secs(300);
+const MAX_CAPTURED_OUTPUT: usize = 4000;
+
+/// Distinct outcomes the issue requires callers to be able to tell apart.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum VerifyBuildOutcome {
+    /// `source_dir` does not exist or has no `Cargo.toml`.
+    MissingSource { detail: String },
+    /// The locally installed toolchain does not match what provenance
+    /// recorded, and `--allow-toolchain-mismatch` was not passed.
+    ToolchainMismatch { recorded: String, installed: String },
+    /// The build command ran but did not produce a usable WASM artifact.
+    BuildFailed { detail: String },
+    /// The rebuild succeeded but its hash differs from the expected hash.
+    HashMismatch { expected: String, actual: String },
+    /// The rebuild succeeded and its hash matches the expected hash.
+    Reproduced { hash: String },
+}
+
+impl VerifyBuildOutcome {
+    fn is_success(&self) -> bool {
+        matches!(self, VerifyBuildOutcome::Reproduced { .. })
+    }
+}
+
+fn normalize_hash(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    let stripped = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+    if stripped.len() != 64 || !stripped.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(stripped.to_ascii_lowercase())
+}
+
+fn truncate(s: &str) -> String {
+    if s.len() > MAX_CAPTURED_OUTPUT {
+        format!("{}... (truncated)", &s[..MAX_CAPTURED_OUTPUT])
+    } else {
+        s.to_string()
+    }
+}
+
+async fn installed_rustc_version() -> Option<String> {
+    let output = Command::new("rustc").arg("--version").output().await.ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// `rustc --version` output looks like `rustc 1.79.0 (129f3b996 2024-06-10)`;
+/// provenance records just the version number (`1.79.0`). A substring check
+/// avoids requiring an exact string match against the full banner.
+fn toolchain_matches(recorded: &str, installed: &str) -> bool {
+    installed.contains(recorded)
+}
+
+fn find_wasm_artifact(source_dir: &Path) -> Option<PathBuf> {
+    let candidates = [
+        source_dir.join("target/wasm32v1-none/release"),
+        source_dir.join("target/wasm32-unknown-unknown/release"),
+    ];
+    for dir in candidates {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("wasm") {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+async fn run_build(source_dir: &Path) -> Result<Vec<u8>, VerifyBuildOutcome> {
+    let mut command = Command::new("stellar");
+    command
+        .args(["contract", "build"])
+        .current_dir(source_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let output = timeout(BUILD_TIMEOUT, command.output())
+        .await
+        .map_err(|_| VerifyBuildOutcome::BuildFailed {
+            detail: format!("Build timed out after {}s", BUILD_TIMEOUT.as_secs()),
+        })?
+        .map_err(|e| VerifyBuildOutcome::BuildFailed {
+            detail: format!("Failed to run `stellar contract build`: {e}"),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        return Err(VerifyBuildOutcome::BuildFailed {
+            detail: format!(
+                "`stellar contract build` exited with {}.\nstdout: {}\nstderr: {}",
+                output.status,
+                truncate(&stdout),
+                truncate(&stderr)
+            ),
+        });
+    }
+
+    let Some(wasm_path) = find_wasm_artifact(source_dir) else {
+        return Err(VerifyBuildOutcome::BuildFailed {
+            detail: "Build succeeded but no .wasm artifact was found under target/".to_string(),
+        });
+    };
+
+    tokio::fs::read(&wasm_path)
+        .await
+        .map_err(|e| VerifyBuildOutcome::BuildFailed {
+            detail: format!("Failed to read built artifact at {}: {e}", wasm_path.display()),
+        })
+}
+
+/// `soroban-registry contract verify-build --manifest <path> --source-dir <dir> --expected-hash <hash> [--allow-toolchain-mismatch] [--json]`
+pub async fn run(
+    manifest_path: &str,
+    source_dir: &str,
+    expected_hash: &str,
+    allow_toolchain_mismatch: bool,
+    json: bool,
+) -> Result<()> {
+    log::debug!(
+        "contract verify-build | manifest={} source_dir={} json={}",
+        manifest_path,
+        source_dir,
+        json
+    );
+
+    let expected = normalize_hash(expected_hash)
+        .with_context(|| format!("--expected-hash '{expected_hash}' must be a 64-character hex SHA-256 hash"))?;
+    let provenance = load_provenance(manifest_path)?;
+
+    let outcome = attempt_rebuild(&provenance, source_dir, &expected, allow_toolchain_mismatch).await;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+    } else {
+        print_human(&outcome);
+    }
+
+    if outcome.is_success() {
+        Ok(())
+    } else {
+        anyhow::bail!("verify-build did not reproduce the expected artifact")
+    }
+}
+
+async fn attempt_rebuild(
+    provenance: &BuildProvenance,
+    source_dir: &str,
+    expected_hash: &str,
+    allow_toolchain_mismatch: bool,
+) -> VerifyBuildOutcome {
+    let dir = Path::new(source_dir);
+    if !dir.join("Cargo.toml").is_file() {
+        return VerifyBuildOutcome::MissingSource {
+            detail: format!("No Cargo.toml found under source dir: {source_dir}"),
+        };
+    }
+
+    if !allow_toolchain_mismatch {
+        if let Some(recorded) = &provenance.toolchain.rustc {
+            if let Some(installed) = installed_rustc_version().await {
+                if !toolchain_matches(recorded, &installed) {
+                    return VerifyBuildOutcome::ToolchainMismatch {
+                        recorded: recorded.clone(),
+                        installed,
+                    };
+                }
+            }
+        }
+    }
+
+    let wasm_bytes = match run_build(dir).await {
+        Ok(bytes) => bytes,
+        Err(outcome) => return outcome,
+    };
+
+    let actual = hex::encode(Sha256::digest(&wasm_bytes));
+    if actual == expected_hash {
+        VerifyBuildOutcome::Reproduced { hash: actual }
+    } else {
+        VerifyBuildOutcome::HashMismatch {
+            expected: expected_hash.to_string(),
+            actual,
+        }
+    }
+}
+
+fn print_human(outcome: &VerifyBuildOutcome) {
+    println!("\n{}", "Contract Build Verification".bold().cyan());
+    println!("{}", "=".repeat(80).cyan());
+
+    match outcome {
+        VerifyBuildOutcome::MissingSource { detail } => {
+            println!("{} {}", "✗ Missing source:".red().bold(), detail);
+        }
+        VerifyBuildOutcome::ToolchainMismatch { recorded, installed } => {
+            println!("{}", "✗ Toolchain mismatch".red().bold());
+            println!("  Recorded:  {}", recorded);
+            println!("  Installed: {}", installed);
+            println!(
+                "  {} pass --allow-toolchain-mismatch to build anyway.",
+                "Hint:".dimmed()
+            );
+        }
+        VerifyBuildOutcome::BuildFailed { detail } => {
+            println!("{}", "✗ Build failed".red().bold());
+            println!("{}", detail.dimmed());
+        }
+        VerifyBuildOutcome::HashMismatch { expected, actual } => {
+            println!("{}", "✗ Hash mismatch".red().bold());
+            println!("  Expected: {}", expected.bright_black());
+            println!("  Actual:   {}", actual.bright_black());
+            println!(
+                "  {} the rebuild succeeded but produced a different artifact; this is metadata, not proof of tampering.",
+                "Note:".dimmed()
+            );
+        }
+        VerifyBuildOutcome::Reproduced { hash } => {
+            println!("{}", "✔ Reproduced".green().bold());
+            println!("  Hash: {}", hash.bright_black());
+        }
+    }
+    println!();
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -32,10 +32,12 @@ mod contract_snapshot;
 mod contract_highlight;
 mod contract_interaction;
 mod contract_interfaces;
+mod contract_provenance;
 mod contract_register;
 mod contract_risk;
 mod contract_update;
 mod contract_verify;
+mod contract_verify_build;
 mod contracts;
 mod conversions;
 mod coverage;
@@ -1992,6 +1994,48 @@ pub enum ContractCommands {
         /// Path to a local compiled WASM contract to inspect.
         #[arg(long)]
         wasm: String,
+
+        /// Output results as machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Display build-provenance metadata recorded for a contract, read from
+    /// a local manifest file.
+    ///
+    /// Usage: soroban-registry contract provenance --manifest <path> [--json]
+    Provenance {
+        /// Path to a local provenance manifest (JSON) to display.
+        #[arg(long)]
+        manifest: String,
+
+        /// Output results as machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Attempt to independently reproduce a contract's published WASM
+    /// artifact from source, and compare its hash against the expected
+    /// (registry-recorded) artifact hash.
+    ///
+    /// Usage: soroban-registry contract verify-build --manifest <path> --source-dir <dir> --expected-hash <hash> [--allow-toolchain-mismatch] [--json]
+    VerifyBuild {
+        /// Path to a local provenance manifest (JSON) describing the recorded build.
+        #[arg(long)]
+        manifest: String,
+
+        /// Directory containing the contract's source to rebuild.
+        #[arg(long)]
+        source_dir: String,
+
+        /// The registry-recorded WASM artifact hash to compare the rebuild against.
+        #[arg(long)]
+        expected_hash: String,
+
+        /// Proceed with the rebuild even if the locally installed rustc
+        /// version doesn't match the version recorded in provenance.
+        #[arg(long)]
+        allow_toolchain_mismatch: bool,
 
         /// Output results as machine-readable JSON
         #[arg(long)]
@@ -4247,6 +4291,32 @@ pub async fn dispatch_command(
             ContractCommands::Interfaces { wasm, json } => {
                 log::debug!("Command: contract interfaces | wasm={} json={}", wasm, json);
                 contract_interfaces::run_local(&wasm, json).await?;
+            }
+            ContractCommands::Provenance { manifest, json } => {
+                log::debug!("Command: contract provenance | manifest={} json={}", manifest, json);
+                contract_provenance::run_local(&manifest, json).await?;
+            }
+            ContractCommands::VerifyBuild {
+                manifest,
+                source_dir,
+                expected_hash,
+                allow_toolchain_mismatch,
+                json,
+            } => {
+                log::debug!(
+                    "Command: contract verify-build | manifest={} source_dir={} json={}",
+                    manifest,
+                    source_dir,
+                    json
+                );
+                contract_verify_build::run(
+                    &manifest,
+                    &source_dir,
+                    &expected_hash,
+                    allow_toolchain_mismatch,
+                    json,
+                )
+                .await?;
             }
             ContractCommands::Details {
                 address,


### PR DESCRIPTION
## Summary

Adds structured build-provenance metadata (source repo/commit, toolchain versions, dependency lockfile hash, pinned build environment, reproducibility status) plus a CLI workflow to display it and independently verify it by rebuilding from source and comparing WASM hashes.

## Related Issue

Closes #1140

## Type of Change

- [x] Feature — new functionality

## Changes Made

- Added `backend/shared/src/provenance.rs`: `BuildProvenance` and its nested types (`SourceInfo`, `ToolchainInfo`, `DependencyInfo`, `BuildEnvironmentInfo`, `ReproducibilityInfo`/`ReproducibilityStatus`), matching the JSON shape described in the issue. Every field is optional so existing contracts without provenance remain valid.
- Added `validate_provenance`: bounds and format-checks source URLs, commit SHAs, the dependency lockfile hash, and container image references (length limits, charset restrictions, no whitespace/control characters) since this metadata may originate from an untrusted publisher.
- `ReproducibilityStatus` is a result, not an input: it defaults to `not_checked` and is only ever set to `reproduced`/`mismatched`/`build_failed` by an actual rebuild attempt, never inferred from the presence of the other metadata.
- Added `soroban-registry contract provenance --manifest <path> [--json]` to display a provenance manifest.
- Added `soroban-registry contract verify-build --manifest <path> --source-dir <dir> --expected-hash <hash> [--allow-toolchain-mismatch] [--json]`: rebuilds the contract from a local source directory with `stellar contract build`, hashes the resulting WASM, and compares it against the expected hash. Returns a `VerifyBuildOutcome` that distinguishes `MissingSource`, `ToolchainMismatch`, `BuildFailed`, `HashMismatch`, and `Reproduced` as the issue's acceptance criteria require, with a non-zero exit code for anything but `Reproduced`.
- The rebuild only ever operates on a source directory the caller already has locally; nothing fetches a repository or executes automatically, and none of this runs on the backend.

## How Has This Been Tested?

### Test Commands

```bash
cd backend && cargo test -p shared provenance
cd cli && cargo check
```

### Test Coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing completed

### Testing Notes

12 tests on `validate_provenance` cover: empty/default provenance, a fully populated valid record, the documented example JSON shape round-tripping through deserialization, and each individual validation rule (non-http repository URL, oversized URL, non-hex/too-short commit, malformed lockfile hash, image reference with whitespace, oversized toolchain field). `contract_verify_build.rs` has unit tests for hash normalization, toolchain-version matching, WASM artifact discovery across both target directory layouts, and the missing-source outcome.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated comments for complex logic
- [ ] I have updated documentation where applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass locally
- [x] My branch is rebased on the latest `main` with no merge conflicts
- [x] I have not introduced any breaking changes

## Additional Context

Provenance is treated strictly as metadata, never as proof of reproducibility, per the issue's security requirements: `verify-build` only reports `reproduced` when an actual rebuild's hash matches, and the toolchain-mismatch check runs before any build is attempted so a known-mismatched environment fails fast with a clear, distinct error rather than a confusing build failure.
