### PR TITLE
Feature/issue 1147 dependency graph risk analysis

### DIFF
--- a/backend/api/src/contract_ref.rs
+++ b/backend/api/src/contract_ref.rs
@@ -1,0 +1,153 @@
+//! Resolving a `:id` path parameter that may be a registry UUID or a Stellar
+//! contract address (Issue #1147).
+//!
+//! The dependency routes previously declared `Path<Uuid>` while the CLI sent a
+//! `C...` strkey, so axum rejected the request with 400 before any handler ran.
+//! Accepting both is the fix, but a bare address is genuinely ambiguous:
+//! `contracts` is `UNIQUE(contract_id, network)`, so the same address can name a
+//! different contract on mainnet and on testnet.
+//!
+//! Rather than silently picking one -- which would answer a question about the
+//! wrong contract, and do so invisibly -- an ambiguous address without `?network=`
+//! returns **409 with the candidates listed**, so the caller can retry with the
+//! network they meant.
+
+use crate::error::{ApiError, ApiResult};
+use crate::handlers::db_internal_error;
+use crate::state::AppState;
+use serde_json::json;
+use shared::Network;
+use uuid::Uuid;
+
+/// A contract resolved from a path parameter, with the network it lives on.
+///
+/// The network travels with the id because every dependency query is
+/// network-scoped; re-deriving it downstream would be an extra round trip and an
+/// opportunity to scope a query to the wrong network.
+#[derive(Debug, Clone, Copy)]
+pub struct ResolvedContract {
+    pub uuid: Uuid,
+    pub network: Network,
+}
+
+#[derive(sqlx::FromRow)]
+struct ContractIdentity {
+    id: Uuid,
+    contract_id: String,
+    network: Network,
+}
+
+/// Resolve `id` (a UUID or a Stellar contract address) to a contract.
+///
+/// `network` disambiguates an address that is registered on more than one
+/// network. It is ignored for a UUID, which is already unique.
+pub async fn resolve(
+    state: &AppState,
+    id: &str,
+    network: Option<Network>,
+) -> ApiResult<ResolvedContract> {
+    let id = id.trim();
+
+    if let Ok(uuid) = Uuid::parse_str(id) {
+        let row: Option<ContractIdentity> =
+            sqlx::query_as("SELECT id, contract_id, network FROM contracts WHERE id = $1")
+                .bind(uuid)
+                .fetch_optional(&state.db)
+                .await
+                .map_err(|err| db_internal_error("resolve contract by uuid", err))?;
+
+        let row = row.ok_or_else(|| not_found(id))?;
+
+        // A UUID names exactly one row, so a mismatched `?network=` is a
+        // contradiction in the request rather than an ambiguity to resolve.
+        if let Some(requested) = network {
+            if row.network != requested {
+                return Err(ApiError::bad_request(
+                    "NetworkMismatch",
+                    format!(
+                        "Contract {id} is registered on {}, but network={requested} was requested",
+                        row.network
+                    ),
+                ));
+            }
+        }
+
+        return Ok(ResolvedContract {
+            uuid: row.id,
+            network: row.network,
+        });
+    }
+
+    // Not a UUID: it must be a Stellar contract address. Validating up front
+    // turns a typo into a 400 that says what was wrong, instead of a 404 that
+    // implies the contract might exist somewhere.
+    crate::validation::validate_contract_id(id).map_err(|reason| {
+        ApiError::bad_request(
+            "InvalidContractRef",
+            format!("'{id}' is neither a contract UUID nor a Stellar contract address: {reason}"),
+        )
+    })?;
+
+    if let Some(network) = network {
+        let row: Option<ContractIdentity> = sqlx::query_as(
+            "SELECT id, contract_id, network FROM contracts WHERE contract_id = $1 AND network = $2",
+        )
+        .bind(id)
+        .bind(network)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|err| db_internal_error("resolve contract by address and network", err))?;
+
+        let row = row.ok_or_else(|| {
+            ApiError::not_found(
+                "ContractNotFound",
+                format!("Contract {id} is not registered on {network}"),
+            )
+        })?;
+
+        return Ok(ResolvedContract {
+            uuid: row.id,
+            network: row.network,
+        });
+    }
+
+    let candidates: Vec<ContractIdentity> = sqlx::query_as(
+        "SELECT id, contract_id, network FROM contracts WHERE contract_id = $1 ORDER BY network",
+    )
+    .bind(id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|err| db_internal_error("resolve contract by address", err))?;
+
+    match candidates.len() {
+        0 => Err(not_found(id)),
+        1 => {
+            let row = &candidates[0];
+            Ok(ResolvedContract {
+                uuid: row.id,
+                network: row.network,
+            })
+        }
+        _ => Err(ApiError::conflict(
+            "AmbiguousContractRef",
+            format!(
+                "Contract address {id} is registered on {} networks. Retry with ?network=",
+                candidates.len()
+            ),
+        )
+        .with_details(json!({
+            "candidates": candidates
+                .iter()
+                .map(|row| json!({
+                    "id": row.id,
+                    "contract_id": row.contract_id,
+                    "network": row.network.to_string(),
+                }))
+                .collect::<Vec<_>>()
+        }))),
+    }
+}
+
+fn not_found(id: &str) -> ApiError {
+    ApiError::not_found("ContractNotFound", format!("Contract {id} not found"))
+}

--- a/backend/api/src/dependency.rs
+++ b/backend/api/src/dependency.rs
@@ -455,9 +455,165 @@ pub async fn save_dependencies(
         .await?;
     }
 
+    write_canonical_edges(&mut tx, contract_id, network, decls, &resolutions).await?;
+
     tx.commit().await?;
 
     Ok(resolutions)
+}
+
+/// Row shape for comparing a declaration against the edge currently on record.
+#[derive(sqlx::FromRow)]
+struct CurrentEdge {
+    target_ref: String,
+    target_contract_id: Option<Uuid>,
+    version_constraint: Option<String>,
+    expected_interface_id: Option<String>,
+    edge_state: String,
+}
+
+/// Mirror the declared dependency set into `contract_dependency_edges`
+/// (Issue #1147), superseding rather than deleting.
+///
+/// **Only genuine changes are superseded.** The natural implementation --
+/// supersede everything, insert everything, mirroring the DELETE-then-INSERT
+/// above -- would append a full history generation on every save even when
+/// nothing changed. `as_of` would then replay a wall of no-op churn and stop
+/// meaning anything. So a declaration whose `(target, version_constraint,
+/// expected_interface_id, state)` tuple is unchanged is left alone, keeping its
+/// original `recorded_at`.
+///
+/// Telemetry edges are never written here: they are read live from
+/// `contract_call_edge_daily_aggregates`, which is already the historical
+/// record and is upserted on every contract invocation.
+async fn write_canonical_edges(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    contract_id: Uuid,
+    network: Network,
+    decls: &[DependencyDeclaration],
+    resolutions: &[DependencyResolution],
+) -> Result<()> {
+    let current: Vec<CurrentEdge> = sqlx::query_as(
+        "SELECT target_ref, target_contract_id, version_constraint, expected_interface_id,
+                edge_state::text AS edge_state
+         FROM contract_dependency_edges
+         WHERE source_contract_id = $1
+           AND network = $2
+           AND edge_source = 'declared'
+           AND superseded_at IS NULL",
+    )
+    .bind(contract_id)
+    .bind(network)
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let current_by_ref: HashMap<&str, &CurrentEdge> = current
+        .iter()
+        .map(|edge| (edge.target_ref.as_str(), edge))
+        .collect();
+
+    let mut unchanged: Vec<&str> = Vec::new();
+    let mut to_write: Vec<(&DependencyDeclaration, EdgeFacts)> = Vec::new();
+
+    for (decl, resolution) in decls.iter().zip(resolutions) {
+        let facts = edge_facts(tx, resolution).await?;
+        match current_by_ref.get(decl.name.as_str()) {
+            Some(existing)
+                if existing.target_contract_id == facts.target_contract_id
+                    && existing.version_constraint.as_deref()
+                        == Some(decl.version_constraint.as_str())
+                    && existing.expected_interface_id == facts.expected_interface_id
+                    && existing.edge_state == facts.edge_state =>
+            {
+                unchanged.push(decl.name.as_str());
+            }
+            _ => to_write.push((decl, facts)),
+        }
+    }
+
+    // Supersede every current edge that is not being carried forward unchanged:
+    // both the ones being rewritten and the ones the operator dropped.
+    sqlx::query(
+        "UPDATE contract_dependency_edges
+         SET superseded_at = NOW()
+         WHERE source_contract_id = $1
+           AND network = $2
+           AND edge_source = 'declared'
+           AND superseded_at IS NULL
+           AND target_ref <> ALL($3)",
+    )
+    .bind(contract_id)
+    .bind(network)
+    .bind(&unchanged)
+    .execute(&mut **tx)
+    .await?;
+
+    for (decl, facts) in &to_write {
+        sqlx::query(
+            "INSERT INTO contract_dependency_edges
+                (source_contract_id, target_contract_id, target_ref, network, edge_source,
+                 edge_state, version_constraint, expected_interface_id, expected_wasm_hash)
+             VALUES ($1, $2, $3, $4, 'declared', $5::dependency_edge_state, $6, $7, $8)",
+        )
+        .bind(contract_id)
+        .bind(facts.target_contract_id)
+        .bind(&decl.name)
+        .bind(network)
+        .bind(&facts.edge_state)
+        .bind(&decl.version_constraint)
+        .bind(&facts.expected_interface_id)
+        .bind(&facts.expected_wasm_hash)
+        .execute(&mut **tx)
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// The target-derived facts recorded on an edge at declaration time.
+struct EdgeFacts {
+    target_contract_id: Option<Uuid>,
+    edge_state: String,
+    expected_interface_id: Option<String>,
+    expected_wasm_hash: Option<String>,
+}
+
+/// Snapshot the target's interface id and wasm hash as they are *now*.
+///
+/// These are the comparands for interface incompatibility later: the edge says
+/// what the target looked like when the dependency was declared, and drift from
+/// the target's current values is the diagnostic. Current values are always
+/// JOINed at read time; they are never denormalized onto the edge.
+async fn edge_facts(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    resolution: &DependencyResolution,
+) -> Result<EdgeFacts> {
+    let (target_contract_id, edge_state) = match resolution {
+        DependencyResolution::Resolved(id) => (Some(*id), "resolved"),
+        DependencyResolution::NetworkMismatch { .. } => (None, "network_mismatch"),
+        DependencyResolution::UnknownAddress | DependencyResolution::NotAnAddress => {
+            (None, "unresolved")
+        }
+    };
+
+    let (expected_interface_id, expected_wasm_hash) = match target_contract_id {
+        Some(id) => sqlx::query_as::<_, (Option<String>, String)>(
+            "SELECT interface_id, wasm_hash FROM contracts WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&mut **tx)
+        .await?
+        .map(|(interface_id, wasm_hash)| (interface_id, Some(wasm_hash)))
+        .unwrap_or((None, None)),
+        None => (None, None),
+    };
+
+    Ok(EdgeFacts {
+        target_contract_id,
+        edge_state: edge_state.to_string(),
+        expected_interface_id,
+        expected_wasm_hash,
+    })
 }
 
 /// Build a localized graph around a specific contract

--- a/backend/api/src/dependency.rs
+++ b/backend/api/src/dependency.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use shared::{DependencyDeclaration, GraphEdge, GraphNode, GraphResponse};
+use shared::{DependencyDeclaration, GraphEdge, GraphNode, GraphResponse, Network};
 use sqlx::PgPool;
 use std::collections::{HashMap, HashSet, VecDeque};
 use uuid::Uuid;
@@ -80,41 +80,6 @@ fn strongly_connected_components(
     }
 
     (component_by_node, component_sizes)
-}
-
-/// Detect dependencies from a contract ABI JSON
-pub fn detect_dependencies_from_abi(abi_json: &serde_json::Value) -> Vec<DependencyDeclaration> {
-    let mut dependencies = Vec::new();
-    let mut seen = HashSet::new();
-
-    // In Soroban, external contract calls often use a 'Client' or are defined in the spec.
-    // We look for 'custom' types that might represent other contracts,
-    // or specific annotations if they exist.
-    // For now, we'll scan for common patterns.
-
-    if let Some(specs) = abi_json.as_array() {
-        for spec in specs {
-            // Look for interface/contract client definitions
-            if let Some(spec_type) = spec.get("type").and_then(|t| t.as_str()) {
-                if spec_type == "contract_spec_interface" || spec_type == "interface" {
-                    if let Some(name) = spec.get("name").and_then(|n| n.as_str()) {
-                        if seen.insert(name.to_string()) {
-                            dependencies.push(DependencyDeclaration {
-                                name: name.to_string(),
-                                version_constraint: "*".to_string(), // Default constraint
-                            });
-                        }
-                    }
-                }
-            }
-
-            // Scan function inputs/outputs for custom types that might be contract IDs?
-            // Actually, usually they are addressed by Symbol or Address.
-            // But sometimes the 'type' field in the spec itself points to another contract.
-        }
-    }
-
-    dependencies
 }
 
 /// Calculate transitive closure of dependencies (all recursive dependencies)
@@ -306,25 +271,33 @@ pub async fn build_dependency_graph(
     })
 }
 
-/// Resolve a dependency name/id to a contract UUID if it exists in the registry
-pub async fn resolve_contract_id(pool: &PgPool, identifier: &str) -> Result<Option<Uuid>> {
-    // Try UUID first
-    if let Ok(id) = Uuid::parse_str(identifier) {
-        return Ok(Some(id));
-    }
+/// Look up a contract by an opaque identifier: a registry UUID or a Stellar
+/// contract address.
+///
+/// Deliberately does **not** resolve by `contracts.name` (Issue #1147).
+/// `contracts.name` carries no UNIQUE constraint, so a name lookup silently
+/// picks an arbitrary row among duplicates. It also does not have the old
+/// unchecked `Uuid::parse_str` fast path, which returned an id for a UUID that
+/// matched no row at all.
+///
+/// This is a general read-side helper for path parameters and telemetry
+/// targets. It is **not** how a dependency edge is bound — see
+/// [`resolve_dependency_target`], which additionally requires a network.
+pub async fn lookup_contract_by_identifier(
+    pool: &PgPool,
+    identifier: &str,
+) -> Result<Option<Uuid>> {
+    let identifier = identifier.trim();
 
-    // Try contract_id (public key)
-    let id: Option<Uuid> = sqlx::query_scalar("SELECT id FROM contracts WHERE contract_id = $1")
-        .bind(identifier)
-        .fetch_optional(pool)
-        .await?;
-
-    if id.is_some() {
+    if let Ok(uuid) = Uuid::parse_str(identifier) {
+        let id: Option<Uuid> = sqlx::query_scalar("SELECT id FROM contracts WHERE id = $1")
+            .bind(uuid)
+            .fetch_optional(pool)
+            .await?;
         return Ok(id);
     }
 
-    // Try name
-    let id: Option<Uuid> = sqlx::query_scalar("SELECT id FROM contracts WHERE name = $1")
+    let id: Option<Uuid> = sqlx::query_scalar("SELECT id FROM contracts WHERE contract_id = $1")
         .bind(identifier)
         .fetch_optional(pool)
         .await?;
@@ -332,38 +305,145 @@ pub async fn resolve_contract_id(pool: &PgPool, identifier: &str) -> Result<Opti
     Ok(id)
 }
 
-/// Save dependencies for a contract, resolving them if possible
+/// Outcome of binding a declared dependency reference to a registry row.
+///
+/// An unresolved or cross-network reference is **retained, not discarded**: the
+/// operator declared something real, and dropping it would silently shrink the
+/// graph. It is simply never treated as a dependency for risk purposes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DependencyResolution {
+    /// Bound to a contract registered on the requested network.
+    Resolved(Uuid),
+    /// A syntactically valid contract address that is registered on some other
+    /// network. An explicit diagnostic, never a silent cross-network binding.
+    NetworkMismatch {
+        contract_uuid: Uuid,
+        found_on: Network,
+    },
+    /// A syntactically valid contract address that is not registered at all.
+    UnknownAddress,
+    /// Not a Stellar contract address. Free-form names are informational only.
+    NotAnAddress,
+}
+
+/// Resolve a declared dependency reference to a registry contract, scoped to a
+/// network.
+///
+/// Two rules, both required by Issue #1147:
+///
+/// - **Addresses only.** The reference must pass
+///   [`crate::validation::validate_contract_id`]. Resolving arbitrary strings
+///   against `contracts.name` bound dependencies to whatever row happened to
+///   share a name; names are not unique and are chosen by the publisher.
+/// - **Network scoped.** `contracts` is `UNIQUE(contract_id, network)`, so an
+///   address alone is ambiguous. Without the predicate a mainnet contract could
+///   be recorded as the dependency of a testnet one.
+pub async fn resolve_dependency_target(
+    pool: &PgPool,
+    target_ref: &str,
+    network: Network,
+) -> Result<DependencyResolution> {
+    let target_ref = target_ref.trim();
+
+    if crate::validation::validate_contract_id(target_ref).is_err() {
+        return Ok(DependencyResolution::NotAnAddress);
+    }
+
+    if let Some(id) = sqlx::query_scalar::<_, Uuid>(
+        "SELECT id FROM contracts WHERE contract_id = $1 AND network = $2",
+    )
+    .bind(target_ref)
+    .bind(network)
+    .fetch_optional(pool)
+    .await?
+    {
+        return Ok(DependencyResolution::Resolved(id));
+    }
+
+    // Registered, but somewhere else. Reported rather than bound.
+    if let Some((id, found_on)) = sqlx::query_as::<_, (Uuid, Network)>(
+        "SELECT id, network FROM contracts WHERE contract_id = $1 ORDER BY network LIMIT 1",
+    )
+    .bind(target_ref)
+    .fetch_optional(pool)
+    .await?
+    {
+        return Ok(DependencyResolution::NetworkMismatch {
+            contract_uuid: id,
+            found_on,
+        });
+    }
+
+    Ok(DependencyResolution::UnknownAddress)
+}
+
+/// Replace a contract's declared dependencies with `decls`.
+///
+/// The whole set is replaced because the declaration is the operator's complete
+/// statement of what this contract depends on: a dependency they removed must
+/// disappear. That is only safe because, after Issue #1147, nothing *infers*
+/// declarations — the ABI scraper that used to feed this function on every
+/// version publish is gone, so the only caller is an explicit operator action.
+///
+/// The delete and the inserts run in one transaction. Previously they did not,
+/// so a mid-loop failure left the contract with a truncated dependency set and
+/// no way to tell.
+///
+/// Returns the resolution outcome per declaration, in input order, so callers
+/// can report unresolved and cross-network references instead of silently
+/// recording NULLs.
 pub async fn save_dependencies(
     pool: &PgPool,
     contract_id: Uuid,
+    network: Network,
     decls: &[DependencyDeclaration],
-) -> Result<()> {
-    // Clear existing dependencies (optional, depends on if we want to merge or replace)
-    sqlx::query("DELETE FROM contract_static_dependencies WHERE contract_id = $1")
-        .bind(contract_id)
-        .execute(pool)
-        .await?;
-
+) -> Result<Vec<DependencyResolution>> {
+    let mut resolutions = Vec::with_capacity(decls.len());
     for decl in decls {
-        let dep_contract_id = resolve_contract_id(pool, &decl.name).await?;
+        resolutions.push(resolve_dependency_target(pool, &decl.name, network).await?);
+    }
 
-        if let Some(dep_id) = dep_contract_id {
-            if detect_cycle(pool, contract_id, dep_id)
+    for (decl, resolution) in decls.iter().zip(&resolutions) {
+        if let DependencyResolution::Resolved(dep_id) = resolution {
+            if detect_cycle(pool, contract_id, *dep_id)
                 .await
                 .unwrap_or(false)
             {
                 tracing::warn!(
-                    "Circular dependency detected: contract {} -> {}",
-                    contract_id,
-                    dep_id
+                    contract_id = %contract_id,
+                    dependency_id = %dep_id,
+                    "circular dependency declared"
                 );
             }
+        } else {
+            tracing::info!(
+                contract_id = %contract_id,
+                target_ref = %decl.name,
+                resolution = ?resolution,
+                "dependency declaration retained but not bound to a registry contract"
+            );
         }
+    }
+
+    let mut tx = pool.begin().await?;
+
+    sqlx::query("DELETE FROM contract_static_dependencies WHERE contract_id = $1")
+        .bind(contract_id)
+        .execute(&mut *tx)
+        .await?;
+
+    for (decl, resolution) in decls.iter().zip(&resolutions) {
+        let dep_contract_id = match resolution {
+            DependencyResolution::Resolved(id) => Some(*id),
+            // A cross-network match is deliberately NOT bound: recording the
+            // UUID here would make it indistinguishable from a real dependency.
+            _ => None,
+        };
 
         sqlx::query(
-            "INSERT INTO contract_static_dependencies (contract_id, dependency_name, dependency_contract_id, version_constraint) 
+            "INSERT INTO contract_static_dependencies (contract_id, dependency_name, dependency_contract_id, version_constraint)
              VALUES ($1, $2, $3, $4)
-             ON CONFLICT (contract_id, dependency_name) DO UPDATE SET 
+             ON CONFLICT (contract_id, dependency_name) DO UPDATE SET
                 dependency_contract_id = EXCLUDED.dependency_contract_id,
                 version_constraint = EXCLUDED.version_constraint"
         )
@@ -371,11 +451,13 @@ pub async fn save_dependencies(
         .bind(&decl.name)
         .bind(dep_contract_id)
         .bind(&decl.version_constraint)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
     }
 
-    Ok(())
+    tx.commit().await?;
+
+    Ok(resolutions)
 }
 
 /// Build a localized graph around a specific contract
@@ -518,39 +600,4 @@ pub async fn build_local_graph(pool: &PgPool, root_id: Uuid, depth: u32) -> Resu
         nodes: contracts,
         edges,
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_detect_dependencies() {
-        let abi = json!([
-            {
-                "type": "interface",
-                "name": "TokenInterface"
-            },
-            {
-                "type": "function",
-                "name": "hello"
-            }
-        ]);
-
-        let deps = detect_dependencies_from_abi(&abi);
-        assert_eq!(deps.len(), 1);
-        assert_eq!(deps[0].name, "TokenInterface");
-    }
-
-    #[test]
-    fn test_detect_dependencies_duplicate() {
-        let abi = json!([
-            { "type": "interface", "name": "Auth" },
-            { "type": "interface", "name": "Auth" }
-        ]);
-
-        let deps = detect_dependencies_from_abi(&abi);
-        assert_eq!(deps.len(), 1);
-    }
 }

--- a/backend/api/src/dependency_graph.rs
+++ b/backend/api/src/dependency_graph.rs
@@ -1,0 +1,644 @@
+//! Bounded, tenancy-safe dependency traversal (Issue #1147).
+//!
+//! One `WITH RECURSIVE` CTE replaces three separate N+1 application-level walks.
+//! The one in `dependency_handlers` was `#[async_recursion]` and removed each
+//! node from its `visited` set on unwind, so a diamond was re-expanded once per
+//! incoming path -- exponential on wide graphs, and non-deterministic in which
+//! path it reported for a shared node.
+//!
+//! ## How the traversal is bounded
+//!
+//! Three independent bounds, because each fails differently:
+//!
+//! - **Cycle guard.** The CTE carries the root-to-here path as a `uuid[]` and
+//!   only descends when `NOT (next_target = ANY(path))`. Without it a cyclic
+//!   graph makes the CTE non-terminating; the depth bound alone would mask that
+//!   as silent truncation rather than reporting the cycle.
+//! - **Depth bound.** `depth < $limit` in the recursive term.
+//! - **Node budget and time budget.** `LIMIT` on the outer select, plus
+//!   `SET LOCAL statement_timeout` inside a transaction. The timeout is not
+//!   redundant: dropping an axum future does **not** cancel an in-flight sqlx
+//!   query. The Postgres backend keeps executing and the pooled connection stays
+//!   checked out, so a client that walks away could otherwise hold a connection
+//!   for the full runtime of a pathological query.
+//!
+//! ## Tenancy
+//!
+//! Every traversal query carries the visibility predicate. A node the caller may
+//! not see is still *counted* -- so `total_dependencies` stays honest -- but is
+//! returned as a redacted placeholder with no name, address, or publisher. The
+//! predicate is applied inside the recursive term, not as a post-filter, so a
+//! private contract cannot even be used as a stepping stone to enumerate the
+//! graph behind it.
+//!
+//! ## Query style
+//!
+//! Runtime `sqlx::query_as` + `.bind()` + `#[derive(FromRow)]`, matching the
+//! rest of the tree. There are zero compile-time query macros in this repo and
+//! introducing one would add a build-time database requirement.
+
+use crate::error::{ApiError, ApiResult};
+use crate::handlers::db_internal_error;
+use shared::dependency_graph::{
+    clamp_depth, clamp_max_nodes, cycle_segment, sort_diagnostics, Diagnostic, DiagnosticKind,
+    EdgeSource, EdgeState, TruncationReason, TRAVERSAL_STATEMENT_TIMEOUT_MS,
+};
+use shared::Network;
+use sqlx::{PgPool, Postgres, Transaction};
+use uuid::Uuid;
+
+/// Which way to walk the graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    /// What this contract depends on.
+    Dependencies,
+    /// What depends on this contract.
+    Dependents,
+}
+
+/// Inputs to one traversal.
+#[derive(Debug, Clone)]
+pub struct TraversalRequest {
+    pub root: Uuid,
+    pub network: Network,
+    pub direction: Direction,
+    /// `false` walks only direct edges (depth 1).
+    pub transitive: bool,
+    pub max_depth: u32,
+    pub max_nodes: usize,
+    /// Replay the declared graph as it stood at this instant. `None` is "now".
+    pub as_of: Option<chrono::DateTime<chrono::Utc>>,
+    /// Organization of the caller, or `None` for an anonymous/public caller.
+    pub caller_org: Option<Uuid>,
+    /// Include telemetry-derived edges alongside declared ones.
+    pub include_telemetry: bool,
+}
+
+impl TraversalRequest {
+    /// Effective depth: 1 for a direct-only walk, the clamped value otherwise.
+    pub fn effective_depth(&self) -> u32 {
+        if self.transitive {
+            clamp_depth(Some(self.max_depth))
+        } else {
+            1
+        }
+    }
+
+    pub fn effective_max_nodes(&self) -> usize {
+        clamp_max_nodes(Some(self.max_nodes))
+    }
+}
+
+/// One reachable node, with the path that reached it.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TraversedEdgeRow {
+    pub depth: i32,
+    /// NULL for an unresolved or cross-network edge.
+    pub target_contract_id: Option<Uuid>,
+    pub target_ref: String,
+    pub network: Network,
+    pub edge_source: String,
+    pub edge_state: String,
+    pub version_constraint: Option<String>,
+    pub expected_interface_id: Option<String>,
+    /// The target's interface id *now*, JOINed rather than denormalized.
+    pub current_interface_id: Option<String>,
+    pub source_contract_id: Uuid,
+    /// Root-to-node path. Ends at the *source* for an edge that contributed no
+    /// node (unresolved, or cycle-closing).
+    pub path: Vec<Uuid>,
+    /// Set when this edge closes a loop: the already-visited contract it points
+    /// back to.
+    pub cycle_with: Option<Uuid>,
+    /// True when the walk did not descend past this row.
+    pub terminal: bool,
+    /// False when tenancy hides this node's details from the caller.
+    pub visible: bool,
+    pub target_address: Option<String>,
+    pub target_name: Option<String>,
+}
+
+/// Result of one traversal: the reachable set plus what had to be reported
+/// about the shape of the walk.
+#[derive(Debug, Clone)]
+pub struct TraversalResult {
+    pub rows: Vec<TraversedEdgeRow>,
+    pub diagnostics: Vec<Diagnostic>,
+    pub truncated: bool,
+    pub truncation_reason: Option<TruncationReason>,
+}
+
+/// The recursive CTE.
+///
+/// Bind order:
+///   $1 root uuid, $2 network, $3 as_of (nullable), $4 depth limit,
+///   $5 caller org (nullable), $6 include telemetry, $7 node budget (+1 probe)
+///
+/// The `+1` on the outer LIMIT is a truncation probe: fetching one row beyond
+/// the budget is how we distinguish "the graph is exactly this big" from "we
+/// stopped". Reporting `truncated: false` on a graph that was in fact clipped
+/// would be the worst possible failure mode for a tool people gate deploys on.
+const FORWARD_TRAVERSAL_SQL: &str = r#"
+-- Bind order: $1 root, $2 network, $3 as_of, $4 depth limit,
+--             $5 caller org, $6 include telemetry, $7 node budget (+1 probe)
+WITH RECURSIVE edges AS (
+    -- Declared edges, resolved to their target's identity and visibility once
+    -- here rather than in the outer select, so the recursive term can test
+    -- visibility without re-joining and without leaking a private node's
+    -- onward dependencies.
+    SELECT
+        e.source_contract_id,
+        e.target_contract_id,
+        e.target_ref,
+        e.network,
+        e.edge_source::text AS edge_source,
+        e.edge_state::text  AS edge_state,
+        e.version_constraint,
+        e.expected_interface_id,
+        -- COALESCE is load-bearing: `c.organization_id = $5` yields NULL, not
+        -- false, when either side is NULL, and `false OR NULL` is NULL in SQL's
+        -- three-valued logic. Without it a private contract read by a caller
+        -- with no organization produced a NULL `visible`, which neither decodes
+        -- into a bool nor means "hidden".
+        (c.id IS NULL
+         OR COALESCE(c.visibility = 'public', false)
+         OR COALESCE(c.organization_id = $5::uuid, false)) AS target_visible,
+        c.contract_id  AS target_address,
+        c.name         AS target_name,
+        c.interface_id AS target_interface_id
+    FROM contract_dependency_edges e
+    LEFT JOIN contracts c ON c.id = e.target_contract_id
+    WHERE e.network = $2
+      AND (
+            -- `as_of` replays declared history: recorded by then, and not yet
+            -- superseded at that instant.
+            ($3::timestamptz IS NULL AND e.superseded_at IS NULL)
+         OR ($3::timestamptz IS NOT NULL
+             AND e.recorded_at <= $3
+             AND (e.superseded_at IS NULL OR e.superseded_at > $3))
+          )
+      AND ($6::boolean OR e.edge_source = 'declared')
+
+    UNION ALL
+
+    -- Telemetry edges are derived live rather than materialized. The aggregate
+    -- table is upserted on every contract invocation, so copying it into the
+    -- bitemporal table would add a supersede+insert to the hottest write path in
+    -- the system for zero information gain -- it already *is* the historical
+    -- record, which is also why `day <= as_of` gives exact historical state free.
+    SELECT DISTINCT
+        a.source_contract_id,
+        a.target_contract_id,
+        t.contract_id AS target_ref,
+        a.network,
+        'telemetry'::text,
+        'resolved'::text,
+        NULL::text,
+        NULL::text,
+        (COALESCE(t.visibility = 'public', false)
+         OR COALESCE(t.organization_id = $5::uuid, false)) AS target_visible,
+        t.contract_id,
+        t.name,
+        t.interface_id
+    FROM contract_call_edge_daily_aggregates a
+    JOIN contracts t ON t.id = a.target_contract_id
+    WHERE $6::boolean
+      AND a.network = $2
+      AND ($3::timestamptz IS NULL OR a.day <= $3::date)
+),
+walk AS (
+    SELECT
+        1 AS depth,
+        e.source_contract_id,
+        e.target_contract_id,
+        e.target_ref,
+        e.network,
+        e.edge_source,
+        e.edge_state,
+        e.version_constraint,
+        e.expected_interface_id,
+        e.target_visible,
+        e.target_address,
+        e.target_name,
+        e.target_interface_id,
+        -- An unresolved edge contributes no node, so its path ends at the source.
+        CASE WHEN e.target_contract_id IS NULL
+             THEN ARRAY[e.source_contract_id]
+             ELSE ARRAY[e.source_contract_id, e.target_contract_id]
+        END AS path,
+        NULL::uuid AS cycle_with,
+        -- `terminal` marks a row the walk must not descend from. Carrying it as
+        -- a column, instead of filtering the edge out of the recursive term, is
+        -- what lets the row still be emitted: an unresolved reference, a
+        -- cycle-closing edge, and a redacted node are all things the caller
+        -- needs reported. Filtering them would make them invisible, not terminal.
+        (e.edge_state <> 'resolved'
+         OR e.target_contract_id IS NULL
+         -- A node the caller cannot see is not a stepping stone. Stopping here
+         -- means a private contract's own dependencies are never enumerated
+         -- through it; the redacted placeholder still says the graph continues.
+         OR NOT e.target_visible) AS terminal
+    FROM edges e
+    WHERE e.source_contract_id = $1
+
+    UNION ALL
+
+    SELECT
+        w.depth + 1,
+        e.source_contract_id,
+        e.target_contract_id,
+        e.target_ref,
+        e.network,
+        e.edge_source,
+        e.edge_state,
+        e.version_constraint,
+        e.expected_interface_id,
+        e.target_visible,
+        e.target_address,
+        e.target_name,
+        e.target_interface_id,
+        CASE WHEN e.target_contract_id IS NULL OR e.target_contract_id = ANY(w.path)
+             THEN w.path
+             ELSE w.path || e.target_contract_id
+        END,
+        -- The node that closes the loop, so the diagnostic can name the cycle
+        -- rather than the whole path leading into it.
+        CASE WHEN e.target_contract_id = ANY(w.path) THEN e.target_contract_id END,
+        (e.edge_state <> 'resolved'
+         OR e.target_contract_id IS NULL
+         OR NOT e.target_visible
+         -- Cycle guard. Emitted once, then terminal, so the CTE terminates on a
+         -- cyclic graph AND the cycle is reportable instead of looking like
+         -- silent depth truncation.
+         OR e.target_contract_id = ANY(w.path)) AS terminal
+    FROM walk w
+    JOIN edges e ON e.source_contract_id = w.target_contract_id
+    WHERE w.depth < $4
+      AND NOT w.terminal
+)
+SELECT
+    w.depth,
+    w.target_contract_id,
+    w.target_ref,
+    w.network,
+    w.edge_source,
+    w.edge_state,
+    w.version_constraint,
+    w.expected_interface_id,
+    w.source_contract_id,
+    w.path,
+    w.cycle_with,
+    w.terminal,
+    w.target_visible AS visible,
+    CASE WHEN w.target_visible THEN w.target_address END AS target_address,
+    CASE WHEN w.target_visible THEN w.target_name END AS target_name,
+    -- Also gated: an interface fingerprint is a stable identifier for a private
+    -- contract's ABI and would confirm a guess about what it exposes.
+    CASE WHEN w.target_visible THEN w.target_interface_id END AS current_interface_id
+FROM walk w
+-- Deterministic total order. No floats in any sort key, and the trailing columns
+-- make the order total even when depth and target coincide.
+ORDER BY w.depth ASC, w.network ASC, w.target_contract_id ASC NULLS LAST,
+         w.target_ref ASC, w.edge_source ASC
+LIMIT $7
+"#;
+
+/// Reverse traversal for `/dependents`. Structurally identical to
+/// [`FORWARD_TRAVERSAL_SQL`] with source and target exchanged; kept as a second
+/// literal rather than string-built so both remain greppable and reviewable.
+const REVERSE_TRAVERSAL_SQL: &str = r#"
+-- Same bind order as FORWARD_TRAVERSAL_SQL.
+WITH RECURSIVE edges AS (
+    -- Reverse direction, so it is the *source* whose identity and visibility
+    -- matter: it is the dependent being reported.
+    SELECT
+        e.source_contract_id,
+        e.target_contract_id,
+        e.target_ref,
+        e.network,
+        e.edge_source::text AS edge_source,
+        e.edge_state::text  AS edge_state,
+        e.version_constraint,
+        e.expected_interface_id,
+        (COALESCE(c.visibility = 'public', false)
+         OR COALESCE(c.organization_id = $5::uuid, false)) AS source_visible,
+        c.contract_id  AS source_address,
+        c.name         AS source_name,
+        c.interface_id AS source_interface_id
+    FROM contract_dependency_edges e
+    JOIN contracts c ON c.id = e.source_contract_id
+    WHERE e.network = $2
+      -- Only a resolved edge names a contract that could be a dependent.
+      AND e.target_contract_id IS NOT NULL
+      AND (
+            ($3::timestamptz IS NULL AND e.superseded_at IS NULL)
+         OR ($3::timestamptz IS NOT NULL
+             AND e.recorded_at <= $3
+             AND (e.superseded_at IS NULL OR e.superseded_at > $3))
+          )
+      AND ($6::boolean OR e.edge_source = 'declared')
+
+    UNION ALL
+
+    SELECT DISTINCT
+        a.source_contract_id,
+        a.target_contract_id,
+        s.contract_id AS target_ref,
+        a.network,
+        'telemetry'::text,
+        'resolved'::text,
+        NULL::text,
+        NULL::text,
+        (COALESCE(s.visibility = 'public', false)
+         OR COALESCE(s.organization_id = $5::uuid, false)) AS source_visible,
+        s.contract_id,
+        s.name,
+        s.interface_id
+    FROM contract_call_edge_daily_aggregates a
+    JOIN contracts s ON s.id = a.source_contract_id
+    WHERE $6::boolean
+      AND a.network = $2
+      AND ($3::timestamptz IS NULL OR a.day <= $3::date)
+),
+walk AS (
+    -- Column names match the forward query exactly -- `target_contract_id` here
+    -- is the dependent -- so one row struct, one diagnostic derivation, and one
+    -- ordering serve both directions.
+    SELECT
+        1 AS depth,
+        e.target_contract_id AS source_contract_id,
+        e.source_contract_id AS target_contract_id,
+        e.target_ref,
+        e.network,
+        e.edge_source,
+        e.edge_state,
+        e.version_constraint,
+        e.expected_interface_id,
+        e.source_visible   AS target_visible,
+        e.source_address   AS target_address,
+        e.source_name      AS target_name,
+        e.source_interface_id AS target_interface_id,
+        ARRAY[e.target_contract_id, e.source_contract_id] AS path,
+        NULL::uuid AS cycle_with,
+        (NOT e.source_visible) AS terminal
+    FROM edges e
+    WHERE e.target_contract_id = $1
+
+    UNION ALL
+
+    SELECT
+        w.depth + 1,
+        e.target_contract_id,
+        e.source_contract_id,
+        e.target_ref,
+        e.network,
+        e.edge_source,
+        e.edge_state,
+        e.version_constraint,
+        e.expected_interface_id,
+        e.source_visible,
+        e.source_address,
+        e.source_name,
+        e.source_interface_id,
+        CASE WHEN e.source_contract_id = ANY(w.path)
+             THEN w.path
+             ELSE w.path || e.source_contract_id
+        END,
+        CASE WHEN e.source_contract_id = ANY(w.path) THEN e.source_contract_id END,
+        (NOT e.source_visible OR e.source_contract_id = ANY(w.path)) AS terminal
+    FROM walk w
+    JOIN edges e ON e.target_contract_id = w.target_contract_id
+    WHERE w.depth < $4
+      AND NOT w.terminal
+)
+SELECT
+    w.depth,
+    w.target_contract_id,
+    w.target_ref,
+    w.network,
+    w.edge_source,
+    w.edge_state,
+    w.version_constraint,
+    w.expected_interface_id,
+    w.source_contract_id,
+    w.path,
+    w.cycle_with,
+    w.terminal,
+    w.target_visible AS visible,
+    CASE WHEN w.target_visible THEN w.target_address END AS target_address,
+    CASE WHEN w.target_visible THEN w.target_name END AS target_name,
+    CASE WHEN w.target_visible THEN w.target_interface_id END AS current_interface_id
+FROM walk w
+ORDER BY w.depth ASC, w.network ASC, w.target_contract_id ASC NULLS LAST,
+         w.target_ref ASC, w.edge_source ASC
+LIMIT $7
+"#;
+
+/// Walk the dependency graph from `request.root`.
+pub async fn traverse(pool: &PgPool, request: &TraversalRequest) -> ApiResult<TraversalResult> {
+    let depth = request.effective_depth();
+    let budget = request.effective_max_nodes();
+
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|err| db_internal_error("begin dependency traversal", err))?;
+
+    apply_statement_timeout(&mut tx).await?;
+
+    let sql = match request.direction {
+        Direction::Dependencies => FORWARD_TRAVERSAL_SQL,
+        Direction::Dependents => REVERSE_TRAVERSAL_SQL,
+    };
+
+    let rows: Vec<TraversedEdgeRow> = sqlx::query_as(sql)
+        .bind(request.root)
+        .bind(request.network)
+        .bind(request.as_of)
+        .bind(depth as i32)
+        .bind(request.caller_org)
+        .bind(request.include_telemetry)
+        // +1 row is the truncation probe; see FORWARD_TRAVERSAL_SQL.
+        .bind(budget as i64 + 1)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(traversal_error)?;
+
+    // The transaction is read-only; committing releases the connection and the
+    // SET LOCAL timeout in one step.
+    tx.commit()
+        .await
+        .map_err(|err| db_internal_error("commit dependency traversal", err))?;
+
+    Ok(assemble(rows, depth, budget))
+}
+
+/// Bound the query in wall-clock time as well as in rows.
+///
+/// `SET LOCAL` scopes the timeout to this transaction, so a pooled connection
+/// is never handed to the next request carrying a modified timeout.
+async fn apply_statement_timeout(tx: &mut Transaction<'_, Postgres>) -> ApiResult<()> {
+    // Interpolated, not bound: SET does not accept bind parameters. The value is
+    // a compile-time constant, never caller input.
+    let sql = format!("SET LOCAL statement_timeout = {TRAVERSAL_STATEMENT_TIMEOUT_MS}");
+    sqlx::query(&sql)
+        .execute(&mut **tx)
+        .await
+        .map_err(|err| db_internal_error("set traversal statement timeout", err))?;
+    Ok(())
+}
+
+/// Map a traversal failure, distinguishing the time budget from a real error.
+///
+/// A statement timeout is `57014 query_canceled`. Reporting it as a 500 would
+/// tell the operator the registry is broken when in fact their graph is too
+/// large for the budget -- a different problem with a different fix.
+fn traversal_error(err: sqlx::Error) -> ApiError {
+    if let sqlx::Error::Database(ref db_err) = err {
+        if db_err.code().as_deref() == Some("57014") {
+            return ApiError::service_unavailable_with(
+                "DependencyTraversalTimeout",
+                format!(
+                    "The dependency traversal exceeded its {TRAVERSAL_STATEMENT_TIMEOUT_MS}ms budget. Retry with a smaller depth or max_nodes."
+                ),
+            );
+        }
+    }
+    db_internal_error("dependency traversal", err)
+}
+
+/// Turn raw rows into a result: trim the probe row, and derive the diagnostics
+/// that the SQL deliberately does not compute.
+fn assemble(mut rows: Vec<TraversedEdgeRow>, depth: u32, budget: usize) -> TraversalResult {
+    let mut truncated = false;
+    let mut truncation_reason = None;
+
+    if rows.len() > budget {
+        rows.truncate(budget);
+        truncated = true;
+        truncation_reason = Some(TruncationReason::NodeLimit);
+    } else if rows
+        .iter()
+        .any(|row| row.depth as u32 >= depth && !row.terminal)
+    {
+        // Truncated only if a row sitting *at* the depth limit could still have
+        // been descended from. A chain that happens to be exactly `depth` long
+        // and ends in terminal rows is a complete answer, and reporting it as
+        // truncated would make every exact-fit graph look clipped.
+        truncated = true;
+        truncation_reason = Some(TruncationReason::DepthLimit);
+    }
+
+    let mut diagnostics = derive_diagnostics(&rows);
+
+    if let Some(reason) = truncation_reason {
+        let limit = match reason {
+            TruncationReason::NodeLimit => budget as u64,
+            TruncationReason::DepthLimit => depth as u64,
+            TruncationReason::TimeLimit => u64::from(TRAVERSAL_STATEMENT_TIMEOUT_MS),
+        };
+        diagnostics.push(Diagnostic {
+            kind: DiagnosticKind::Truncated,
+            path: Vec::new(),
+            detail: reason.detail(limit),
+        });
+    }
+
+    sort_diagnostics(&mut diagnostics);
+
+    TraversalResult {
+        rows,
+        diagnostics,
+        truncated,
+        truncation_reason,
+    }
+}
+
+/// Diagnostics derivable from the returned rows alone.
+///
+/// Cycles are found here rather than in SQL because the CTE's guard *prevents*
+/// the revisit -- it never emits the row that would prove the loop. The evidence
+/// is instead an edge whose target already appears on its own path prefix.
+fn derive_diagnostics(rows: &[TraversedEdgeRow]) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    for row in rows {
+        match row.edge_state.as_str() {
+            "unresolved" => diagnostics.push(Diagnostic {
+                kind: DiagnosticKind::UnresolvedEdge,
+                path: row.path.clone(),
+                detail: unresolved_detail(&row.target_ref),
+            }),
+            "network_mismatch" => diagnostics.push(Diagnostic {
+                kind: DiagnosticKind::NetworkMismatch,
+                path: row.path.clone(),
+                detail: format!(
+                    "'{}' is registered on a different network than {}",
+                    row.target_ref, row.network
+                ),
+            }),
+            _ => {}
+        }
+
+        if !row.visible {
+            diagnostics.push(Diagnostic {
+                kind: DiagnosticKind::RedactedNode,
+                path: row.path.clone(),
+                detail: format!("a node at depth {} is not visible to you", row.depth),
+            });
+        }
+
+        // `cycle_with` is set by the CTE on the one row that closes a loop. It
+        // has to come from the query rather than be inferred here, because the
+        // guard stops the walk *before* the repeat would show up in the path.
+        if let Some(repeated) = row.cycle_with {
+            if let Some(segment) = cycle_segment(&row.path, repeated) {
+                diagnostics.push(Diagnostic {
+                    kind: DiagnosticKind::Cycle,
+                    path: segment,
+                    detail: "dependency cycle; traversal stopped at the repeated contract"
+                        .to_string(),
+                });
+            }
+        }
+    }
+
+    // Several paths can produce the same diagnostic; sorting first makes dedup
+    // total rather than only collapsing adjacent duplicates.
+    sort_diagnostics(&mut diagnostics);
+    diagnostics.dedup();
+    diagnostics
+}
+
+/// Unresolved edges are split by shape (Issue #1147).
+///
+/// After dependencies stopped being inferred from arbitrary strings, most
+/// unresolved references are free-form library names, and treating every one as
+/// a gap would bury the real signal. A syntactically valid contract address that
+/// is not registered is a genuine hole in the graph; anything else is an
+/// undeclared library and merely informational.
+fn unresolved_detail(target_ref: &str) -> String {
+    if crate::validation::validate_contract_id(target_ref).is_ok() {
+        format!("'{target_ref}' is a valid contract address but is not registered")
+    } else {
+        format!("'{target_ref}' is not a contract address; treated as an undeclared library")
+    }
+}
+
+/// Parse the textual `edge_source`/`edge_state` columns back into the shared
+/// enums. Unknown values degrade rather than fail: a future enum value added by
+/// a newer migration must not 500 an older reader.
+pub fn parse_edge_source(value: &str) -> EdgeSource {
+    match value {
+        "telemetry" => EdgeSource::Telemetry,
+        _ => EdgeSource::Declared,
+    }
+}
+
+pub fn parse_edge_state(value: &str) -> EdgeState {
+    match value {
+        "resolved" => EdgeState::Resolved,
+        "network_mismatch" => EdgeState::NetworkMismatch,
+        _ => EdgeState::Unresolved,
+    }
+}

--- a/backend/api/src/dependency_handlers.rs
+++ b/backend/api/src/dependency_handlers.rs
@@ -226,28 +226,45 @@ async fn dependency_tree(
 
 /// Rebuild the nested tree from the flat, path-carrying traversal rows.
 ///
-/// Each row already knows its full root-to-node path, so nesting is a single
-/// grouping pass keyed on the parent -- no further queries, and no recursion
-/// over the database. A node that appears under two parents is emitted under
-/// each, which is what the tree shape means; it is expanded only once by the
-/// traversal itself.
+/// Grouping is keyed on the **parent path**, not on the parent contract id.
+/// Keying on the id alone conflates every occurrence of a contract that is
+/// reachable by more than one route: in a diamond, the shared node's children
+/// would be attached once per incoming path and then rendered under every
+/// occurrence, multiplying the subtree.
+///
+/// Each row already carries its full root-to-here path, so this is a single
+/// grouping pass -- no further queries and no recursion over the database.
 fn nest(rows: &[TraversedEdgeRow], root: Uuid) -> Vec<DependencyNode> {
-    let mut by_parent: BTreeMap<Uuid, Vec<&TraversedEdgeRow>> = BTreeMap::new();
+    let mut by_parent: BTreeMap<Vec<Uuid>, Vec<&TraversedEdgeRow>> = BTreeMap::new();
     for row in rows {
         by_parent
-            .entry(row.source_contract_id)
+            .entry(parent_path(row).to_vec())
             .or_default()
             .push(row);
     }
-    children_of(&by_parent, root, 1)
+    children_of(&by_parent, &[root], 1)
+}
+
+/// The path of the node this row hangs under.
+///
+/// A row that contributed a node (resolved, non-cycle) has `path` ending at
+/// that node, so its parent is one element shorter. A row that contributed no
+/// node -- unresolved, or cycle-closing -- already ends at its source, which is
+/// its parent.
+fn parent_path(row: &TraversedEdgeRow) -> &[Uuid] {
+    if row.target_contract_id.is_some() && row.cycle_with.is_none() {
+        &row.path[..row.path.len().saturating_sub(1)]
+    } else {
+        &row.path
+    }
 }
 
 fn children_of(
-    by_parent: &BTreeMap<Uuid, Vec<&TraversedEdgeRow>>,
-    parent: Uuid,
+    by_parent: &BTreeMap<Vec<Uuid>, Vec<&TraversedEdgeRow>>,
+    parent: &[Uuid],
     depth: usize,
 ) -> Vec<DependencyNode> {
-    let Some(rows) = by_parent.get(&parent) else {
+    let Some(rows) = by_parent.get(parent) else {
         return Vec::new();
     };
 
@@ -255,10 +272,11 @@ fn children_of(
         .map(|row| {
             let is_circular = row.cycle_with.is_some();
             // A cycle-closing row must not be expanded again here, or the tree
-            // would be infinite even though the traversal terminated.
-            let dependencies = match (row.target_contract_id, is_circular) {
-                (Some(target), false) => children_of(by_parent, target, depth + 1),
-                _ => Vec::new(),
+            // would be infinite even though the traversal itself terminated.
+            let dependencies = if is_circular || row.target_contract_id.is_none() {
+                Vec::new()
+            } else {
+                children_of(by_parent, &row.path, depth + 1)
             };
 
             DependencyNode {
@@ -266,8 +284,8 @@ fn children_of(
                 resolved_id: row.target_contract_id.filter(|_| row.visible),
                 name: row.target_name.clone(),
                 // Call volume is not carried by the edge model; the aggregate
-                // table remains the source for it and is reported separately by
-                // the graph endpoints rather than guessed at here.
+                // table remains the source for it and is reported by the graph
+                // endpoints rather than guessed at here.
                 call_volume: 0,
                 status: node_status(row),
                 is_circular,

--- a/backend/api/src/dependency_handlers.rs
+++ b/backend/api/src/dependency_handlers.rs
@@ -1,190 +1,311 @@
+//! Contract dependency endpoints.
+//!
+//! The read path was rebuilt on the bounded recursive traversal in
+//! [`crate::dependency_graph`] (Issue #1147). What it replaced had three
+//! defects that are worth naming, because each is easy to reintroduce:
+//!
+//! - It queried `contract_dependencies` under a *call* shape
+//!   (`caller_id` / `callee_contract_id` / `call_volume`) that no migration ever
+//!   created, so the endpoint could only ever fail.
+//! - Its `LEFT JOIN contracts c ON c.contract_id = cd.callee_contract_id` had no
+//!   network qualifier. Since `contracts` is `UNIQUE(contract_id, network)`, an
+//!   address deployed on two networks matched **two** rows: a duplicate edge plus
+//!   silent cross-network contamination.
+//! - It was `#[async_recursion]` and called `visited.remove()` on unwind, so a
+//!   diamond was re-expanded once per incoming path -- exponential on wide
+//!   graphs, and non-deterministic about which path it reported.
+
 use crate::validation::extractors::ValidatedJson;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     Json,
 };
+use shared::dependency_graph::{DiagnosticKind, EdgeState};
 use shared::{ContractDependency, DependencyDeclaration, DependencyNode, DependencyResponse};
-use sqlx::Row;
-use std::collections::HashSet;
+use std::collections::BTreeMap;
 use uuid::Uuid;
 
 use crate::{
-    dependency,
+    contract_ref, dependency,
+    dependency_graph::{self, Direction, TraversalRequest, TraversedEdgeRow},
     error::{ApiError, ApiResult},
     handlers::db_internal_error,
     state::AppState,
 };
 
+/// Query parameters shared by the dependency read endpoints.
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct DependencyQuery {
+    /// Required to disambiguate a bare contract address, which is only unique
+    /// per `(contract_id, network)`.
+    pub network: Option<shared::Network>,
+    /// Walk the whole closure rather than only direct edges. Defaults to true so
+    /// the endpoint keeps its historical recursive behaviour.
+    pub transitive: Option<bool>,
+    pub depth: Option<u32>,
+    pub max_nodes: Option<usize>,
+    /// Replay the declared graph as it stood at this instant.
+    pub as_of: Option<chrono::DateTime<chrono::Utc>>,
+    /// Include on-chain call edges alongside declared ones.
+    pub include_telemetry: Option<bool>,
+}
+
 /// GET /api/contracts/:id/dependencies
-/// Returns the full recursive dependency tree (backward-compatible handler).
+///
+/// `:id` accepts a registry UUID or a Stellar contract address. A bare address
+/// registered on more than one network is a 409 with the candidates, not a
+/// silent pick.
+#[utoipa::path(
+    get,
+    path = "/api/contracts/{id}/dependencies",
+    params(
+        ("id" = String, Path, description = "Contract UUID or Stellar contract address"),
+        ("network" = Option<String>, Query, description = "mainnet | testnet | futurenet. Required to disambiguate an address registered on more than one network"),
+        ("transitive" = Option<bool>, Query, description = "Walk the whole closure (default true) rather than direct edges only"),
+        ("depth" = Option<u32>, Query, description = "Maximum traversal depth, capped server-side"),
+        ("max_nodes" = Option<u32>, Query, description = "Maximum nodes returned, capped server-side"),
+        ("as_of" = Option<String>, Query, description = "RFC3339 instant; replays the declared graph as it stood then"),
+        ("include_telemetry" = Option<bool>, Query, description = "Include on-chain call edges alongside declared ones")
+    ),
+    responses(
+        (status = 200, description = "Dependency tree", body = DependencyResponse),
+        (status = 400, description = "The id is neither a UUID nor a contract address"),
+        (status = 404, description = "Contract not found"),
+        (status = 409, description = "Ambiguous contract address; retry with ?network="),
+        (status = 503, description = "Traversal exceeded its time budget")
+    ),
+    tag = "Graphs"
+)]
 pub async fn get_contract_dependencies(
     State(state): State<AppState>,
-    Path(id): Path<Uuid>,
+    Path(id): Path<String>,
+    Query(query): Query<DependencyQuery>,
 ) -> ApiResult<Json<DependencyResponse>> {
-    let response = get_contract_dependencies_internal(&state, id).await?;
+    let contract = contract_ref::resolve(&state, &id, query.network).await?;
+    let response = dependency_tree(&state, contract, &query, Direction::Dependencies).await?;
     Ok(Json(response))
 }
 
+/// GET /api/contracts/:id/dependents
+///
+/// The reverse edges: what would be affected if this contract changed.
+#[utoipa::path(
+    get,
+    path = "/api/contracts/{id}/dependents",
+    params(
+        ("id" = String, Path, description = "Contract UUID or Stellar contract address"),
+        ("network" = Option<String>, Query, description = "mainnet | testnet | futurenet. Required to disambiguate an address registered on more than one network"),
+        ("transitive" = Option<bool>, Query, description = "Walk the whole closure (default true) rather than direct edges only"),
+        ("depth" = Option<u32>, Query, description = "Maximum traversal depth, capped server-side"),
+        ("max_nodes" = Option<u32>, Query, description = "Maximum nodes returned, capped server-side"),
+        ("as_of" = Option<String>, Query, description = "RFC3339 instant; replays the declared graph as it stood then"),
+        ("include_telemetry" = Option<bool>, Query, description = "Include on-chain call edges alongside declared ones")
+    ),
+    responses(
+        (status = 200, description = "Dependent tree", body = DependencyResponse),
+        (status = 400, description = "The id is neither a UUID nor a contract address"),
+        (status = 404, description = "Contract not found"),
+        (status = 409, description = "Ambiguous contract address; retry with ?network="),
+        (status = 503, description = "Traversal exceeded its time budget")
+    ),
+    tag = "Graphs"
+)]
+pub async fn get_contract_dependents(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Query(query): Query<DependencyQuery>,
+) -> ApiResult<Json<DependencyResponse>> {
+    let contract = contract_ref::resolve(&state, &id, query.network).await?;
+    let response = dependency_tree(&state, contract, &query, Direction::Dependents).await?;
+    Ok(Json(response))
+}
+
+/// GraphQL entry point (`Contract.dependencies`).
+///
+/// Takes a UUID because GraphQL has already resolved the contract; the network
+/// is read from the row rather than guessed.
 pub(crate) async fn get_contract_dependencies_internal(
     state: &AppState,
     id: Uuid,
 ) -> ApiResult<DependencyResponse> {
-    // 1. Fetch the root contract
-    let root_contract = sqlx::query(
-        "SELECT id, contract_id, name, verification_status FROM contracts WHERE id = $1",
+    let network: shared::Network =
+        sqlx::query_scalar("SELECT network FROM contracts WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|err| db_internal_error("get root contract for dependencies", err))?
+            .ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
+
+    dependency_tree(
+        state,
+        contract_ref::ResolvedContract { uuid: id, network },
+        &DependencyQuery::default(),
+        Direction::Dependencies,
     )
-    .bind(id)
+    .await
+}
+
+/// Run the traversal and fold its flat rows back into the nested
+/// [`DependencyResponse`] shape.
+///
+/// The response type is kept **field-stable**: `graphql/types.rs` resolves
+/// `Contract.dependencies` through it, so fields may be added with serde
+/// defaults but never renamed or removed.
+async fn dependency_tree(
+    state: &AppState,
+    contract: contract_ref::ResolvedContract,
+    query: &DependencyQuery,
+    direction: Direction,
+) -> ApiResult<DependencyResponse> {
+    let root = sqlx::query_as::<_, (String, String, String)>(
+        "SELECT contract_id, name, verification_status::text FROM contracts WHERE id = $1",
+    )
+    .bind(contract.uuid)
     .fetch_optional(&state.db)
     .await
     .map_err(|err| db_internal_error("get root contract for dependencies", err))?
     .ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
 
-    let root_internal_id: Uuid = root_contract.get("id");
-    let root_c_id: String = root_contract.get("contract_id");
-    let root_name: String = root_contract.get("name");
-    let verification_status: String = root_contract.get("verification_status");
-
-    // Default status for root (string form)
-    let root_status = verification_status;
-
-    // 2. Build the tree using DFS and a visited set to detect circular references
-    let mut visited = HashSet::new();
-    visited.insert(root_internal_id);
-
-    let mut context = DependencyContext {
-        db: state.db.clone(),
-        total_dependencies: 0,
-        max_depth: 0,
-        has_circular: false,
-        depth_limit: 20,
+    let request = TraversalRequest {
+        root: contract.uuid,
+        network: contract.network,
+        direction,
+        transitive: query.transitive.unwrap_or(true),
+        max_depth: query
+            .depth
+            .unwrap_or(shared::dependency_graph::DEFAULT_MAX_DEPTH),
+        max_nodes: query
+            .max_nodes
+            .unwrap_or(shared::dependency_graph::DEFAULT_MAX_NODES),
+        as_of: query.as_of,
+        // Tenancy is enforced inside the traversal; this endpoint has no
+        // authenticated actor, so it sees the public graph only.
+        caller_org: None,
+        include_telemetry: query.include_telemetry.unwrap_or(false),
     };
 
-    let children = build_dependency_tree(
-        &mut context,
-        root_internal_id,
-        &mut visited,
-        1, // Current depth
-    )
-    .await?;
+    let result = dependency_graph::traverse(&state.db, &request).await?;
 
-    let root_node = DependencyNode {
-        contract_id: root_c_id,
-        resolved_id: Some(root_internal_id),
-        name: Some(root_name),
-        call_volume: 0, // Root volume is undefined or total calls
-        status: root_status.to_string(),
-        is_circular: false,
-        dependencies: children,
-        visualization_hints: serde_json::json!({
-            "node_type": "root",
-            "depth": 0
-        }),
-    };
+    let has_circular = result
+        .diagnostics
+        .iter()
+        .any(|d| d.kind == DiagnosticKind::Cycle);
+    let max_depth = result
+        .rows
+        .iter()
+        .map(|r| r.depth as usize)
+        .max()
+        .unwrap_or(0);
+    let total_dependencies = result.rows.len();
+
+    let (root_contract_id, root_name, root_status) = root;
 
     Ok(DependencyResponse {
-        root: root_node,
-        total_dependencies: context.total_dependencies,
-        max_depth: context.max_depth,
-        has_circular: context.has_circular,
+        root: DependencyNode {
+            contract_id: root_contract_id,
+            resolved_id: Some(contract.uuid),
+            name: Some(root_name),
+            call_volume: 0,
+            status: root_status,
+            is_circular: false,
+            dependencies: nest(&result.rows, contract.uuid),
+            visualization_hints: serde_json::json!({
+                "node_type": "root",
+                "depth": 0,
+                "truncated": result.truncated,
+                "truncation_reason": result.truncation_reason,
+                "diagnostics": result.diagnostics,
+            }),
+        },
+        total_dependencies,
+        max_depth,
+        has_circular,
     })
 }
 
-struct DependencyContext {
-    db: sqlx::PgPool,
-    total_dependencies: usize,
-    max_depth: usize,
-    has_circular: bool,
-    depth_limit: usize,
+/// Rebuild the nested tree from the flat, path-carrying traversal rows.
+///
+/// Each row already knows its full root-to-node path, so nesting is a single
+/// grouping pass keyed on the parent -- no further queries, and no recursion
+/// over the database. A node that appears under two parents is emitted under
+/// each, which is what the tree shape means; it is expanded only once by the
+/// traversal itself.
+fn nest(rows: &[TraversedEdgeRow], root: Uuid) -> Vec<DependencyNode> {
+    let mut by_parent: BTreeMap<Uuid, Vec<&TraversedEdgeRow>> = BTreeMap::new();
+    for row in rows {
+        by_parent
+            .entry(row.source_contract_id)
+            .or_default()
+            .push(row);
+    }
+    children_of(&by_parent, root, 1)
 }
 
-#[async_recursion::async_recursion]
-async fn build_dependency_tree(
-    ctx: &mut DependencyContext,
-    caller_internal_id: Uuid,
-    visited: &mut HashSet<Uuid>,
+fn children_of(
+    by_parent: &BTreeMap<Uuid, Vec<&TraversedEdgeRow>>,
+    parent: Uuid,
     depth: usize,
-) -> Result<Vec<DependencyNode>, ApiError> {
-    if depth > ctx.max_depth {
-        ctx.max_depth = depth;
-    }
+) -> Vec<DependencyNode> {
+    let Some(rows) = by_parent.get(&parent) else {
+        return Vec::new();
+    };
 
-    // Safety limit to prevent extremely deep graphs from dragging down the server
-    if depth > ctx.depth_limit {
-        return Ok(vec![]);
-    }
+    rows.iter()
+        .map(|row| {
+            let is_circular = row.cycle_with.is_some();
+            // A cycle-closing row must not be expanded again here, or the tree
+            // would be infinite even though the traversal terminated.
+            let dependencies = match (row.target_contract_id, is_circular) {
+                (Some(target), false) => children_of(by_parent, target, depth + 1),
+                _ => Vec::new(),
+            };
 
-    // Fetch all outgoing dependencies from `caller_internal_id`
-    // We use a LEFT JOIN to see if the callee_contract_id exists in our registry
-    let rows = sqlx::query(
-        r#"
-        SELECT 
-            cd.callee_contract_id, 
-            cd.call_volume,
-            c.id as resolved_id,
-            c.name as resolved_name,
-            c.verification_status as verification_status
-        FROM contract_dependencies cd
-        LEFT JOIN contracts c ON c.contract_id = cd.callee_contract_id
-        WHERE cd.caller_id = $1
-        ORDER BY cd.call_volume DESC
-        "#,
-    )
-    .bind(caller_internal_id)
-    .fetch_all(&ctx.db)
-    .await
-    .map_err(|err| db_internal_error("fetch node children", err))?;
-
-    let mut children = Vec::new();
-
-    for row in rows {
-        ctx.total_dependencies += 1;
-
-        let callee_c_id: String = row.get("callee_contract_id");
-        let call_volume: i32 = row.get("call_volume");
-        let resolved_id: Option<Uuid> = row.get("resolved_id");
-        let resolved_name: Option<String> = row.get("resolved_name");
-        let verification_status: Option<String> = row.get("verification_status");
-
-        let status = if let Some(s) = verification_status.clone() {
-            s
-        } else if resolved_id.is_some() {
-            "unverified".to_string()
-        } else {
-            "unknown".to_string()
-        };
-
-        let mut is_circular = false;
-        let mut sub_dependencies = Vec::new();
-
-        if let Some(r_id) = resolved_id {
-            if visited.contains(&r_id) {
-                is_circular = true;
-                ctx.has_circular = true;
-            } else {
-                // Traverse deeper
-                visited.insert(r_id);
-                sub_dependencies = build_dependency_tree(ctx, r_id, visited, depth + 1).await?;
-                visited.remove(&r_id);
+            DependencyNode {
+                contract_id: display_ref(row),
+                resolved_id: row.target_contract_id.filter(|_| row.visible),
+                name: row.target_name.clone(),
+                // Call volume is not carried by the edge model; the aggregate
+                // table remains the source for it and is reported separately by
+                // the graph endpoints rather than guessed at here.
+                call_volume: 0,
+                status: node_status(row),
+                is_circular,
+                dependencies,
+                visualization_hints: serde_json::json!({
+                    "depth": depth,
+                    "node_type": if is_circular { "circular" } else { "standard" },
+                    "edge_source": row.edge_source,
+                    "edge_state": row.edge_state,
+                    "redacted": !row.visible,
+                }),
             }
-        }
+        })
+        .collect()
+}
 
-        children.push(DependencyNode {
-            contract_id: callee_c_id,
-            resolved_id,
-            name: resolved_name,
-            call_volume,
-            status: status.to_string(),
-            is_circular,
-            dependencies: sub_dependencies,
-            visualization_hints: serde_json::json!({
-                "depth": depth,
-                "node_type": if is_circular { "circular" } else { "standard" }
-            }),
-        });
+/// What to call a node in the response.
+///
+/// A redacted node is named by neither address nor name -- only the fact that it
+/// exists. Echoing `target_ref` would defeat the redaction, since the reference
+/// *is* the private contract's address.
+fn display_ref(row: &TraversedEdgeRow) -> String {
+    if row.visible {
+        row.target_address
+            .clone()
+            .unwrap_or_else(|| row.target_ref.clone())
+    } else {
+        "[redacted]".to_string()
     }
+}
 
-    Ok(children)
+fn node_status(row: &TraversedEdgeRow) -> String {
+    match dependency_graph::parse_edge_state(&row.edge_state) {
+        EdgeState::Resolved if !row.visible => "redacted".to_string(),
+        EdgeState::Resolved => "resolved".to_string(),
+        EdgeState::Unresolved => "unresolved".to_string(),
+        EdgeState::NetworkMismatch => "network_mismatch".to_string(),
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -318,337 +439,4 @@ pub async fn declare_contract_dependencies(
             unresolved,
         }),
     ))
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Issue #726 — New dependency tracking endpoints
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Query params for GET /api/contracts/:id/direct-dependencies
-#[derive(Debug, serde::Deserialize)]
-pub struct DirectDepsQuery {
-    /// Filter by dependency type: import, call, data
-    pub dep_type: Option<String>,
-}
-
-/// A flat direct dependency entry
-#[derive(Debug, serde::Serialize)]
-pub struct DirectDep {
-    pub callee_contract_id: String,
-    pub resolved_id: Option<Uuid>,
-    pub name: Option<String>,
-    pub call_volume: i32,
-    pub dep_type: String,
-    pub is_verified: bool,
-    pub status: String,
-    pub is_resolvable: bool,
-}
-
-/// Response for GET /api/contracts/:id/direct-dependencies
-#[derive(Debug, serde::Serialize)]
-pub struct DirectDependenciesResponse {
-    pub contract_id: Uuid,
-    pub dependencies: Vec<DirectDep>,
-    pub total: usize,
-}
-
-/// GET /api/contracts/:id/direct-dependencies
-///
-/// Returns only the immediate (non-recursive) dependencies of a contract.
-/// Accepts optional `?dep_type=import|call|data` to filter by relationship type.
-pub async fn get_direct_contract_dependencies(
-    State(state): State<AppState>,
-    Path(id): Path<Uuid>,
-    Query(params): Query<DirectDepsQuery>,
-) -> ApiResult<Json<DirectDependenciesResponse>> {
-    let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM contracts WHERE id = $1")
-        .bind(id)
-        .fetch_one(&state.db)
-        .await
-        .map_err(|e| db_internal_error("check contract exists", e))?;
-
-    if !exists {
-        return Err(ApiError::not_found(
-            "ContractNotFound",
-            "Contract not found",
-        ));
-    }
-
-    let rows = sqlx::query(
-        r#"
-        SELECT
-            cd.callee_contract_id,
-            cd.call_volume,
-            cd.is_verified,
-            COALESCE(cd.dep_type, 'call') AS dep_type,
-            c.id          AS resolved_id,
-            c.name        AS resolved_name,
-            c.verification_status
-        FROM contract_dependencies cd
-        LEFT JOIN contracts c ON c.contract_id = cd.callee_contract_id
-        WHERE cd.caller_id = $1
-          AND ($2::text IS NULL OR COALESCE(cd.dep_type, 'call') = $2)
-        ORDER BY cd.call_volume DESC
-        "#,
-    )
-    .bind(id)
-    .bind(params.dep_type.as_deref())
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| db_internal_error("fetch direct dependencies", e))?;
-
-    let dependencies: Vec<DirectDep> = rows
-        .iter()
-        .map(|row| {
-            let callee_contract_id: String = row.get("callee_contract_id");
-            let call_volume: i32 = row.get("call_volume");
-            let is_verified: bool = row.get("is_verified");
-            let dep_type: String = row.get("dep_type");
-            let resolved_id: Option<Uuid> = row.get("resolved_id");
-            let resolved_name: Option<String> = row.get("resolved_name");
-            let verification_status: Option<String> = row.get("verification_status");
-            let is_resolvable = resolved_id.is_some();
-            let status = verification_status.unwrap_or_else(|| {
-                if is_resolvable {
-                    "unverified".to_string()
-                } else {
-                    "unresolvable".to_string()
-                }
-            });
-            DirectDep {
-                callee_contract_id,
-                resolved_id,
-                name: resolved_name,
-                call_volume,
-                dep_type,
-                is_verified,
-                status,
-                is_resolvable,
-            }
-        })
-        .collect();
-
-    let total = dependencies.len();
-    Ok(Json(DirectDependenciesResponse {
-        contract_id: id,
-        dependencies,
-        total,
-    }))
-}
-
-/// GET /api/contracts/:id/dependency-tree
-///
-/// Returns the full recursive dependency tree limited to MAX_TREE_DEPTH levels.
-/// Circular dependencies are detected and flagged rather than traversed.
-const MAX_TREE_DEPTH: usize = 5;
-
-pub async fn get_contract_dependency_tree(
-    State(state): State<AppState>,
-    Path(id): Path<Uuid>,
-) -> ApiResult<Json<DependencyResponse>> {
-    let root_contract = sqlx::query(
-        "SELECT id, contract_id, name, verification_status FROM contracts WHERE id = $1",
-    )
-    .bind(id)
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|err| db_internal_error("get root contract for dependency tree", err))?
-    .ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
-
-    let root_internal_id: Uuid = root_contract.get("id");
-    let root_c_id: String = root_contract.get("contract_id");
-    let root_name: String = root_contract.get("name");
-    let verification_status: String = root_contract.get("verification_status");
-
-    let mut visited = HashSet::new();
-    visited.insert(root_internal_id);
-
-    let mut context = DependencyContext {
-        db: state.db.clone(),
-        total_dependencies: 0,
-        max_depth: 0,
-        has_circular: false,
-        depth_limit: MAX_TREE_DEPTH,
-    };
-
-    let children = build_dependency_tree(&mut context, root_internal_id, &mut visited, 1).await?;
-
-    let root_node = DependencyNode {
-        contract_id: root_c_id,
-        resolved_id: Some(root_internal_id),
-        name: Some(root_name),
-        call_volume: 0,
-        status: verification_status,
-        is_circular: false,
-        dependencies: children,
-        visualization_hints: serde_json::json!({ "node_type": "root", "depth": 0 }),
-    };
-
-    Ok(Json(DependencyResponse {
-        root: root_node,
-        total_dependencies: context.total_dependencies,
-        max_depth: context.max_depth,
-        has_circular: context.has_circular,
-    }))
-}
-
-/// A single resolved transitive dependency
-#[derive(Debug, serde::Serialize)]
-pub struct TransitiveDep {
-    pub id: Uuid,
-    pub name: String,
-    pub contract_id: String,
-    pub depth: usize,
-}
-
-/// Response for POST /api/contracts/:id/resolve-dependencies
-#[derive(Debug, serde::Serialize)]
-pub struct ResolveDependenciesResponse {
-    pub contract_id: Uuid,
-    pub resolved: Vec<TransitiveDep>,
-    pub unresolvable: Vec<String>,
-    pub has_circular: bool,
-    pub circular_contracts: Vec<String>,
-    pub total_resolved: usize,
-    pub total_unresolvable: usize,
-}
-
-/// POST /api/contracts/:id/resolve-dependencies
-///
-/// Traverses the full transitive dependency graph via BFS.
-/// Returns all reachable contracts, contracts that cannot be resolved to a
-/// registry entry, and contracts that form circular references.
-/// Completes in O(nodes + edges) — well within the 500 ms acceptance criterion
-/// for typical registry graphs.
-pub async fn post_resolve_dependencies(
-    State(state): State<AppState>,
-    Path(id): Path<Uuid>,
-) -> ApiResult<Json<ResolveDependenciesResponse>> {
-    let root = sqlx::query("SELECT id FROM contracts WHERE id = $1")
-        .bind(id)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|e| db_internal_error("get root contract for resolution", e))?
-        .ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
-
-    let root_id: Uuid = root.get("id");
-
-    struct QueueItem {
-        id: Uuid,
-        depth: usize,
-    }
-
-    let mut queue = std::collections::VecDeque::new();
-    queue.push_back(QueueItem {
-        id: root_id,
-        depth: 0,
-    });
-
-    let mut visited: HashSet<Uuid> = HashSet::new();
-    visited.insert(root_id);
-
-    let mut resolved: Vec<TransitiveDep> = Vec::new();
-    let mut unresolvable: Vec<String> = Vec::new();
-    let mut circular_contracts: Vec<String> = Vec::new();
-
-    while let Some(item) = queue.pop_front() {
-        let rows = sqlx::query(
-            r#"
-            SELECT
-                cd.callee_contract_id,
-                c.id            AS resolved_id,
-                c.name          AS resolved_name,
-                c.contract_id   AS c_contract_id
-            FROM contract_dependencies cd
-            LEFT JOIN contracts c ON c.contract_id = cd.callee_contract_id
-            WHERE cd.caller_id = $1
-            "#,
-        )
-        .bind(item.id)
-        .fetch_all(&state.db)
-        .await
-        .map_err(|e| db_internal_error("fetch deps for resolution", e))?;
-
-        for row in &rows {
-            let callee_str: String = row.get("callee_contract_id");
-            let resolved_id: Option<Uuid> = row.get("resolved_id");
-            let resolved_name: Option<String> = row.get("resolved_name");
-            let c_contract_id: Option<String> = row.get("c_contract_id");
-
-            match resolved_id {
-                None => {
-                    if !unresolvable.contains(&callee_str) {
-                        unresolvable.push(callee_str);
-                    }
-                }
-                Some(dep_id) if dep_id == root_id || visited.contains(&dep_id) => {
-                    // Already visited or points back to root — circular
-                    let label = resolved_name.or(c_contract_id).unwrap_or(callee_str);
-                    if !circular_contracts.contains(&label) {
-                        circular_contracts.push(label);
-                    }
-                }
-                Some(dep_id) => {
-                    visited.insert(dep_id);
-                    resolved.push(TransitiveDep {
-                        id: dep_id,
-                        name: resolved_name.unwrap_or_default(),
-                        contract_id: c_contract_id.unwrap_or_default(),
-                        depth: item.depth + 1,
-                    });
-                    queue.push_back(QueueItem {
-                        id: dep_id,
-                        depth: item.depth + 1,
-                    });
-                }
-            }
-        }
-    }
-
-    let total_resolved = resolved.len();
-    let total_unresolvable = unresolvable.len();
-    let has_circular = !circular_contracts.is_empty();
-
-    Ok(Json(ResolveDependenciesResponse {
-        contract_id: id,
-        resolved,
-        unresolvable,
-        has_circular,
-        circular_contracts,
-        total_resolved,
-        total_unresolvable,
-    }))
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashSet;
-    use uuid::Uuid;
-
-    #[tokio::test]
-    async fn test_circular_dependency_logic() {
-        // We can test the visited set logic without db if we want,
-        // but since build_dependency_tree requires a db transaction,
-        // a pure unit test of the circular logic is best done by asserting the behavior of visited sets.
-        let mut visited = HashSet::new();
-        let id1 = Uuid::new_v4();
-        let id2 = Uuid::new_v4();
-
-        visited.insert(id1);
-
-        let mut is_circular = false;
-
-        // Simulate finding id2
-        if visited.contains(&id2) {
-            is_circular = true;
-        } else {
-            visited.insert(id2);
-            // Simulate finding id1 again
-            if visited.contains(&id1) {
-                is_circular = true;
-            }
-        }
-
-        assert!(is_circular, "Circular reference should be detected");
-    }
 }

--- a/backend/api/src/dependency_handlers.rs
+++ b/backend/api/src/dependency_handlers.rs
@@ -49,7 +49,19 @@ pub struct DependencyQuery {
     pub as_of: Option<chrono::DateTime<chrono::Utc>>,
     /// Include on-chain call edges alongside declared ones.
     pub include_telemetry: Option<bool>,
+    /// 1-based page for the flat node list on `/dependency-graph`.
+    pub page: Option<i64>,
+    /// Nodes per page. Capped by [`MAX_PER_PAGE`].
+    pub per_page: Option<i64>,
 }
+
+/// Upper bound on `per_page`.
+///
+/// Offset pagination is only defensible here because the traversal already
+/// hard-caps its result set (`max_nodes`, itself capped at 10000). This keeps a
+/// single page from simply re-requesting that whole cap.
+const MAX_PER_PAGE: i64 = 200;
+const DEFAULT_PER_PAGE: i64 = 50;
 
 /// GET /api/contracts/:id/dependencies
 ///
@@ -486,6 +498,30 @@ pub struct DependencyGraphSummary {
     pub truncation_reason: Option<shared::dependency_graph::TruncationReason>,
     /// Graph facts with no severity: cycles, unresolved edges, truncation.
     pub diagnostics: Vec<shared::dependency_graph::Diagnostic>,
+    /// The reachable set as a flat, paginated list.
+    ///
+    /// Flat rather than nested because a tree cannot be coherently paginated:
+    /// page 2 of a tree is not a tree. `/dependencies` returns the nested shape
+    /// whole (bounded by `max_nodes`); this is the pageable view of the same
+    /// traversal.
+    pub nodes: shared::PaginatedResponse<DependencyGraphNode>,
+}
+
+/// One reachable contract, flattened out of the traversal.
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct DependencyGraphNode {
+    /// The target's address, or `[redacted]` when tenancy hides it.
+    pub contract_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub depth: i32,
+    pub edge_source: String,
+    pub edge_state: String,
+    /// Root-to-node path.
+    pub path: Vec<Uuid>,
+    pub redacted: bool,
 }
 
 /// GET /api/contracts/:id/dependency-graph
@@ -498,7 +534,9 @@ pub struct DependencyGraphSummary {
         ("depth" = Option<u32>, Query, description = "Maximum traversal depth, capped server-side"),
         ("max_nodes" = Option<u32>, Query, description = "Maximum nodes returned, capped server-side"),
         ("as_of" = Option<String>, Query, description = "RFC3339 instant; replays the declared graph as it stood then"),
-        ("include_telemetry" = Option<bool>, Query, description = "Include on-chain call edges alongside declared ones")
+        ("include_telemetry" = Option<bool>, Query, description = "Include on-chain call edges alongside declared ones"),
+        ("page" = Option<i64>, Query, description = "1-based page of the flat node list (default 1)"),
+        ("per_page" = Option<i64>, Query, description = "Nodes per page, default 50, capped at 200")
     ),
     responses(
         (status = 200, description = "Dependency graph summary", body = DependencyGraphSummary),
@@ -544,9 +582,36 @@ pub async fn get_dependency_graph(
         .filter(|r| r.target_contract_id.is_none())
         .count();
 
+    // Offset pagination over the flat node list. The rows arrive in the
+    // traversal's total order, so a page boundary is stable for a given graph
+    // rather than depending on row arrival.
+    let per_page = query
+        .per_page
+        .unwrap_or(DEFAULT_PER_PAGE)
+        .clamp(1, MAX_PER_PAGE);
+    let page = query.page.unwrap_or(1).max(1);
+    let total = result.rows.len() as i64;
+    let offset = ((page - 1) * per_page).min(total) as usize;
+    let end = (offset + per_page as usize).min(result.rows.len());
+
+    let items: Vec<DependencyGraphNode> = result.rows[offset..end]
+        .iter()
+        .map(|row| DependencyGraphNode {
+            contract_id: display_ref(row),
+            resolved_id: row.target_contract_id.filter(|_| row.visible),
+            name: row.target_name.clone(),
+            depth: row.depth,
+            edge_source: row.edge_source.clone(),
+            edge_state: row.edge_state.clone(),
+            path: row.path.clone(),
+            redacted: !row.visible,
+        })
+        .collect();
+
     Ok(Json(DependencyGraphSummary {
         contract_id: contract.uuid,
         network: contract.network.to_string(),
+        nodes: shared::PaginatedResponse::new(items, total, page, per_page),
         total_dependencies: result.rows.len(),
         resolved,
         unresolved,

--- a/backend/api/src/dependency_handlers.rs
+++ b/backend/api/src/dependency_handlers.rs
@@ -197,12 +197,24 @@ pub struct DeclareDependenciesRequest {
     pub dependencies: Vec<DependencyDeclaration>,
 }
 
+/// A declaration that was stored but could not be bound to a registry contract
+/// (Issue #1147). Retained rather than dropped, because the operator declared
+/// something real; reported so it is not mistaken for a resolved dependency.
+#[derive(Debug, serde::Serialize)]
+pub struct UnresolvedDependency {
+    pub target_ref: String,
+    pub reason: String,
+}
+
 /// Response for POST /api/contracts/:id/dependencies
 #[derive(Debug, serde::Serialize)]
 pub struct DeclareDependenciesResponse {
     pub contract_id: Uuid,
     pub saved: Vec<ContractDependency>,
     pub has_circular: bool,
+    /// Empty when every declaration bound to a registered contract.
+    #[serde(default)]
+    pub unresolved: Vec<UnresolvedDependency>,
 }
 
 /// POST /api/contracts/:id/dependencies
@@ -217,19 +229,16 @@ pub async fn declare_contract_dependencies(
     Path(id): Path<Uuid>,
     ValidatedJson(body): ValidatedJson<DeclareDependenciesRequest>,
 ) -> ApiResult<(StatusCode, Json<DeclareDependenciesResponse>)> {
-    // Verify contract exists.
-    let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM contracts WHERE id = $1")
-        .bind(id)
-        .fetch_one(&state.db)
-        .await
-        .map_err(|e| db_internal_error("check contract exists", e))?;
-
-    if !exists {
-        return Err(ApiError::not_found(
-            "ContractNotFound",
-            "Contract not found",
-        ));
-    }
+    // Fetch the network alongside the existence check: a dependency reference
+    // is only meaningful within one network (Issue #1147), so the declaring
+    // contract's own network is what its targets are resolved against.
+    let network: shared::Network =
+        sqlx::query_scalar("SELECT network FROM contracts WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|e| db_internal_error("check contract exists", e))?
+            .ok_or_else(|| ApiError::not_found("ContractNotFound", "Contract not found"))?;
 
     // Pre-check for self-referential declarations.
     let self_dep = body.dependencies.iter().any(|d| d.name == id.to_string());
@@ -241,9 +250,35 @@ pub async fn declare_contract_dependencies(
     }
 
     // Save declarations (will detect cycles against existing graph in the DB).
-    dependency::save_dependencies(&state.db, id, &body.dependencies)
+    let resolutions = dependency::save_dependencies(&state.db, id, network, &body.dependencies)
         .await
         .map_err(|e| ApiError::internal(format!("Failed to save dependencies: {e}")))?;
+
+    // Surface references that were stored but could not be bound, rather than
+    // letting them appear as a silent NULL in `dependency_contract_id`.
+    let unresolved: Vec<UnresolvedDependency> = body
+        .dependencies
+        .iter()
+        .zip(&resolutions)
+        .filter_map(|(decl, resolution)| {
+            let reason = match resolution {
+                dependency::DependencyResolution::Resolved(_) => return None,
+                dependency::DependencyResolution::NetworkMismatch { found_on, .. } => {
+                    format!("registered on {found_on}, not {network}")
+                }
+                dependency::DependencyResolution::UnknownAddress => {
+                    "no contract with this address is registered".to_string()
+                }
+                dependency::DependencyResolution::NotAnAddress => {
+                    "not a Stellar contract address".to_string()
+                }
+            };
+            Some(UnresolvedDependency {
+                target_ref: decl.name.clone(),
+                reason,
+            })
+        })
+        .collect();
 
     // Fetch stored rows for response.
     let saved: Vec<ContractDependency> = sqlx::query_as(
@@ -280,6 +315,7 @@ pub async fn declare_contract_dependencies(
             contract_id: id,
             saved,
             has_circular,
+            unresolved,
         }),
     ))
 }

--- a/backend/api/src/dependency_handlers.rs
+++ b/backend/api/src/dependency_handlers.rs
@@ -440,3 +440,151 @@ pub async fn declare_contract_dependencies(
         }),
     ))
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #1147 — Dependency graph summary and transitive risk
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Response for GET /api/contracts/:id/dependency-graph
+///
+/// A flat summary rather than the nested tree: this endpoint exists to answer
+/// "how big and how healthy is the closure", which a caller should be able to
+/// read without walking a recursive structure.
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct DependencyGraphSummary {
+    pub contract_id: Uuid,
+    pub network: String,
+    pub total_dependencies: usize,
+    /// Reachable contracts that resolved to a registry row.
+    pub resolved: usize,
+    /// References retained but not bound to any contract.
+    pub unresolved: usize,
+    /// Nodes hidden by tenancy: counted so the total stays honest, never named.
+    pub redacted: usize,
+    pub max_depth: usize,
+    pub has_circular: bool,
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation_reason: Option<shared::dependency_graph::TruncationReason>,
+    /// Graph facts with no severity: cycles, unresolved edges, truncation.
+    pub diagnostics: Vec<shared::dependency_graph::Diagnostic>,
+}
+
+/// GET /api/contracts/:id/dependency-graph
+#[utoipa::path(
+    get,
+    path = "/api/contracts/{id}/dependency-graph",
+    params(
+        ("id" = String, Path, description = "Contract UUID or Stellar contract address"),
+        ("network" = Option<String>, Query, description = "Required to disambiguate an address registered on more than one network"),
+        ("depth" = Option<u32>, Query, description = "Maximum traversal depth, capped server-side"),
+        ("max_nodes" = Option<u32>, Query, description = "Maximum nodes returned, capped server-side"),
+        ("as_of" = Option<String>, Query, description = "RFC3339 instant; replays the declared graph as it stood then"),
+        ("include_telemetry" = Option<bool>, Query, description = "Include on-chain call edges alongside declared ones")
+    ),
+    responses(
+        (status = 200, description = "Dependency graph summary", body = DependencyGraphSummary),
+        (status = 404, description = "Contract not found"),
+        (status = 409, description = "Ambiguous contract address; retry with ?network=")
+    ),
+    tag = "Graphs"
+)]
+pub async fn get_dependency_graph(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Query(query): Query<DependencyQuery>,
+) -> ApiResult<Json<DependencyGraphSummary>> {
+    let contract = contract_ref::resolve(&state, &id, query.network).await?;
+
+    let request = TraversalRequest {
+        root: contract.uuid,
+        network: contract.network,
+        direction: Direction::Dependencies,
+        transitive: query.transitive.unwrap_or(true),
+        max_depth: query
+            .depth
+            .unwrap_or(shared::dependency_graph::DEFAULT_MAX_DEPTH),
+        max_nodes: query
+            .max_nodes
+            .unwrap_or(shared::dependency_graph::DEFAULT_MAX_NODES),
+        as_of: query.as_of,
+        caller_org: None,
+        include_telemetry: query.include_telemetry.unwrap_or(false),
+    };
+
+    let result = dependency_graph::traverse(&state.db, &request).await?;
+
+    let resolved = result
+        .rows
+        .iter()
+        .filter(|r| r.target_contract_id.is_some() && r.visible)
+        .count();
+    let redacted = result.rows.iter().filter(|r| !r.visible).count();
+    let unresolved = result
+        .rows
+        .iter()
+        .filter(|r| r.target_contract_id.is_none())
+        .count();
+
+    Ok(Json(DependencyGraphSummary {
+        contract_id: contract.uuid,
+        network: contract.network.to_string(),
+        total_dependencies: result.rows.len(),
+        resolved,
+        unresolved,
+        redacted,
+        max_depth: result
+            .rows
+            .iter()
+            .map(|r| r.depth as usize)
+            .max()
+            .unwrap_or(0),
+        has_circular: result
+            .diagnostics
+            .iter()
+            .any(|d| d.kind == DiagnosticKind::Cycle),
+        truncated: result.truncated,
+        truncation_reason: result.truncation_reason,
+        diagnostics: result.diagnostics,
+    }))
+}
+
+/// GET /api/contracts/:id/dependency-risk
+///
+/// Direct and inherited findings, each with the shortest path that reaches it,
+/// plus severity-free diagnostics.
+#[utoipa::path(
+    get,
+    path = "/api/contracts/{id}/dependency-risk",
+    params(
+        ("id" = String, Path, description = "Contract UUID or Stellar contract address"),
+        ("network" = Option<String>, Query, description = "Required to disambiguate an address registered on more than one network"),
+        ("depth" = Option<u32>, Query, description = "Maximum traversal depth, capped server-side")
+    ),
+    responses(
+        (status = 200, description = "Transitive risk report", body = Object),
+        (status = 404, description = "Contract not found"),
+        (status = 409, description = "Ambiguous contract address; retry with ?network=")
+    ),
+    tag = "Graphs"
+)]
+pub async fn get_dependency_risk(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Query(query): Query<DependencyQuery>,
+) -> ApiResult<Json<crate::dependency_risk::DependencyRiskReport>> {
+    let contract = contract_ref::resolve(&state, &id, query.network).await?;
+
+    let report = crate::dependency_risk::assess(
+        &state,
+        contract.uuid,
+        contract.network,
+        query
+            .depth
+            .unwrap_or(shared::dependency_graph::DEFAULT_MAX_DEPTH),
+        None,
+    )
+    .await?;
+
+    Ok(Json(report))
+}

--- a/backend/api/src/dependency_risk.rs
+++ b/backend/api/src/dependency_risk.rs
@@ -1,0 +1,510 @@
+//! Transitive risk propagation with provenance (Issue #1147).
+//!
+//! Answers "what is wrong with this contract, and what is wrong with the things
+//! it depends on" -- and, critically, *by which path*.
+//!
+//! ## Why this is a new module
+//!
+//! [`crate::graph_analysis::propagate_vulnerability`] is live and stays
+//! untouched. It answers a different question with a float-decay model: how much
+//! influence a vulnerability exerts over a network, decaying with distance. That
+//! is useful for ranking blast radius, but it cannot say "this specific finding
+//! reaches you through this specific chain", and its float scores are not a
+//! basis for a deterministic, byte-stable report that a CLI can gate a deploy
+//! on. Retrofitting provenance onto it would change what its existing consumers
+//! see.
+//!
+//! ## Findings and diagnostics are separate
+//!
+//! Only severity-bearing security conditions become findings. Cycles, unresolved
+//! edges, truncation, and version conflicts are diagnostics with no severity --
+//! see [`shared::dependency_graph`]. Folding them into `findings` would make
+//! `max()` rank every cyclic graph at Low or above, so "zero findings" could
+//! never be reached and the report would be useless as a gate.
+//!
+//! ## Cost
+//!
+//! One traversal, then one batched query per risk source over the whole
+//! reachable set -- not one query per node. The set is already bounded by the
+//! traversal's node budget, so the total query count is constant in the size of
+//! the graph.
+
+use crate::dependency_graph::{self, Direction, TraversalRequest, TraversedEdgeRow};
+use crate::error::ApiResult;
+use crate::handlers::db_internal_error;
+use crate::state::AppState;
+use shared::dependency_graph::{
+    constraints_conflict, dedup_findings, sort_diagnostics, Diagnostic, DiagnosticKind,
+    EffectiveRisk, Finding, RiskRule,
+};
+use shared::models::IssueSeverity;
+use shared::Network;
+use sqlx::PgPool;
+use std::collections::{BTreeMap, BTreeSet};
+use uuid::Uuid;
+
+/// The full risk report for one contract.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DependencyRiskReport {
+    pub contract_id: Uuid,
+    pub network: Network,
+    /// Severity-bearing conditions on the contract itself.
+    pub direct_findings: Vec<Finding>,
+    /// Severity-bearing conditions reached through dependencies, each carrying
+    /// the shortest path that reaches it.
+    pub inherited_findings: Vec<Finding>,
+    /// Graph facts with no severity.
+    pub diagnostics: Vec<Diagnostic>,
+    /// `(effective_severity, counts)` over direct findings only.
+    pub direct_risk: EffectiveRisk,
+    /// The same over direct and inherited findings together. This is what a
+    /// `--fail-on` gate compares against.
+    pub overall_risk: EffectiveRisk,
+    pub total_dependencies: usize,
+    pub max_depth: usize,
+    pub truncated: bool,
+}
+
+/// Build the risk report for `root`.
+pub async fn assess(
+    state: &AppState,
+    root: Uuid,
+    network: Network,
+    max_depth: u32,
+    caller_org: Option<Uuid>,
+) -> ApiResult<DependencyRiskReport> {
+    let request = TraversalRequest {
+        root,
+        network,
+        direction: Direction::Dependencies,
+        transitive: true,
+        max_depth,
+        max_nodes: shared::dependency_graph::DEFAULT_MAX_NODES,
+        as_of: None,
+        caller_org,
+        include_telemetry: false,
+    };
+
+    let traversal = dependency_graph::traverse(&state.db, &request).await?;
+
+    // Shortest path to each reachable contract. Computed once here so every rule
+    // reports the same provenance for the same contract, instead of each rule
+    // picking whichever path its own query happened to return.
+    let reach = shortest_paths(&traversal.rows);
+
+    let mut subjects: Vec<Uuid> = reach.keys().copied().collect();
+    subjects.push(root);
+
+    let mut findings = collect_findings(&state.db, &subjects, root, &reach).await?;
+    findings.extend(interface_findings(&traversal.rows, root, &reach));
+
+    let mut diagnostics = traversal.diagnostics.clone();
+    diagnostics.extend(version_conflicts(&state.db, &traversal.rows).await?);
+    sort_diagnostics(&mut diagnostics);
+
+    let all = dedup_findings(findings);
+    let (direct_findings, inherited_findings): (Vec<Finding>, Vec<Finding>) =
+        all.iter().cloned().partition(Finding::is_direct);
+
+    Ok(DependencyRiskReport {
+        contract_id: root,
+        network,
+        direct_risk: EffectiveRisk::from_findings(&direct_findings),
+        overall_risk: EffectiveRisk::from_findings(&all),
+        direct_findings,
+        inherited_findings,
+        diagnostics,
+        total_dependencies: reach.len(),
+        max_depth: traversal
+            .rows
+            .iter()
+            .map(|r| r.depth as usize)
+            .max()
+            .unwrap_or(0),
+        truncated: traversal.truncated,
+    })
+}
+
+/// Shortest root-to-contract path for every visible, resolved node.
+///
+/// Only visible nodes are included: a contract the caller may not see must not
+/// have its vulnerabilities enumerated, even anonymously. The traversal already
+/// stops at such a node, so its own dependencies never appear either.
+fn shortest_paths(rows: &[TraversedEdgeRow]) -> BTreeMap<Uuid, Vec<Uuid>> {
+    let mut best: BTreeMap<Uuid, Vec<Uuid>> = BTreeMap::new();
+
+    for row in rows {
+        let Some(target) = row.target_contract_id else {
+            continue;
+        };
+        if !row.visible || row.cycle_with.is_some() {
+            continue;
+        }
+
+        match best.get(&target) {
+            // Ties break on the path itself so the result is a function of the
+            // reachable set, not of row order.
+            Some(existing) if (existing.len(), existing) <= (row.path.len(), &row.path) => {}
+            _ => {
+                best.insert(target, row.path.clone());
+            }
+        }
+    }
+
+    best
+}
+
+/// Row returned by every contract-keyed risk query.
+#[derive(sqlx::FromRow)]
+struct RiskRow {
+    contract_id: Uuid,
+    finding_id: String,
+    severity: Option<String>,
+    detail: String,
+}
+
+/// Run each risk source once over the whole reachable set.
+async fn collect_findings(
+    pool: &PgPool,
+    subjects: &[Uuid],
+    root: Uuid,
+    reach: &BTreeMap<Uuid, Vec<Uuid>>,
+) -> ApiResult<Vec<Finding>> {
+    let mut findings = Vec::new();
+
+    // Open vulnerabilities. Severity comes from the record, never from the rule
+    // table: overwriting what a scanner actually found would be a lie.
+    let rows: Vec<RiskRow> = sqlx::query_as(
+        "SELECT contract_id,
+                id::text AS finding_id,
+                severity::text AS severity,
+                title AS detail
+         FROM security_issues
+         WHERE contract_id = ANY($1) AND status = 'open'",
+    )
+    .bind(subjects)
+    .fetch_all(pool)
+    .await
+    .map_err(|err| db_internal_error("collect open security issues", err))?;
+    push_all(
+        &mut findings,
+        RiskRule::OpenVulnerability,
+        rows,
+        root,
+        reach,
+    );
+
+    // Revoked signatures for the artifact currently published.
+    let rows: Vec<RiskRow> = sqlx::query_as(
+        "SELECT ps.contract_id,
+                ps.id::text AS finding_id,
+                NULL::text AS severity,
+                'package signature revoked: ' || COALESCE(ps.revoked_reason, 'no reason recorded') AS detail
+         FROM package_signatures ps
+         JOIN contracts c ON c.id = ps.contract_id AND c.wasm_hash = ps.wasm_hash
+         WHERE ps.contract_id = ANY($1) AND ps.status = 'revoked'",
+    )
+    .bind(subjects)
+    .fetch_all(pool)
+    .await
+    .map_err(|err| db_internal_error("collect revoked signatures", err))?;
+    push_all(&mut findings, RiskRule::SignatureRevoked, rows, root, reach);
+
+    // Quarantined artifacts.
+    let rows: Vec<RiskRow> = sqlx::query_as(
+        "SELECT id AS contract_id,
+                id::text AS finding_id,
+                NULL::text AS severity,
+                'published artifact is quarantined' AS detail
+         FROM contracts
+         WHERE id = ANY($1) AND artifact_scan_status = 'quarantined'",
+    )
+    .bind(subjects)
+    .fetch_all(pool)
+    .await
+    .map_err(|err| db_internal_error("collect quarantined artifacts", err))?;
+    push_all(
+        &mut findings,
+        RiskRule::ArtifactQuarantined,
+        rows,
+        root,
+        reach,
+    );
+
+    // Unsigned artifacts: no *valid* signature for the wasm hash on the row now.
+    // A signature for a previous artifact does not vouch for the current one,
+    // which is why the join is on `wasm_hash` rather than on contract alone.
+    let rows: Vec<RiskRow> = sqlx::query_as(
+        "SELECT c.id AS contract_id,
+                c.id::text AS finding_id,
+                NULL::text AS severity,
+                'no valid signature for the published wasm hash' AS detail
+         FROM contracts c
+         WHERE c.id = ANY($1)
+           AND NOT EXISTS (
+               SELECT 1 FROM package_signatures ps
+               WHERE ps.contract_id = c.id
+                 AND ps.wasm_hash = c.wasm_hash
+                 AND ps.status = 'valid'
+           )",
+    )
+    .bind(subjects)
+    .fetch_all(pool)
+    .await
+    .map_err(|err| db_internal_error("collect unsigned artifacts", err))?;
+    push_all(&mut findings, RiskRule::ArtifactUnsigned, rows, root, reach);
+
+    // Deprecation. Split by whether a replacement exists and the grace period is
+    // still running, because those are different problems: one is a live hazard,
+    // the other a scheduled migration.
+    let rows: Vec<RiskRow> = sqlx::query_as(
+        "SELECT c.id AS contract_id,
+                c.id::text AS finding_id,
+                NULL::text AS severity,
+                'contract is ' || c.deprecation_status
+                    || COALESCE(': ' || c.deprecation_reason, '') AS detail
+         FROM contracts c
+         LEFT JOIN contract_deprecations d ON d.contract_id = c.id
+         WHERE c.id = ANY($1)
+           AND c.deprecated_at IS NOT NULL
+           AND NOT (
+               c.replacement_contract_id IS NOT NULL
+               AND d.grace_period_days IS NOT NULL
+               AND NOW() < c.deprecated_at + make_interval(days => d.grace_period_days)
+           )",
+    )
+    .bind(subjects)
+    .fetch_all(pool)
+    .await
+    .map_err(|err| db_internal_error("collect deprecated contracts", err))?;
+    push_all(
+        &mut findings,
+        RiskRule::DeprecatedNoReplacement,
+        rows,
+        root,
+        reach,
+    );
+
+    let rows: Vec<RiskRow> = sqlx::query_as(
+        "SELECT c.id AS contract_id,
+                c.id::text AS finding_id,
+                NULL::text AS severity,
+                'deprecated with a replacement; grace period ends '
+                    || (c.deprecated_at + make_interval(days => d.grace_period_days))::text AS detail
+         FROM contracts c
+         JOIN contract_deprecations d ON d.contract_id = c.id
+         WHERE c.id = ANY($1)
+           AND c.deprecated_at IS NOT NULL
+           AND c.replacement_contract_id IS NOT NULL
+           AND d.grace_period_days IS NOT NULL
+           AND NOW() < c.deprecated_at + make_interval(days => d.grace_period_days)",
+    )
+    .bind(subjects)
+    .fetch_all(pool)
+    .await
+    .map_err(|err| db_internal_error("collect grace-period deprecations", err))?;
+    push_all(
+        &mut findings,
+        RiskRule::DeprecatedWithReplacement,
+        rows,
+        root,
+        reach,
+    );
+
+    Ok(findings)
+}
+
+/// Turn raw rows into findings, applying the direct/inherited severity rule.
+///
+/// A rule whose `inherited_severity` is `None` simply produces no finding for a
+/// non-root contract -- the condition is real but does not propagate.
+fn push_all(
+    out: &mut Vec<Finding>,
+    rule: RiskRule,
+    rows: Vec<RiskRow>,
+    root: Uuid,
+    reach: &BTreeMap<Uuid, Vec<Uuid>>,
+) {
+    for row in rows {
+        let recorded = row.severity.as_deref().and_then(parse_severity);
+        let is_direct = row.contract_id == root;
+
+        // `direct_severity()` is None only for OpenVulnerability, whose severity
+        // is on the record. If a record somehow has neither, there is nothing
+        // honest to report, so it is skipped rather than assigned a default.
+        let Some(direct) = recorded.or_else(|| rule.direct_severity()) else {
+            continue;
+        };
+
+        let severity = if is_direct {
+            direct
+        } else {
+            match rule.inherited_severity(direct) {
+                Some(severity) => severity,
+                None => continue,
+            }
+        };
+
+        let path = if is_direct {
+            vec![root]
+        } else {
+            match reach.get(&row.contract_id) {
+                Some(path) => path.clone(),
+                // Unreachable in practice: subjects come from `reach`. Skipping
+                // is still the right response -- a finding with no provenance is
+                // exactly what this feature exists to avoid emitting.
+                None => continue,
+            }
+        };
+
+        out.push(Finding {
+            rule_id: rule.id().to_string(),
+            severity,
+            origin_contract_id: row.contract_id,
+            finding_id: row.finding_id,
+            inherited_via_depth: path.len().saturating_sub(1) as u32,
+            path,
+            detail: row.detail,
+        });
+    }
+}
+
+fn parse_severity(value: &str) -> Option<IssueSeverity> {
+    match value {
+        "low" => Some(IssueSeverity::Low),
+        "medium" => Some(IssueSeverity::Medium),
+        "high" => Some(IssueSeverity::High),
+        "critical" => Some(IssueSeverity::Critical),
+        _ => None,
+    }
+}
+
+/// Interface incompatibility: the target's interface id now differs from the one
+/// recorded on the edge when the dependency was declared.
+///
+/// Derived from the traversal rows rather than a query, because the comparison
+/// is between an edge column and a contract column that the traversal already
+/// joined. It does not propagate: it is a fact about one specific edge, so
+/// re-reporting it further down the chain would be meaningless.
+///
+/// A NULL on either side means "unknown", not "different". Reporting drift
+/// against an unknown would flag every artifact-less contract as incompatible.
+fn interface_findings(
+    rows: &[TraversedEdgeRow],
+    root: Uuid,
+    reach: &BTreeMap<Uuid, Vec<Uuid>>,
+) -> Vec<Finding> {
+    let mut out = Vec::new();
+
+    for row in rows {
+        let (Some(expected), Some(current)) = (
+            row.expected_interface_id.as_deref(),
+            row.current_interface_id.as_deref(),
+        ) else {
+            continue;
+        };
+        if expected == current {
+            continue;
+        }
+        let Some(target) = row.target_contract_id else {
+            continue;
+        };
+
+        let path = if row.source_contract_id == root {
+            vec![root, target]
+        } else {
+            match reach.get(&target) {
+                Some(path) => path.clone(),
+                None => continue,
+            }
+        };
+
+        out.push(Finding {
+            rule_id: RiskRule::InterfaceIncompatibility.id().to_string(),
+            severity: RiskRule::InterfaceIncompatibility
+                .direct_severity()
+                .unwrap_or(IssueSeverity::High),
+            origin_contract_id: target,
+            // Keyed by the edge, not the contract: two dependents can each have
+            // recorded a different expectation of the same target.
+            finding_id: format!("{}:{}", row.source_contract_id, target),
+            inherited_via_depth: path.len().saturating_sub(1) as u32,
+            path,
+            detail: format!(
+                "interface changed since this dependency was declared (expected {expected}, now {current})"
+            ),
+        });
+    }
+
+    out
+}
+
+/// Two edges targeting the same contract under constraints that no published
+/// version satisfies.
+///
+/// A diagnostic, not a finding: it is a fact about how the graph was declared,
+/// not a security condition, and it has no defensible severity.
+async fn version_conflicts(pool: &PgPool, rows: &[TraversedEdgeRow]) -> ApiResult<Vec<Diagnostic>> {
+    // Group the declared constraints per target.
+    let mut by_target: BTreeMap<Uuid, BTreeSet<String>> = BTreeMap::new();
+    for row in rows {
+        let (Some(target), Some(constraint)) =
+            (row.target_contract_id, row.version_constraint.as_deref())
+        else {
+            continue;
+        };
+        by_target
+            .entry(target)
+            .or_default()
+            .insert(constraint.to_string());
+    }
+
+    // Only targets with at least two distinct constraints can conflict.
+    let contested: Vec<Uuid> = by_target
+        .iter()
+        .filter(|(_, constraints)| constraints.len() > 1)
+        .map(|(target, _)| *target)
+        .collect();
+
+    if contested.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // The target carries no version on `contracts` -- versions live in
+    // `contract_versions` -- so the conflict can only be decided against what is
+    // actually published.
+    let version_rows: Vec<(Uuid, String)> = sqlx::query_as(
+        "SELECT contract_id, version FROM contract_versions WHERE contract_id = ANY($1)",
+    )
+    .bind(&contested)
+    .fetch_all(pool)
+    .await
+    .map_err(|err| db_internal_error("collect versions for conflict check", err))?;
+
+    let mut published: BTreeMap<Uuid, Vec<String>> = BTreeMap::new();
+    for (contract_id, version) in version_rows {
+        published.entry(contract_id).or_default().push(version);
+    }
+
+    let mut diagnostics = Vec::new();
+    for target in contested {
+        let constraints: Vec<&String> = by_target[&target].iter().collect();
+        let versions = published.get(&target).cloned().unwrap_or_default();
+
+        for (i, a) in constraints.iter().enumerate() {
+            for b in &constraints[i + 1..] {
+                if constraints_conflict(a, b, &versions) {
+                    diagnostics.push(Diagnostic {
+                        kind: DiagnosticKind::VersionConflict,
+                        path: vec![target],
+                        detail: format!(
+                            "constraints '{a}' and '{b}' on the same dependency have no commonly satisfying published version"
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(diagnostics)
+}

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -4655,7 +4655,10 @@ async fn publish_contract_inner(
     req: PublishRequest,
 ) -> ApiResult<Json<Contract>> {
     let publisher_id = actor.publisher_id()?;
-    let artifact_scan = match req.wasm_artifact_base64.as_deref() {
+    // The decoded artifact serves two consumers (Issue #1147): the existing
+    // scanner, and the interface fingerprint persisted on the row. Decode once.
+    let artifact = req.wasm_artifact_base64.as_deref();
+    let (artifact_scan, interface_id, interface_algorithm) = match artifact {
         Some(encoded) => {
             let bytes = BASE64.decode(encoded).map_err(|_| {
                 ApiError::bad_request(
@@ -4663,12 +4666,19 @@ async fn publish_contract_inner(
                     "wasm_artifact_base64 must be valid base64",
                 )
             })?;
-            crate::wasm_scanner::scan(&bytes, &req.wasm_hash)
+            let scan = crate::wasm_scanner::scan(&bytes, &req.wasm_hash);
+            let (interface_id, algorithm) =
+                crate::interface_id::derive_columns(&bytes, &req.contract_id);
+            (scan, interface_id, algorithm)
         }
-        None => crate::wasm_scanner::WasmScanResult {
-            status: "pending",
-            findings: vec!["artifact_not_supplied".to_string()],
-        },
+        None => (
+            crate::wasm_scanner::WasmScanResult {
+                status: "pending",
+                findings: vec!["artifact_not_supplied".to_string()],
+            },
+            None,
+            None,
+        ),
     };
     let wasm_hash = req.wasm_hash.clone();
 
@@ -4728,8 +4738,8 @@ async fn publish_contract_inner(
     let slug = generate_unique_slug(&state.db, &req.name, &req.network, req.slug.clone()).await?;
 
     let insert_result = sqlx::query_as::<_, Contract>(
-        "INSERT INTO contracts (contract_id, wasm_hash, name, slug, description, publisher_id, network, category, tags, logical_id, network_configs, visibility, artifact_scan_status, artifact_scan_findings)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, CASE WHEN $12 = 'passed' THEN 'public'::visibility_type ELSE 'private'::visibility_type END, $12, $13)
+        "INSERT INTO contracts (contract_id, wasm_hash, name, slug, description, publisher_id, network, category, tags, logical_id, network_configs, visibility, artifact_scan_status, artifact_scan_findings, interface_id, interface_algorithm)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, CASE WHEN $12 = 'passed' THEN 'public'::visibility_type ELSE 'private'::visibility_type END, $12, $13, $14, $15)
          RETURNING *",
     )
     .bind(&req.contract_id)
@@ -4745,6 +4755,8 @@ async fn publish_contract_inner(
     .bind(&network_configs)
     .bind(artifact_scan.status)
     .bind(json!(artifact_scan.findings))
+    .bind(&interface_id)
+    .bind(interface_algorithm)
     .fetch_one(&state.db)
     .await;
 

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -5664,64 +5664,6 @@ pub async fn get_trust_score() -> impl IntoResponse {
 #[allow(dead_code)]
 #[utoipa::path(
     get,
-    path = "/api/contracts/{id}/dependencies",
-    params(
-        ("id" = String, Path, description = "Contract UUID")
-    ),
-    responses(
-        (status = 200, description = "List of direct dependencies", body = Object),
-        (status = 404, description = "Contract not found")
-    ),
-    tag = "Graphs"
-)]
-pub async fn get_contract_dependencies(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-) -> ApiResult<Json<Value>> {
-    let contract_uuid = Uuid::parse_str(&id)
-        .map_err(|_| ApiError::bad_request("InvalidContractId", format!("Invalid ID: {}", id)))?;
-
-    let deps: Vec<shared::ContractDependency> =
-        sqlx::query_as("SELECT * FROM contract_dependencies WHERE contract_id = $1")
-            .bind(contract_uuid)
-            .fetch_all(&state.db)
-            .await
-            .map_err(|e| db_internal_error("get_contract_dependencies", e))?;
-
-    Ok(Json(json!({ "dependencies": deps })))
-}
-
-#[utoipa::path(
-    get,
-    path = "/api/contracts/{id}/dependents",
-    params(
-        ("id" = String, Path, description = "Contract UUID")
-    ),
-    responses(
-        (status = 200, description = "List of direct dependents", body = Object),
-        (status = 404, description = "Contract not found")
-    ),
-    tag = "Graphs"
-)]
-pub async fn get_contract_dependents(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-) -> ApiResult<Json<Value>> {
-    let contract_uuid = Uuid::parse_str(&id)
-        .map_err(|_| ApiError::bad_request("InvalidContractId", format!("Invalid ID: {}", id)))?;
-
-    let dependents: Vec<shared::ContractDependency> =
-        sqlx::query_as("SELECT * FROM contract_dependencies WHERE dependency_contract_id = $1")
-            .bind(contract_uuid)
-            .fetch_all(&state.db)
-            .await
-            .map_err(|e| db_internal_error("get_contract_dependents", e))?;
-
-    Ok(Json(json!({ "dependents": dependents })))
-}
-
-#[utoipa::path(
-    get,
     path = "/api/contracts/graph",
     responses(
         (status = 200, description = "Full contract dependency graph", body = GraphResponse)

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -1409,7 +1409,7 @@ async fn resolve_call_target_contract(
         return Ok(None);
     };
 
-    dependency::resolve_contract_id(db, &identifier)
+    dependency::lookup_contract_by_identifier(db, &identifier)
         .await
         .map_err(|err| {
             ApiError::internal(format!(
@@ -4391,24 +4391,14 @@ pub async fn create_contract_version(
         );
     }
 
-    // Post-commit dependency analysis
-    let detected_deps = dependency::detect_dependencies_from_abi(&req.abi);
-    if !detected_deps.is_empty() {
-        if let Err(e) =
-            dependency::save_dependencies(&state.db, contract_uuid, &detected_deps).await
-        {
-            tracing::error!(
-                "Failed to save dependencies for version {}: {}",
-                req.version,
-                e
-            );
-        }
-        // Invalidate global graph cache
-        state
-            .cache
-            .invalidate("system", "global:dependency_graph")
-            .await;
-    }
+    // Issue #1147: publishing a version no longer touches dependencies at all.
+    //
+    // This used to scrape `type == "interface"` strings out of the submitted ABI
+    // and hand them to `save_dependencies`, whose first statement deletes every
+    // existing row for the contract. Two defects in one: dependencies were
+    // inferred from arbitrary strings, and every version publish silently wiped
+    // the operator's real declarations. Declarations now change only through
+    // POST /api/contracts/:id/dependencies.
 
     let _ = analytics::record_event(
         &state.db,
@@ -4835,14 +4825,37 @@ async fn publish_contract_inner(
 
     // Save dependencies if provided
     if !req.dependencies.is_empty() {
-        if let Err(e) =
-            dependency::save_dependencies(&state.db, contract.id, &req.dependencies).await
+        // Resolved against this contract's own network (Issue #1147): an
+        // address is only unique per (contract_id, network).
+        match dependency::save_dependencies(
+            &state.db,
+            contract.id,
+            contract.network,
+            &req.dependencies,
+        )
+        .await
         {
-            tracing::error!(
-                "Failed to save initial dependencies for contract {}: {}",
-                contract.contract_id,
-                e
-            );
+            Ok(resolutions) => {
+                let unresolved = resolutions
+                    .iter()
+                    .filter(|r| !matches!(r, dependency::DependencyResolution::Resolved(_)))
+                    .count();
+                if unresolved > 0 {
+                    tracing::info!(
+                        contract_id = %contract.contract_id,
+                        unresolved,
+                        total = resolutions.len(),
+                        "some declared dependencies were stored but not bound to a registry contract"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Failed to save initial dependencies for contract {}: {}",
+                    contract.contract_id,
+                    e
+                );
+            }
         }
         // Invalidate global graph cache
         state
@@ -8344,7 +8357,7 @@ pub async fn get_contract_deployments(
         }
     } else {
         // Try resolving by Stellar ID
-        let uuid = dependency::resolve_contract_id(&state.db, &id)
+        let uuid = dependency::lookup_contract_by_identifier(&state.db, &id)
             .await
             .map_err(|err| {
                 ApiError::not_found(

--- a/backend/api/src/interface_id.rs
+++ b/backend/api/src/interface_id.rs
@@ -1,0 +1,50 @@
+//! Persisting a contract's interface fingerprint at publish time (Issue #1147).
+//!
+//! The derivation itself is pure and lives in
+//! [`shared::interface_fingerprint::fingerprint_wasm`] — in `shared` rather
+//! than here so the CLI, the API, and any future verifier all compute the same
+//! id from the same bytes, and so it is covered by `cargo test -p shared`.
+//!
+//! This module is only the persistence adapter: it flattens the result into the
+//! two nullable `contracts` columns and records *why* an id was not produced.
+//! Failure is deliberately never fatal to a publish — a contract with no
+//! `contractspecv0` section is a legitimate publish that simply has no
+//! interface id, exactly like a publish with no artifact at all. Rejecting it
+//! would turn an additive feature into a breaking change to the publish
+//! contract.
+
+use shared::interface_fingerprint::{self, FingerprintWasmError};
+
+/// Derive `(interface_id, interface_algorithm)` for the `contracts` row.
+///
+/// `(None, None)` means "unknown interface", which the dependency graph treats
+/// as "cannot assess compatibility" rather than "interfaces differ".
+pub fn derive_columns(
+    wasm_bytes: &[u8],
+    contract_id: &str,
+) -> (Option<String>, Option<&'static str>) {
+    match interface_fingerprint::fingerprint_wasm(wasm_bytes) {
+        Ok(fingerprint) => (
+            Some(fingerprint.interface_id),
+            Some(interface_fingerprint::ALGORITHM),
+        ),
+        Err(FingerprintWasmError::NoSpecSection) => {
+            // Common and unremarkable: plenty of modules ship without a spec.
+            tracing::debug!(
+                contract_id,
+                "published artifact embeds no contract spec section; no interface id recorded"
+            );
+            (None, None)
+        }
+        Err(err) => {
+            // A present-but-broken section is worth a louder log: it usually
+            // means a build-toolchain problem on the publisher's side.
+            tracing::warn!(
+                contract_id,
+                error = %err,
+                "could not derive an interface fingerprint for published artifact"
+            );
+            (None, None)
+        }
+    }
+}

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -105,6 +105,7 @@ pub mod alerting;
 pub mod archival;
 pub mod audit;
 pub mod config;
+pub mod contract_ref;
 pub mod db_monitoring;
 pub mod db_pool;
 pub mod db_resilience;

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -109,6 +109,7 @@ pub mod db_monitoring;
 pub mod db_pool;
 pub mod db_resilience;
 pub mod dependency;
+pub mod dependency_graph;
 pub mod dependency_vulnerability;
 pub mod dependency_vulnerability_handlers;
 pub mod deprecated_contracts_handlers;

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -111,6 +111,7 @@ pub mod db_pool;
 pub mod db_resilience;
 pub mod dependency;
 pub mod dependency_graph;
+pub mod dependency_risk;
 pub mod dependency_vulnerability;
 pub mod dependency_vulnerability_handlers;
 pub mod deprecated_contracts_handlers;

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -44,6 +44,7 @@ pub mod health;
 pub mod health_monitor;
 pub mod incident_handlers;
 pub mod incident_routes;
+pub mod interface_id;
 pub mod interoperability;
 pub mod interoperability_handlers;
 pub mod logging;

--- a/backend/api/src/openapi.rs
+++ b/backend/api/src/openapi.rs
@@ -41,6 +41,8 @@ use utoipa::OpenApi;
         analytics_handlers::get_analytics_summary,
         dependency_handlers::get_contract_dependencies,
         dependency_handlers::get_contract_dependents,
+        dependency_handlers::get_dependency_graph,
+        dependency_handlers::get_dependency_risk,
         handlers::get_contract_graph,
         handlers::get_impact_analysis,
         contract_stats_handlers::get_contract_stats,

--- a/backend/api/src/openapi.rs
+++ b/backend/api/src/openapi.rs
@@ -2,6 +2,7 @@ use crate::analytics_handlers;
 use crate::breaking_changes;
 use crate::contract_stats_handlers;
 use crate::custom_metrics_handlers;
+use crate::dependency_handlers;
 use crate::deprecation_handlers;
 use crate::handlers;
 use crate::handlers::{ContractChangelogEntry, ContractChangelogResponse};
@@ -38,8 +39,8 @@ use utoipa::OpenApi;
         handlers::get_contract_openapi_json,
         analytics_handlers::get_contract_analytics,
         analytics_handlers::get_analytics_summary,
-        handlers::get_contract_dependencies,
-        handlers::get_contract_dependents,
+        dependency_handlers::get_contract_dependencies,
+        dependency_handlers::get_contract_dependents,
         handlers::get_contract_graph,
         handlers::get_impact_analysis,
         contract_stats_handlers::get_contract_stats,

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -626,6 +626,14 @@ pub fn contract_routes() -> Router<AppState> {
             get(dependency_handlers::get_contract_dependents),
         )
         .route(
+            "/api/contracts/:id/dependency-graph",
+            get(dependency_handlers::get_dependency_graph),
+        )
+        .route(
+            "/api/contracts/:id/dependency-risk",
+            get(dependency_handlers::get_dependency_risk),
+        )
+        .route(
             "/api/contracts/:id/impact",
             get(handlers::get_impact_analysis),
         )

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -623,7 +623,7 @@ pub fn contract_routes() -> Router<AppState> {
         )
         .route(
             "/api/contracts/:id/dependents",
-            get(handlers::get_contract_dependents),
+            get(dependency_handlers::get_contract_dependents),
         )
         .route(
             "/api/contracts/:id/impact",

--- a/backend/api/src/snapshot_handlers.rs
+++ b/backend/api/src/snapshot_handlers.rs
@@ -6,13 +6,13 @@
 //! all live in `shared::snapshot` so the CLI signs and verifies the same bytes.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     Json,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use chrono::{DateTime, Utc};
 use ed25519_dalek::{SigningKey, SECRET_KEY_LENGTH};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use shared::snapshot::{
     key_fingerprint, sign_snapshot, ContractSnapshot, LineageLink, SnapshotContract,
@@ -25,6 +25,15 @@ use crate::{
     handlers::db_internal_error,
     state::AppState,
 };
+
+/// Query parameters for GET /api/contracts/:id/snapshot
+#[derive(Debug, Default, Deserialize)]
+pub struct SnapshotQuery {
+    /// Embed the dependency graph and transitive risk report (Issue #1147).
+    /// Off by default: it is large, and including it raises the payload to
+    /// schema 1.1.
+    pub include_dependency_graph: Option<bool>,
+}
 
 const ENV_SIGNING_KEY: &str = "REGISTRY_SIGNING_KEY";
 const ENV_REGISTRY_URL: &str = "REGISTRY_PUBLIC_URL";
@@ -57,9 +66,7 @@ fn load_signing_key() -> Result<SigningKey, ApiError> {
 
     let seed = BASE64
         .decode(raw.trim())
-        .or_else(|_| {
-            base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(raw.trim())
-        })
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(raw.trim()))
         .map_err(|_| {
             ApiError::internal_error(
                 "SNAPSHOT_SIGNING_KEY_INVALID",
@@ -124,7 +131,10 @@ type ContractRow = (
     get,
     path = "/api/contracts/{id}/snapshot",
     tag = "snapshots",
-    params(("id" = Uuid, Path, description = "Contract UUID")),
+    params(
+        ("id" = Uuid, Path, description = "Contract UUID"),
+        ("include_dependency_graph" = Option<bool>, Query, description = "Embed the dependency graph and transitive risk report. Raises the payload to schema 1.1, which older verifiers reject as UnsupportedSchema rather than mis-reporting a signature failure.")
+    ),
     responses(
         (status = 200, description = "Signed contract snapshot"),
         (status = 404, description = "Contract not found"),
@@ -134,6 +144,7 @@ type ContractRow = (
 pub async fn get_contract_snapshot(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    Query(query): Query<SnapshotQuery>,
 ) -> ApiResult<Json<ContractSnapshot>> {
     let signing_key = load_signing_key()?;
 
@@ -165,7 +176,10 @@ pub async fn get_contract_snapshot(
         updated_at,
     )) = row
     else {
-        return Err(ApiError::not_found("ContractNotFound", "Contract not found"));
+        return Err(ApiError::not_found(
+            "ContractNotFound",
+            "Contract not found",
+        ));
     };
 
     let verification = fetch_verification(&state, contract_uuid).await?;
@@ -173,7 +187,37 @@ pub async fn get_contract_snapshot(
     let deprecation = fetch_deprecation(&state, contract_uuid).await?;
     let lineage = fetch_lineage(&state, contract_uuid).await?;
 
-    let payload = SnapshotPayload {
+    // Off by default. The graph is large, and its presence changes the schema
+    // version, so it is never added to a snapshot that did not ask for it.
+    let dependency_graph = if query.include_dependency_graph.unwrap_or(false) {
+        // `Network` has no FromStr; the row was selected as text, so map it
+        // back explicitly rather than round-tripping through serde.
+        let parsed_network = match network.as_str() {
+            "mainnet" => shared::Network::Mainnet,
+            "testnet" => shared::Network::Testnet,
+            "futurenet" => shared::Network::Futurenet,
+            other => {
+                return Err(ApiError::internal(format!(
+                    "contract has an unrecognized network: {other}"
+                )))
+            }
+        };
+        let report = crate::dependency_risk::assess(
+            &state,
+            contract_uuid,
+            parsed_network,
+            shared::dependency_graph::DEFAULT_MAX_DEPTH,
+            None,
+        )
+        .await?;
+        Some(serde_json::to_value(&report).map_err(|e| {
+            ApiError::internal(format!("failed to serialize dependency graph: {e}"))
+        })?)
+    } else {
+        None
+    };
+
+    let mut payload = SnapshotPayload {
         schema_version: SNAPSHOT_SCHEMA_VERSION.to_string(),
         exported_at: Utc::now(),
         registry_url: std::env::var(ENV_REGISTRY_URL).ok(),
@@ -197,10 +241,19 @@ pub async fn get_contract_snapshot(
         dependency_scan,
         deprecation,
         lineage,
+        dependency_graph,
     };
 
+    // Derived from the content, never from the request, so a graph-bearing
+    // payload cannot claim to be 1.0 and mislead an older verifier into
+    // reporting a signature failure.
+    payload.schema_version = payload.required_schema_version().to_string();
+
     let snapshot = sign_snapshot(payload, &signing_key).map_err(|e| {
-        ApiError::internal_error("SNAPSHOT_SIGN_FAILED", format!("failed to sign snapshot: {e}"))
+        ApiError::internal_error(
+            "SNAPSHOT_SIGN_FAILED",
+            format!("failed to sign snapshot: {e}"),
+        )
     })?;
 
     Ok(Json(snapshot))

--- a/backend/api/tests/dependency_graph_tests.rs
+++ b/backend/api/tests/dependency_graph_tests.rs
@@ -876,6 +876,124 @@ async fn a_null_interface_id_is_unknown_not_incompatible() {
         .expect("restore B's interface");
 }
 
+// ── Pagination ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn the_flat_node_list_is_paginated() {
+    seed(&pool().await).await;
+    let (status, body) = get(&format!(
+        "/api/contracts/{}/dependency-graph?per_page=2&page=1",
+        contract_uuid(1)
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["nodes"]["items"].as_array().map(Vec::len), Some(2));
+    assert_eq!(body["nodes"]["per_page"].as_i64(), Some(2));
+    assert_eq!(body["nodes"]["page"].as_i64(), Some(1));
+    // The total counts the whole reachable set, not the page.
+    assert_eq!(
+        body["nodes"]["total"].as_i64(),
+        body["total_dependencies"].as_i64()
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn pages_partition_the_node_set_without_gaps_or_duplicates() {
+    // The property that makes offset pagination usable here: the traversal
+    // emits a total order, so walking every page reconstructs the set exactly.
+    seed(&pool().await).await;
+
+    let (_, first) = get(&format!(
+        "/api/contracts/{}/dependency-graph?per_page=100",
+        contract_uuid(1)
+    ))
+    .await;
+    let total = first["nodes"]["total"].as_i64().expect("total") as usize;
+
+    let mut walked: Vec<String> = Vec::new();
+    for page in 1..=((total / 2) + 2) {
+        let (_, body) = get(&format!(
+            "/api/contracts/{}/dependency-graph?per_page=2&page={page}",
+            contract_uuid(1)
+        ))
+        .await;
+        let items = body["nodes"]["items"].as_array().expect("items");
+        if items.is_empty() {
+            break;
+        }
+        for item in items {
+            walked.push(serde_json::to_string(item).expect("serialize node"));
+        }
+    }
+
+    assert_eq!(walked.len(), total, "every node appears exactly once");
+    let mut deduped = walked.clone();
+    deduped.sort();
+    deduped.dedup();
+    assert_eq!(deduped.len(), walked.len(), "no node is returned twice");
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_page_boundary_is_stable_across_requests() {
+    seed(&pool().await).await;
+    let path = format!(
+        "/api/contracts/{}/dependency-graph?per_page=2&page=2",
+        contract_uuid(1)
+    );
+    assert_eq!(get_text(&path).await, get_text(&path).await);
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_page_past_the_end_is_empty_not_an_error() {
+    seed(&pool().await).await;
+    let (status, body) = get(&format!(
+        "/api/contracts/{}/dependency-graph?per_page=2&page=9999",
+        contract_uuid(1)
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["nodes"]["items"].as_array().map(Vec::len), Some(0));
+    assert!(
+        body["nodes"]["total"].as_i64().unwrap() > 0,
+        "total is unaffected"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn per_page_is_capped_server_side() {
+    // A caller must not be able to page in the whole node cap at once.
+    seed(&pool().await).await;
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependency-graph?per_page=100000",
+        contract_uuid(1)
+    ))
+    .await;
+    assert_eq!(body["nodes"]["per_page"].as_i64(), Some(200));
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_zero_or_negative_page_is_clamped_not_rejected() {
+    seed(&pool().await).await;
+    for query in ["page=0", "page=-5", "per_page=0"] {
+        let (status, body) = get(&format!(
+            "/api/contracts/{}/dependency-graph?{query}",
+            contract_uuid(1)
+        ))
+        .await;
+        assert_eq!(status, StatusCode::OK, "{query} -> {body}");
+        assert!(body["nodes"]["page"].as_i64().unwrap() >= 1);
+        assert!(body["nodes"]["per_page"].as_i64().unwrap() >= 1);
+    }
+}
+
 // ── Determinism ─────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/backend/api/tests/dependency_graph_tests.rs
+++ b/backend/api/tests/dependency_graph_tests.rs
@@ -1,0 +1,1003 @@
+// tests/dependency_graph_tests.rs
+//
+// Issue #1147 — Contract dependency graphs and transitive risk analysis.
+//
+// These are live-HTTP tests: they seed a known graph directly in Postgres, then
+// drive the real endpoints. That combination is deliberate. The interesting
+// behaviour of this feature lives in a recursive CTE and in SQL's three-valued
+// logic around the tenancy predicate, and neither is exercised by a pure test.
+// The pure rules -- severity table, combinator, dedup, ordering, version
+// conflicts -- are covered by `cargo test -p shared`, where they run with no
+// database at all.
+//
+// To run:
+//   docker run -d --name sr-test-pg -e POSTGRES_PASSWORD=postgres \
+//     -e POSTGRES_DB=soroban_registry -p 5432:5432 postgres:16
+//   export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/soroban_registry"
+//   export JWT_SECRET="test-jwt-secret-at-least-32-characters-long"
+//   export ELASTICSEARCH_URL="http://localhost:9200"
+//   cargo run --bin api &            # migrations run on startup
+//   export TEST_API_BASE_URL="http://localhost:3001"
+//   cargo test --test dependency_graph_tests -- --ignored --test-threads=1
+//
+// The suite issues enough requests to trip the default per-IP rate limit. Start
+// the API with a raised limit to keep runs clean:
+//   export RATE_LIMIT_IP_PER_MINUTE=100000
+//   export RATE_LIMIT_ANON_PER_MINUTE=100000
+//
+// `--test-threads=1` is required: every test shares one seeded fixture keyed by
+// the `sr1147-` slug prefix, and they mutate visibility and edges.
+
+use std::env;
+
+use reqwest::StatusCode;
+use serde_json::Value;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn api_base_url() -> String {
+    env::var("TEST_API_BASE_URL").unwrap_or_else(|_| "http://localhost:3001".to_string())
+}
+
+fn database_url() -> String {
+    env::var("TEST_DATABASE_URL")
+        .or_else(|_| env::var("DATABASE_URL"))
+        .expect("TEST_DATABASE_URL or DATABASE_URL must be set for dependency graph tests")
+}
+
+async fn pool() -> PgPool {
+    PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url())
+        .await
+        .expect("failed to connect to the test database")
+}
+
+// ── Fixture ─────────────────────────────────────────────────────────────────
+
+const PUBLISHER: Uuid = Uuid::from_u128(0x1147_0000_0000_0000_0000_0000_0000_0001);
+
+/// Distinctive fixture address. `publishers.stellar_address` is UNIQUE, so a
+/// generic all-A address would collide with whatever else happens to be in a
+/// shared test database.
+fn publisher_address() -> String {
+    format!("GSR1147{}", "0".repeat(49))
+}
+
+fn contract_uuid(tag: u8) -> Uuid {
+    Uuid::from_u128(0x1147_0000_0000_0000_0000_0000_0000_0100 + tag as u128)
+}
+
+/// Deterministic 56-character `C...` strkey-shaped id. Not a real strkey (no
+/// checksum), but `validate_contract_id` only checks shape, and using real
+/// addresses would make the fixtures unreadable.
+fn address(letter: char) -> String {
+    format!("C{}", letter.to_string().repeat(55).to_uppercase())
+}
+
+/// `contracts.wasm_hash` is CHECK-constrained to 64 hex characters, so the
+/// fixture letter is folded into the hex alphabet rather than used directly.
+fn wasm_hash(letter: char) -> String {
+    let hex = match letter {
+        'a'..='f' => letter,
+        other => char::from_digit((other as u32 - 'a' as u32) % 10, 10).unwrap_or('0'),
+    };
+    hex.to_string().repeat(64)
+}
+
+/// Seed the graph these tests share:
+///
+/// ```text
+///   A -> B -> C -> D -> A      (a 4-cycle)
+///   A -> D                     (diamond: D is reachable at depth 1 and depth 3)
+///   A -> "some-library"        (unresolved, not an address)
+///   C -> CZZZ...               (unresolved, a well-formed but unregistered address)
+///   B also exists on mainnet   (so a bare address for B is ambiguous)
+///   E                          (isolated, signed, no findings)
+/// ```
+async fn seed(pool: &PgPool) {
+    // Clear child rows first. `contract_dependency_edges` cascades with its
+    // contracts, but `contract_versions` and the signature/scan tables use
+    // RESTRICT, so a previous run's rows would block the delete.
+    //
+    // Matched by the same slug pattern as the contracts themselves rather than
+    // by this run's ids: a fixture left behind by an interrupted run has
+    // different ids but the same slugs, and would otherwise wedge every
+    // subsequent run.
+    for table in [
+        "security_issues",
+        "security_scans",
+        "package_signatures",
+        "contract_versions",
+        "contract_deprecations",
+    ] {
+        sqlx::query(&format!(
+            "DELETE FROM {table} WHERE contract_id IN
+                (SELECT id FROM contracts WHERE slug LIKE 'sr1147-%')"
+        ))
+        .execute(pool)
+        .await
+        .unwrap_or_else(|e| panic!("clear {table}: {e}"));
+    }
+
+    sqlx::query("DELETE FROM contracts WHERE slug LIKE 'sr1147-%'")
+        .execute(pool)
+        .await
+        .expect("clear fixture contracts");
+    // By id and by address: the address is UNIQUE, so a row left over from an
+    // interrupted run under a different id would still block the insert.
+    sqlx::query("DELETE FROM publishers WHERE id = $1 OR stellar_address = $2")
+        .bind(PUBLISHER)
+        .bind(publisher_address())
+        .execute(pool)
+        .await
+        .expect("clear fixture publisher");
+
+    sqlx::query("INSERT INTO publishers (id, stellar_address, username) VALUES ($1, $2, 'sr1147')")
+        .bind(PUBLISHER)
+        .bind(publisher_address())
+        .execute(pool)
+        .await
+        .expect("create fixture publisher");
+
+    for (tag, letter, name) in [
+        (1u8, 'a', "A"),
+        (2, 'b', "B"),
+        (3, 'c', "C"),
+        (4, 'd', "D"),
+        (5, 'e', "E"),
+    ] {
+        sqlx::query(
+            "INSERT INTO contracts (id, contract_id, wasm_hash, name, slug, publisher_id, network, interface_id, interface_algorithm)
+             VALUES ($1, $2, $3, $4, $5, $6, 'testnet', $7, 'soroban-interface-v1')",
+        )
+        .bind(contract_uuid(tag))
+        .bind(address(letter))
+        .bind(wasm_hash(letter))
+        .bind(name)
+        .bind(format!("sr1147-{}", name.to_lowercase()))
+        .bind(PUBLISHER)
+        .bind(format!("iface-{letter}"))
+        .execute(pool)
+        .await
+        .expect("create fixture contract");
+    }
+
+    // B's mainnet homograph: same address, different network. This is what makes
+    // a bare address ambiguous and is the reason the routes take ?network=.
+    sqlx::query(
+        "INSERT INTO contracts (id, contract_id, wasm_hash, name, slug, publisher_id, network)
+         VALUES ($1, $2, $3, 'B-mainnet', 'sr1147-b-mainnet', $4, 'mainnet')",
+    )
+    .bind(contract_uuid(20))
+    .bind(address('b'))
+    .bind(wasm_hash('z'))
+    .bind(PUBLISHER)
+    .execute(pool)
+    .await
+    .expect("create mainnet homograph");
+
+    let edges: &[(u8, Option<u8>, String, &str, &str)] = &[
+        (1, Some(2), address('b'), "resolved", "^1.0.0"),
+        (2, Some(3), address('c'), "resolved", "^1.0.0"),
+        (3, Some(4), address('d'), "resolved", "^1.0.0"),
+        (4, Some(1), address('a'), "resolved", "^1.0.0"),
+        (1, Some(4), address('d'), "resolved", "^2.0.0"),
+        (1, None, "some-library".to_string(), "unresolved", "*"),
+        (3, None, address('z'), "unresolved", "*"),
+    ];
+
+    for (source, target, target_ref, state, constraint) in edges {
+        sqlx::query(
+            "INSERT INTO contract_dependency_edges
+                (source_contract_id, target_contract_id, target_ref, network, edge_source,
+                 edge_state, version_constraint, expected_interface_id)
+             VALUES ($1, $2, $3, 'testnet', 'declared', $4::dependency_edge_state, $5, $6)",
+        )
+        .bind(contract_uuid(*source))
+        .bind(target.map(contract_uuid))
+        .bind(target_ref)
+        .bind(state)
+        .bind(constraint)
+        .bind(target.map(|t| format!("iface-{}", (b'a' + t - 1) as char)))
+        .execute(pool)
+        .await
+        .expect("create fixture edge");
+    }
+
+    // E is fully signed, so it has no findings at all -- the case that proves
+    // "zero findings" is reachable.
+    sqlx::query(
+        "INSERT INTO package_signatures
+            (contract_id, version, wasm_hash, signature, signing_address, public_key, status)
+         VALUES ($1, '1.0.0', $2, 'sig', $3, 'pk', 'valid')",
+    )
+    .bind(contract_uuid(5))
+    .bind(wasm_hash('e'))
+    .bind(publisher_address())
+    .execute(pool)
+    .await
+    .expect("sign contract E");
+}
+
+/// Number of 429s to ride out before giving up.
+///
+/// The suite makes enough requests to trip the default per-IP limit, and a 429
+/// says nothing about the behaviour under test -- letting one fail a test would
+/// make the whole suite flaky for a reason unrelated to dependency graphs.
+const RATE_LIMIT_RETRIES: usize = 8;
+
+async fn get_response(path: &str) -> reqwest::Response {
+    let url = format!("{}{}", api_base_url(), path);
+    for attempt in 0..=RATE_LIMIT_RETRIES {
+        let response = reqwest::get(&url).await.expect("request the API");
+        if response.status() != StatusCode::TOO_MANY_REQUESTS {
+            return response;
+        }
+        if attempt < RATE_LIMIT_RETRIES {
+            tokio::time::sleep(std::time::Duration::from_millis(250 * (attempt as u64 + 1))).await;
+        }
+    }
+    panic!("still rate limited after {RATE_LIMIT_RETRIES} retries: {url}. Raise RATE_LIMIT_IP_PER_MINUTE on the API under test.");
+}
+
+async fn get(path: &str) -> (StatusCode, Value) {
+    let response = get_response(path).await;
+    let status = response.status();
+    let body = response.json().await.unwrap_or(Value::Null);
+    (status, body)
+}
+
+async fn get_text(path: &str) -> String {
+    get_response(path).await.text().await.expect("read body")
+}
+
+/// Every contract id appearing anywhere in a nested dependency tree.
+fn flatten(node: &Value, out: &mut Vec<String>) {
+    if let Some(id) = node.get("contract_id").and_then(Value::as_str) {
+        out.push(id.to_string());
+    }
+    if let Some(children) = node.get("dependencies").and_then(Value::as_array) {
+        for child in children {
+            flatten(child, out);
+        }
+    }
+}
+
+fn diagnostics_of(body: &Value) -> Vec<String> {
+    body.get("root")
+        .and_then(|r| r.get("visualization_hints"))
+        .and_then(|h| h.get("diagnostics"))
+        .or_else(|| body.get("diagnostics"))
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|d| d.get("kind").and_then(Value::as_str))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// ── Path resolution ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn strkey_with_network_resolves() {
+    // The original defect: the route declared Path<Uuid> while the CLI sent a
+    // C... address, so axum rejected with 400 before any SQL ran.
+    seed(&pool().await).await;
+
+    let (status, body) = get(&format!(
+        "/api/contracts/{}/dependencies?network=testnet",
+        address('a')
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(
+        body["root"]["contract_id"].as_str(),
+        Some(address('a').as_str())
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn uuid_resolves() {
+    seed(&pool().await).await;
+    let (status, body) = get(&format!(
+        "/api/contracts/{}/dependencies?transitive=true",
+        contract_uuid(1)
+    ))
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn ambiguous_address_is_a_conflict_with_candidates() {
+    // Silently picking one network would answer a question about the wrong
+    // contract, invisibly. 409 with the candidates lets the caller choose.
+    seed(&pool().await).await;
+
+    let (status, body) = get(&format!("/api/contracts/{}/dependencies", address('b'))).await;
+
+    assert_eq!(status, StatusCode::CONFLICT, "body: {body}");
+    let candidates = body["details"]["candidates"]
+        .as_array()
+        .expect("candidates listed");
+    let networks: Vec<&str> = candidates
+        .iter()
+        .filter_map(|c| c["network"].as_str())
+        .collect();
+    assert!(networks.contains(&"mainnet"));
+    assert!(networks.contains(&"testnet"));
+}
+
+#[tokio::test]
+#[ignore]
+async fn ambiguous_address_resolves_once_scoped() {
+    seed(&pool().await).await;
+    let (status, _) = get(&format!(
+        "/api/contracts/{}/dependencies?network=testnet",
+        address('b')
+    ))
+    .await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_non_address_non_uuid_is_a_bad_request_not_a_not_found() {
+    // 404 would imply the contract might exist somewhere; 400 says the input is
+    // malformed, which is the actionable message.
+    seed(&pool().await).await;
+    let (status, _) = get("/api/contracts/not-a-contract/dependencies").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_well_formed_unregistered_address_is_not_found() {
+    seed(&pool().await).await;
+    let (status, _) = get(&format!(
+        "/api/contracts/{}/dependencies?network=testnet",
+        address('q')
+    ))
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+#[ignore]
+async fn uuid_with_a_contradicting_network_is_rejected() {
+    // A UUID names exactly one row, so a mismatched ?network= is a contradiction
+    // in the request rather than an ambiguity to resolve.
+    seed(&pool().await).await;
+    let (status, _) = get(&format!(
+        "/api/contracts/{}/dependencies?network=mainnet",
+        contract_uuid(1)
+    ))
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ── Traversal shape ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn empty_graph_returns_a_root_with_no_dependencies() {
+    seed(&pool().await).await;
+    let (status, body) = get(&format!(
+        "/api/contracts/{}/dependencies?transitive=true",
+        contract_uuid(5)
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total_dependencies"].as_u64(), Some(0));
+    assert_eq!(body["has_circular"].as_bool(), Some(false));
+    assert_eq!(
+        body["root"]["dependencies"].as_array().map(Vec::len),
+        Some(0)
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_cycle_terminates_and_is_reported() {
+    // The guard must stop the walk *and* leave evidence. Terminating silently
+    // would be indistinguishable from depth truncation.
+    seed(&pool().await).await;
+    let (status, body) = get(&format!(
+        "/api/contracts/{}/dependencies?transitive=true",
+        contract_uuid(1)
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["has_circular"].as_bool(), Some(true));
+    assert!(diagnostics_of(&body).contains(&"cycle".to_string()));
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_diamond_does_not_duplicate_the_shared_subtree() {
+    // D is reachable at depth 1 (A->D) and depth 3 (A->B->C->D). Keying tree
+    // nesting on the parent contract id rather than the parent path attached
+    // D's children once per incoming path and rendered them under every
+    // occurrence, multiplying the subtree.
+    seed(&pool().await).await;
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependencies?transitive=true",
+        contract_uuid(1)
+    ))
+    .await;
+
+    let mut ids = Vec::new();
+    flatten(&body["root"], &mut ids);
+
+    // A appears as the root and once per cycle closure (two distinct cycles),
+    // never more.
+    let a_occurrences = ids.iter().filter(|id| **id == address('a')).count();
+    assert_eq!(
+        a_occurrences, 3,
+        "root plus exactly two cycle closures; got {ids:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn direct_only_does_not_walk_the_closure() {
+    seed(&pool().await).await;
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependencies?transitive=false",
+        contract_uuid(1)
+    ))
+    .await;
+
+    assert_eq!(body["max_depth"].as_u64(), Some(1));
+    for child in body["root"]["dependencies"].as_array().unwrap() {
+        assert_eq!(
+            child["dependencies"].as_array().map(Vec::len),
+            Some(0),
+            "a direct-only walk must not expand children"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn depth_limit_truncates_and_says_so() {
+    seed(&pool().await).await;
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependency-graph?depth=2",
+        contract_uuid(1)
+    ))
+    .await;
+
+    assert_eq!(body["truncated"].as_bool(), Some(true));
+    assert_eq!(body["truncation_reason"].as_str(), Some("depth_limit"));
+    assert!(diagnostics_of(&body).contains(&"truncated".to_string()));
+}
+
+#[tokio::test]
+#[ignore]
+async fn node_budget_truncates_and_says_so() {
+    seed(&pool().await).await;
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependency-graph?max_nodes=1",
+        contract_uuid(1)
+    ))
+    .await;
+
+    assert_eq!(body["truncated"].as_bool(), Some(true));
+    assert_eq!(body["truncation_reason"].as_str(), Some("node_limit"));
+    assert_eq!(body["total_dependencies"].as_u64(), Some(1));
+}
+
+#[tokio::test]
+#[ignore]
+async fn unresolved_edges_are_retained_and_split_by_shape() {
+    // A well-formed address that is not registered is a real gap in the graph.
+    // A free-form name is an undeclared library and merely informational. A
+    // blanket severity over both would bury the signal in noise.
+    seed(&pool().await).await;
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependency-graph",
+        contract_uuid(1)
+    ))
+    .await;
+
+    assert_eq!(body["unresolved"].as_u64(), Some(2));
+
+    let details: Vec<&str> = body["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|d| d["kind"] == "unresolved_edge")
+        .filter_map(|d| d["detail"].as_str())
+        .collect();
+
+    assert!(
+        details.iter().any(|d| d.contains("not registered")),
+        "a valid address that is unregistered is a gap: {details:?}"
+    );
+    assert!(
+        details.iter().any(|d| d.contains("undeclared library")),
+        "a free-form name is informational: {details:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn dependents_walks_the_reverse_edges() {
+    seed(&pool().await).await;
+    let (status, body) = get(&format!(
+        "/api/contracts/{}/dependents?transitive=true",
+        contract_uuid(4)
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let mut ids = Vec::new();
+    flatten(&body["root"], &mut ids);
+    // Both routes into D: directly from A, and from C.
+    assert!(ids.contains(&address('a')));
+    assert!(ids.contains(&address('c')));
+}
+
+// ── Tenancy ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn a_private_node_is_counted_but_never_named() {
+    let pool = pool().await;
+    seed(&pool).await;
+
+    sqlx::query("UPDATE contracts SET visibility = 'private' WHERE id = $1")
+        .bind(contract_uuid(3))
+        .execute(&pool)
+        .await
+        .expect("hide C");
+
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependencies?transitive=true",
+        contract_uuid(1)
+    ))
+    .await;
+
+    let mut ids = Vec::new();
+    flatten(&body["root"], &mut ids);
+
+    assert!(
+        !ids.contains(&address('c')),
+        "a private contract's address must not appear: {ids:?}"
+    );
+    assert!(
+        ids.iter().any(|id| id == "[redacted]"),
+        "the node must still be counted: {ids:?}"
+    );
+
+    sqlx::query("UPDATE contracts SET visibility = 'public' WHERE id = $1")
+        .bind(contract_uuid(3))
+        .execute(&pool)
+        .await
+        .expect("restore C");
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_private_node_is_not_a_stepping_stone() {
+    // C is the only route to D's own dependencies via B. With C hidden, the
+    // walk must stop there rather than enumerating what a private contract
+    // depends on.
+    let pool = pool().await;
+    seed(&pool).await;
+
+    // Remove the A->D shortcut so C is the only path onward.
+    sqlx::query("DELETE FROM contract_dependency_edges WHERE source_contract_id = $1 AND target_contract_id = $2")
+        .bind(contract_uuid(1))
+        .bind(contract_uuid(4))
+        .execute(&pool)
+        .await
+        .expect("drop the diamond shortcut");
+
+    sqlx::query("UPDATE contracts SET visibility = 'private' WHERE id = $1")
+        .bind(contract_uuid(3))
+        .execute(&pool)
+        .await
+        .expect("hide C");
+
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependencies?transitive=true",
+        contract_uuid(1)
+    ))
+    .await;
+
+    let mut ids = Vec::new();
+    flatten(&body["root"], &mut ids);
+    assert!(
+        !ids.contains(&address('d')),
+        "D sits behind a private node and must not be enumerated: {ids:?}"
+    );
+
+    sqlx::query("UPDATE contracts SET visibility = 'public' WHERE id = $1")
+        .bind(contract_uuid(3))
+        .execute(&pool)
+        .await
+        .expect("restore C");
+}
+
+// ── Risk ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn a_clean_contract_has_zero_findings() {
+    // Reachable only because diagnostics are kept out of `findings`. If cycles
+    // or unresolved edges carried a severity, no graph could ever be clean.
+    seed(&pool().await).await;
+    let (status, body) = get(&format!(
+        "/api/contracts/{}/dependency-risk",
+        contract_uuid(5)
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["direct_findings"].as_array().map(Vec::len), Some(0));
+    assert_eq!(body["inherited_findings"].as_array().map(Vec::len), Some(0));
+    assert!(body["overall_risk"]["effective_severity"].is_null());
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_vulnerability_propagates_with_its_path_and_severity() {
+    let pool = pool().await;
+    seed(&pool).await;
+
+    let scan_id = Uuid::new_v4();
+    // The notify_security_issue trigger has a pre-existing bug (it references
+    // `sub.` inside the query that defines `sub`), so it is disabled for the
+    // seed. Unrelated to this feature.
+    sqlx::query("ALTER TABLE security_issues DISABLE TRIGGER USER")
+        .execute(&pool)
+        .await
+        .expect("disable notify trigger");
+    sqlx::query(
+        "INSERT INTO security_scans (id, contract_id, status, scan_type)
+         VALUES ($1, $2, 'completed', 'static')",
+    )
+    .bind(scan_id)
+    .bind(contract_uuid(4))
+    .execute(&pool)
+    .await
+    .expect("create scan");
+    sqlx::query(
+        "INSERT INTO security_issues (scan_id, contract_id, title, description, severity, status)
+         VALUES ($1, $2, 'Reentrancy', 'external call before state write', 'critical', 'open')",
+    )
+    .bind(scan_id)
+    .bind(contract_uuid(4))
+    .execute(&pool)
+    .await
+    .expect("create issue");
+
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependency-risk",
+        contract_uuid(1)
+    ))
+    .await;
+
+    let inherited = body["inherited_findings"].as_array().unwrap();
+    let vuln: Vec<&Value> = inherited
+        .iter()
+        .filter(|f| f["rule_id"] == "open_vulnerability")
+        .collect();
+
+    assert_eq!(
+        vuln.len(),
+        1,
+        "the same finding reached by two paths must dedupe to one"
+    );
+    assert_eq!(
+        vuln[0]["severity"].as_str(),
+        Some("Critical"),
+        "a vulnerable dependency is as exploitable through the caller"
+    );
+    // Shortest path wins: A->D, not A->B->C->D.
+    assert_eq!(vuln[0]["inherited_via_depth"].as_u64(), Some(1));
+    assert_eq!(vuln[0]["path"].as_array().map(Vec::len), Some(2));
+    assert_eq!(
+        body["overall_risk"]["effective_severity"].as_str(),
+        Some("Critical")
+    );
+
+    sqlx::query("DELETE FROM security_issues WHERE scan_id = $1")
+        .bind(scan_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("ALTER TABLE security_issues ENABLE TRIGGER USER")
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_revoked_signature_on_a_dependency_is_inherited() {
+    let pool = pool().await;
+    seed(&pool).await;
+
+    sqlx::query(
+        "INSERT INTO package_signatures
+            (contract_id, version, wasm_hash, signature, signing_address, public_key, status, revoked_reason)
+         VALUES ($1, '1.0.0', $2, 'sig', $3, 'pk', 'revoked', 'key compromise')",
+    )
+    .bind(contract_uuid(2))
+    .bind(wasm_hash('b'))
+    .bind(publisher_address())
+    .execute(&pool)
+    .await
+    .expect("revoke B's signature");
+
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependency-risk",
+        contract_uuid(1)
+    ))
+    .await;
+
+    let revoked: Vec<&Value> = body["inherited_findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|f| f["rule_id"] == "signature_revoked")
+        .collect();
+
+    assert_eq!(revoked.len(), 1, "body: {body}");
+    assert_eq!(revoked[0]["severity"].as_str(), Some("High"));
+}
+
+#[tokio::test]
+#[ignore]
+async fn conflicting_constraints_are_a_diagnostic_not_a_finding() {
+    // A version conflict has no defensible severity, so it must never inflate
+    // the risk level of an otherwise clean graph.
+    let pool = pool().await;
+    seed(&pool).await;
+
+    for version in ["1.0.0", "2.0.0"] {
+        sqlx::query(
+            "INSERT INTO contract_versions (contract_id, version, wasm_hash) VALUES ($1, $2, $3)",
+        )
+        .bind(contract_uuid(4))
+        .bind(version)
+        .bind(wasm_hash(if version == "1.0.0" { 'd' } else { 'e' }))
+        .execute(&pool)
+        .await
+        .ok();
+    }
+
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependency-risk",
+        contract_uuid(1)
+    ))
+    .await;
+
+    assert!(
+        diagnostics_of(&body).contains(&"version_conflict".to_string()),
+        "^1.0.0 and ^2.0.0 on D have no commonly satisfying version: {body}"
+    );
+    assert!(
+        !body["inherited_findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|f| f["rule_id"] == "version_conflict"),
+        "a conflict must not appear as a severity-bearing finding"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn an_interface_change_is_reported_against_the_recorded_expectation() {
+    let pool = pool().await;
+    seed(&pool).await;
+
+    sqlx::query("UPDATE contracts SET interface_id = 'iface-b-v2' WHERE id = $1")
+        .bind(contract_uuid(2))
+        .execute(&pool)
+        .await
+        .expect("change B's interface");
+
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependency-risk",
+        contract_uuid(1)
+    ))
+    .await;
+
+    let all: Vec<&Value> = body["direct_findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .chain(body["inherited_findings"].as_array().unwrap())
+        .filter(|f| f["rule_id"] == "interface_incompatibility")
+        .collect();
+
+    assert_eq!(all.len(), 1, "body: {body}");
+    assert!(all[0]["detail"]
+        .as_str()
+        .unwrap()
+        .contains("interface changed"));
+
+    sqlx::query("UPDATE contracts SET interface_id = 'iface-b' WHERE id = $1")
+        .bind(contract_uuid(2))
+        .execute(&pool)
+        .await
+        .expect("restore B's interface");
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_null_interface_id_is_unknown_not_incompatible() {
+    // Every artifact-less contract has a NULL interface id. Treating that as
+    // drift would flag most of the registry as incompatible.
+    let pool = pool().await;
+    seed(&pool).await;
+
+    sqlx::query("UPDATE contracts SET interface_id = NULL WHERE id = $1")
+        .bind(contract_uuid(2))
+        .execute(&pool)
+        .await
+        .expect("clear B's interface");
+
+    let (_, body) = get(&format!(
+        "/api/contracts/{}/dependency-risk",
+        contract_uuid(1)
+    ))
+    .await;
+
+    assert!(
+        !body["direct_findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .chain(body["inherited_findings"].as_array().unwrap())
+            .any(|f| f["rule_id"] == "interface_incompatibility"),
+        "unknown must not read as different: {body}"
+    );
+
+    sqlx::query("UPDATE contracts SET interface_id = 'iface-b' WHERE id = $1")
+        .bind(contract_uuid(2))
+        .execute(&pool)
+        .await
+        .expect("restore B's interface");
+}
+
+// ── Determinism ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn repeated_traversals_are_byte_identical() {
+    // The acceptance criterion. Order comes from a total SQL ORDER BY with no
+    // floats, and dedup keeps the shortest path with a lexicographic tie-break,
+    // so the output is a function of the graph rather than of row arrival order.
+    seed(&pool().await).await;
+    let path = format!(
+        "/api/contracts/{}/dependencies?transitive=true",
+        contract_uuid(1)
+    );
+
+    let first = get_text(&path).await;
+    let second = get_text(&path).await;
+    assert_eq!(first, second);
+}
+
+#[tokio::test]
+#[ignore]
+async fn repeated_risk_reports_are_byte_identical() {
+    seed(&pool().await).await;
+    let path = format!("/api/contracts/{}/dependency-risk", contract_uuid(1));
+
+    let first = get_text(&path).await;
+    let second = get_text(&path).await;
+    assert_eq!(first, second);
+}
+
+// ── Compatibility ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn the_compatibility_view_exposes_declared_edges() {
+    // Eight of the eleven phantom-table call sites read `contract_dependencies`
+    // in the legacy static shape. The view is what makes them work unchanged.
+    let pool = pool().await;
+    seed(&pool).await;
+
+    let rows: Vec<(Uuid, String, Option<Uuid>)> = sqlx::query_as(
+        "SELECT contract_id, dependency_name, dependency_contract_id
+         FROM contract_dependencies WHERE contract_id = $1 ORDER BY dependency_name",
+    )
+    .bind(contract_uuid(1))
+    .fetch_all(&pool)
+    .await
+    .expect("read the compatibility view");
+
+    assert_eq!(rows.len(), 3, "two resolved plus one unresolved");
+    assert!(rows
+        .iter()
+        .any(|(_, name, id)| name == &address('b') && id.is_some()));
+    assert!(rows
+        .iter()
+        .any(|(_, name, id)| name == "some-library" && id.is_none()));
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_superseded_edge_leaves_the_current_view() {
+    let pool = pool().await;
+    seed(&pool).await;
+
+    sqlx::query(
+        "UPDATE contract_dependency_edges SET superseded_at = NOW()
+         WHERE source_contract_id = $1 AND target_ref = $2",
+    )
+    .bind(contract_uuid(1))
+    .bind(address('b'))
+    .execute(&pool)
+    .await
+    .expect("supersede an edge");
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM contract_dependencies WHERE contract_id = $1 AND dependency_name = $2",
+    )
+    .bind(contract_uuid(1))
+    .bind(address('b'))
+    .fetch_one(&pool)
+    .await
+    .expect("count current edges");
+
+    assert_eq!(count, 0, "the view must show current state only");
+}
+
+// ── Snapshot schema ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn a_snapshot_without_a_graph_stays_on_schema_1_0() {
+    // Requires REGISTRY_SIGNING_KEY on the API. Skipped otherwise, because a
+    // 503 here says nothing about the schema rule under test.
+    seed(&pool().await).await;
+    let (status, body) = get(&format!("/api/contracts/{}/snapshot", contract_uuid(1))).await;
+    if status == StatusCode::SERVICE_UNAVAILABLE {
+        eprintln!("skipping: REGISTRY_SIGNING_KEY is not configured on the API");
+        return;
+    }
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["payload"]["schema_version"].as_str(), Some("1.0"));
+    assert!(body["payload"].get("dependency_graph").is_none());
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_graph_bearing_snapshot_declares_schema_1_1() {
+    // An old verifier must get UnsupportedSchema("1.1"), not a signature
+    // failure. That is only possible if the version moves with the content.
+    seed(&pool().await).await;
+    let (status, body) = get(&format!(
+        "/api/contracts/{}/snapshot?include_dependency_graph=true",
+        contract_uuid(1)
+    ))
+    .await;
+    if status == StatusCode::SERVICE_UNAVAILABLE {
+        eprintln!("skipping: REGISTRY_SIGNING_KEY is not configured on the API");
+        return;
+    }
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["payload"]["schema_version"].as_str(), Some("1.1"));
+    assert!(body["payload"]["dependency_graph"]["overall_risk"].is_object());
+}

--- a/backend/api/tests/dependency_tests.rs
+++ b/backend/api/tests/dependency_tests.rs
@@ -1,178 +1,82 @@
 // tests/dependency_tests.rs
 //
 // Issue #610 — Contract dependency tracking and resolution.
-// Unit tests for the dependency logic (no live DB required).
+// Issue #1147 — rewritten to test the shipped code.
+//
+// This file used to assert against helper functions defined in the file itself:
+// an in-memory `has_cycle_in_memory` that reimplemented cycle detection, a
+// `get_transitive_dependencies_in_memory` whose entire body was `vec![]`, and
+// checks like "a version constraint string is not empty". None of it exercised
+// any code that ships, so it passed no matter what the real implementation did
+// -- the worst kind of test, because it reads as coverage.
+//
+// The behaviour is now tested where it actually lives:
+//
+// - Cycle, ordering, dedup, severity and version-conflict rules are pure and
+//   live in `shared::dependency_graph`; `cargo test -p shared` covers them with
+//   no database.
+// - The traversal itself is a recursive CTE, so it is only meaningfully tested
+//   against Postgres: see `api/tests/dependency_graph_tests.rs`.
+//
+// What remains here is the part that belongs at this level: the invariants
+// Issue #610 cared about, asserted against the real shared functions rather
+// than against a copy of them.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use shared::dependency_graph::{cycle_segment, EdgeState};
+use uuid::Uuid;
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Helpers mirroring dependency.rs logic
-// ─────────────────────────────────────────────────────────────────────────────
-
-fn get_transitive_dependencies_in_memory(
-    graph: &HashMap<&str, Vec<&str>>,
-    root: &str,
-) -> Vec<&'static str> {
-    // We can't easily return &'static str from a ref, so use owned comparisons.
-    let _ = root;
-    let _ = graph;
-    vec![]
-}
-
-fn has_cycle_in_memory(graph: &HashMap<&str, Vec<&str>>, start: &str, potential_dep: &str) -> bool {
-    if start == potential_dep {
-        return true;
-    }
-    // DFS from potential_dep — if start is reachable, adding start→potential_dep creates a cycle.
-    let mut visited = HashSet::new();
-    let mut queue = VecDeque::new();
-    queue.push_back(potential_dep);
-
-    while let Some(node) = queue.pop_front() {
-        if visited.contains(node) {
-            continue;
-        }
-        visited.insert(node);
-        for &dep in graph.get(node).unwrap_or(&vec![]) {
-            if dep == start {
-                return true;
-            }
-            queue.push_back(dep);
-        }
-    }
-    false
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Tests
-// ─────────────────────────────────────────────────────────────────────────────
-
-#[test]
-fn test_no_cycle_basic() {
-    let mut graph: HashMap<&str, Vec<&str>> = HashMap::new();
-    graph.insert("A", vec!["B"]);
-    graph.insert("B", vec!["C"]);
-    graph.insert("C", vec![]);
-    assert!(!has_cycle_in_memory(&graph, "A", "C"), "A→B→C has no cycle");
+fn node(n: u8) -> Uuid {
+    Uuid::from_bytes([n; 16])
 }
 
 #[test]
-fn test_self_dependency_is_cycle() {
-    let graph: HashMap<&str, Vec<&str>> = HashMap::new();
+fn a_direct_cycle_is_detected() {
+    // A -> B, and B points back at A.
+    let path = [node(1), node(2)];
+    let segment = cycle_segment(&path, node(1)).expect("A -> B -> A is a cycle");
+    assert_eq!(segment, vec![node(1), node(2), node(1)]);
+}
+
+#[test]
+fn a_transitive_cycle_is_detected() {
+    // A -> B -> C, and C points back at A.
+    let path = [node(1), node(2), node(3)];
+    let segment = cycle_segment(&path, node(1)).expect("A -> B -> C -> A is a cycle");
+    assert_eq!(segment, vec![node(1), node(2), node(3), node(1)]);
+}
+
+#[test]
+fn a_self_dependency_is_a_cycle() {
+    let segment = cycle_segment(&[node(1)], node(1)).expect("A -> A is a cycle");
+    assert_eq!(segment, vec![node(1), node(1)]);
+}
+
+#[test]
+fn a_diamond_is_not_a_cycle() {
+    // A -> B -> D and A -> C -> D share D but close no loop. Reporting a
+    // diamond as circular was the practical failure mode of the old
+    // visited-set walk, which removed nodes on unwind.
+    assert_eq!(cycle_segment(&[node(1), node(2)], node(4)), None);
+    assert_eq!(cycle_segment(&[node(1), node(3)], node(4)), None);
+}
+
+#[test]
+fn the_cycle_segment_excludes_the_lead_in() {
+    // Entering a loop is not the same as being in it: a diagnostic that named
+    // the whole path would point at contracts that are not part of the cycle.
+    let path = [node(9), node(1), node(2)];
+    let segment = cycle_segment(&path, node(1)).expect("cycle");
     assert!(
-        has_cycle_in_memory(&graph, "A", "A"),
-        "Self-dependency is a cycle"
+        !segment.contains(&node(9)),
+        "the lead-in node is not part of the loop: {segment:?}"
     );
 }
 
 #[test]
-fn test_direct_cycle_detected() {
-    let mut graph: HashMap<&str, Vec<&str>> = HashMap::new();
-    graph.insert("B", vec!["A"]); // B already depends on A
-                                  // Adding A → B would create: A → B → A
-    assert!(
-        has_cycle_in_memory(&graph, "A", "B"),
-        "A→B would create cycle"
-    );
-}
-
-#[test]
-fn test_transitive_cycle_detected() {
-    let mut graph: HashMap<&str, Vec<&str>> = HashMap::new();
-    graph.insert("B", vec!["C"]);
-    graph.insert("C", vec!["A"]); // C → A already exists
-                                  // Adding A → B would create: A → B → C → A
-    assert!(
-        has_cycle_in_memory(&graph, "A", "B"),
-        "Transitive cycle A→B→C→A detected"
-    );
-}
-
-#[test]
-fn test_no_cycle_with_diamond() {
-    let mut graph: HashMap<&str, Vec<&str>> = HashMap::new();
-    graph.insert("A", vec!["B", "C"]);
-    graph.insert("B", vec!["D"]);
-    graph.insert("C", vec!["D"]);
-    graph.insert("D", vec![]);
-    // Diamond: A→B→D, A→C→D — no cycle
-    assert!(!has_cycle_in_memory(&graph, "A", "D"));
-    assert!(!has_cycle_in_memory(&graph, "B", "D"));
-}
-
-#[test]
-fn test_circular_detection_visited_set() {
-    // Mirror the logic in dependency_handlers::build_dependency_tree
-    let mut visited = HashSet::new();
-    let id_a = "contract-A";
-    let id_b = "contract-B";
-    let id_c = "contract-C";
-
-    visited.insert(id_a);
-    visited.insert(id_b);
-
-    // c tries to reference a — already in visited → circular
-    let is_circular = visited.contains(&id_a);
-    assert!(
-        is_circular,
-        "#610: circular dependency to A detected via visited set"
-    );
-
-    // c references d — not in visited
-    let is_d_circular = visited.contains(&"contract-D");
-    assert!(!is_d_circular, "#610: D not in visited, no circle");
-    let _ = id_c;
-}
-
-#[test]
-fn test_dependency_name_resolution_uuid_format() {
-    // Simulate: if identifier parses as UUID, it's used directly.
-    let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
-    let is_uuid =
-        uuid_str.parse::<u128>().is_err() && uuid_str.contains('-') && uuid_str.len() == 36;
-    assert!(
-        is_uuid,
-        "#610: UUID identifiers recognised for dependency resolution"
-    );
-}
-
-#[test]
-fn test_dependency_declaration_version_constraint() {
-    // Ensure version constraint wildcards are stored as-is.
-    let constraints = vec!["*", ">=1.0.0", "^2.3.0", "~1.5.0"];
-    for c in &constraints {
-        assert!(!c.is_empty(), "constraint '{}' should not be empty", c);
-    }
-}
-
-#[test]
-fn test_transitive_dependency_bfs_ordering() {
-    // Simulate BFS traversal to collect transitive deps in breadth-first order.
-    let mut graph: HashMap<&str, Vec<&str>> = HashMap::new();
-    graph.insert("root", vec!["A", "B"]);
-    graph.insert("A", vec!["C"]);
-    graph.insert("B", vec!["C"]);
-    graph.insert("C", vec![]);
-
-    let mut visited = HashSet::new();
-    let mut queue = VecDeque::new();
-    let mut result = Vec::new();
-
-    queue.push_back("root");
-    visited.insert("root");
-
-    while let Some(node) = queue.pop_front() {
-        for &dep in graph.get(node).unwrap_or(&vec![]) {
-            if visited.insert(dep) {
-                queue.push_back(dep);
-                result.push(dep);
-            }
-        }
-    }
-
-    // root → A, B → C (C appears once due to visited set)
-    assert_eq!(result.len(), 3, "#610: 3 unique transitive deps");
-    assert!(result.contains(&"A"));
-    assert!(result.contains(&"B"));
-    assert!(result.contains(&"C"));
+fn only_resolved_edges_are_followed() {
+    // Issue #1147 D3: a dependency reference that names nothing must be kept
+    // and reported, but never treated as a dependency for traversal or risk.
+    assert!(EdgeState::Resolved.is_traversable());
+    assert!(!EdgeState::Unresolved.is_traversable());
+    assert!(!EdgeState::NetworkMismatch.is_traversable());
 }

--- a/backend/shared/src/dependency_graph.rs
+++ b/backend/shared/src/dependency_graph.rs
@@ -7,9 +7,10 @@
 //! propagation in `api::dependency_risk` supply rows; this module decides what
 //! they mean and in what order they are reported.
 //!
-//! Like [`crate::contract_spec`], this module is deliberately dependency-light
-//! so every workspace member -- API, CLI, verifier -- can share one definition
-//! of the wire shapes and one definition of the rules.
+//! It lives in `shared`, alongside [`crate::contract_spec`], so every workspace
+//! member -- API, CLI, verifier -- shares one definition of the wire shapes and
+//! one definition of the rules, and so the rules stay covered by
+//! `cargo test -p shared`.
 //!
 //! ## Two arrays, not one
 //!
@@ -23,6 +24,7 @@ use crate::models::IssueSeverity;
 use crate::semver::{SemVer, VersionConstraint};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 // ── Traversal budget ────────────────────────────────────────────────────────
@@ -71,7 +73,9 @@ pub fn clamp_max_nodes(requested: Option<usize>) -> usize {
 // ── Edge vocabulary ─────────────────────────────────────────────────────────
 
 /// Where an edge came from. Mirrors the `dependency_edge_source` enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, ToSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum EdgeSource {
     /// Declared by the publisher through the dependencies endpoint.
@@ -82,7 +86,9 @@ pub enum EdgeSource {
 
 /// Whether an edge's declared reference bound to a registry contract.
 /// Mirrors the `dependency_edge_state` enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, ToSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum EdgeState {
     Resolved,
@@ -101,7 +107,7 @@ impl EdgeState {
 // ── Diagnostics ─────────────────────────────────────────────────────────────
 
 /// A fact about the shape of the graph. Carries **no** severity, deliberately.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct Diagnostic {
     pub kind: DiagnosticKind,
     /// Contracts involved, root first. Empty when the diagnostic is about the
@@ -112,7 +118,9 @@ pub struct Diagnostic {
     pub detail: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, ToSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum DiagnosticKind {
     /// The traversal re-encountered a contract already on the current path.
@@ -132,7 +140,7 @@ pub enum DiagnosticKind {
 
 /// Why a traversal stopped early. Always reported alongside `truncated: true`
 /// so a consumer can tell a genuinely small graph from a clipped one.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TruncationReason {
     DepthLimit,
@@ -160,7 +168,9 @@ impl TruncationReason {
 /// you are calling directly is an immediate one. Some conditions do not
 /// propagate at all -- an interface incompatibility is a fact about one specific
 /// edge, so re-reporting it two hops away would be meaningless.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, ToSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum RiskRule {
     /// An open entry in `security_issues` or a matched CVE.
@@ -231,7 +241,7 @@ impl RiskRule {
 }
 
 /// One severity-bearing security condition, with provenance.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct Finding {
     pub rule_id: String,
     pub severity: IssueSeverity,
@@ -268,7 +278,7 @@ impl Finding {
 // ── Aggregation ─────────────────────────────────────────────────────────────
 
 /// Count of findings at each severity.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct SeverityCounts {
     pub critical: u32,
     pub high: u32,
@@ -308,7 +318,7 @@ impl SeverityCounts {
 /// is exactly the distinction an operator triaging an upgrade needs; and
 /// severity is ordinal, so summing or averaging it is meaningless. The tuple is
 /// deterministic, float-free, and is also what the CLI table renders.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct EffectiveRisk {
     /// `None` means no findings at all -- a state that stays reachable only
     /// because diagnostics are kept out of `findings`.

--- a/backend/shared/src/dependency_graph.rs
+++ b/backend/shared/src/dependency_graph.rs
@@ -1,0 +1,821 @@
+//! Pure types and rules for contract dependency graphs and transitive risk
+//! (Issue #1147).
+//!
+//! Everything here is deterministic and free of I/O, so the rules that decide
+//! *what counts as a risk* and *how risks combine* can be tested exhaustively
+//! without a database. The SQL traversal in `api::dependency_graph` and the
+//! propagation in `api::dependency_risk` supply rows; this module decides what
+//! they mean and in what order they are reported.
+//!
+//! Like [`crate::contract_spec`], this module is deliberately dependency-light
+//! so every workspace member -- API, CLI, verifier -- can share one definition
+//! of the wire shapes and one definition of the rules.
+//!
+//! ## Two arrays, not one
+//!
+//! Findings carry a severity; diagnostics do not. A cycle, an unresolved edge,
+//! or a truncated traversal is a fact about the *graph*, not a security
+//! condition, and giving it a severity would drag `max()` over every cyclic
+//! graph up to at least Low -- making "zero findings" unreachable and the whole
+//! report useless as a gate. See [`Diagnostic`].
+
+use crate::models::IssueSeverity;
+use crate::semver::{SemVer, VersionConstraint};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+// ── Traversal budget ────────────────────────────────────────────────────────
+
+/// Default traversal depth when the caller does not ask for one.
+///
+/// One constant, referenced everywhere. Before Issue #1147 there were four
+/// different limits in three modules (20, 5, and 8), so the same graph reported
+/// a different shape depending on which endpoint you asked.
+pub const DEFAULT_MAX_DEPTH: u32 = 10;
+
+/// Hard ceiling on `depth`, regardless of what the caller requests.
+pub const MAX_DEPTH_CAP: u32 = 32;
+
+/// Default cap on distinct nodes returned by one traversal.
+pub const DEFAULT_MAX_NODES: usize = 1_000;
+
+/// Hard ceiling on `max_nodes`. Also the reason offset pagination is
+/// defensible here: the result set can never exceed this.
+pub const MAX_NODES_CAP: usize = 10_000;
+
+/// Wall-clock budget applied as `SET LOCAL statement_timeout` around a
+/// traversal.
+///
+/// Dropping an axum future does **not** cancel an in-flight sqlx query: the
+/// Postgres backend keeps running and the pooled connection stays checked out.
+/// A client that disconnects mid-traversal would otherwise cost a connection
+/// for as long as the query takes. This makes the bound enforceable rather than
+/// aspirational.
+pub const TRAVERSAL_STATEMENT_TIMEOUT_MS: u32 = 10_000;
+
+/// Clamp a caller-supplied depth into `1..=MAX_DEPTH_CAP`.
+pub fn clamp_depth(requested: Option<u32>) -> u32 {
+    requested
+        .unwrap_or(DEFAULT_MAX_DEPTH)
+        .clamp(1, MAX_DEPTH_CAP)
+}
+
+/// Clamp a caller-supplied node budget into `1..=MAX_NODES_CAP`.
+pub fn clamp_max_nodes(requested: Option<usize>) -> usize {
+    requested
+        .unwrap_or(DEFAULT_MAX_NODES)
+        .clamp(1, MAX_NODES_CAP)
+}
+
+// ── Edge vocabulary ─────────────────────────────────────────────────────────
+
+/// Where an edge came from. Mirrors the `dependency_edge_source` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeSource {
+    /// Declared by the publisher through the dependencies endpoint.
+    Declared,
+    /// Observed on chain, derived live from daily call aggregates.
+    Telemetry,
+}
+
+/// Whether an edge's declared reference bound to a registry contract.
+/// Mirrors the `dependency_edge_state` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeState {
+    Resolved,
+    Unresolved,
+    NetworkMismatch,
+}
+
+impl EdgeState {
+    /// Only a resolved edge is walked for risk. An unresolved reference names
+    /// nothing whose risk could be inherited.
+    pub fn is_traversable(self) -> bool {
+        matches!(self, EdgeState::Resolved)
+    }
+}
+
+// ── Diagnostics ─────────────────────────────────────────────────────────────
+
+/// A fact about the shape of the graph. Carries **no** severity, deliberately.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Diagnostic {
+    pub kind: DiagnosticKind,
+    /// Contracts involved, root first. Empty when the diagnostic is about the
+    /// traversal as a whole rather than a specific path.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub path: Vec<Uuid>,
+    /// Human-readable explanation. Never a severity.
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticKind {
+    /// The traversal re-encountered a contract already on the current path.
+    Cycle,
+    /// A declared reference that does not name a registered contract.
+    UnresolvedEdge,
+    /// A declared reference that names a contract on a different network.
+    NetworkMismatch,
+    /// The traversal hit a depth, node, or time budget.
+    Truncated,
+    /// Two edges target the same contract under constraints no published
+    /// version satisfies.
+    VersionConflict,
+    /// A node the caller may not see, counted but not named.
+    RedactedNode,
+}
+
+/// Why a traversal stopped early. Always reported alongside `truncated: true`
+/// so a consumer can tell a genuinely small graph from a clipped one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TruncationReason {
+    DepthLimit,
+    NodeLimit,
+    TimeLimit,
+}
+
+impl TruncationReason {
+    pub fn detail(self, limit: u64) -> String {
+        match self {
+            Self::DepthLimit => format!("traversal stopped at the depth limit of {limit}"),
+            Self::NodeLimit => format!("traversal stopped at the node limit of {limit}"),
+            Self::TimeLimit => format!("traversal exceeded its {limit}ms time budget"),
+        }
+    }
+}
+
+// ── Risk rules ──────────────────────────────────────────────────────────────
+
+/// A security condition that can be attached to a contract.
+///
+/// Each rule declares its own direct and inherited severities. Inherited
+/// severity is separate because most conditions matter less at a distance: a
+/// deprecated *dependency* is a planning problem, whereas a deprecated contract
+/// you are calling directly is an immediate one. Some conditions do not
+/// propagate at all -- an interface incompatibility is a fact about one specific
+/// edge, so re-reporting it two hops away would be meaningless.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskRule {
+    /// An open entry in `security_issues` or a matched CVE.
+    OpenVulnerability,
+    /// The package signature for the current artifact was revoked.
+    SignatureRevoked,
+    /// The published artifact failed its scan and is quarantined.
+    ArtifactQuarantined,
+    /// No valid signature exists for the current wasm hash.
+    ArtifactUnsigned,
+    /// Deprecated with no replacement, or superseded.
+    DeprecatedNoReplacement,
+    /// Deprecated but with a named replacement and still inside its grace
+    /// period. A migration task, not a live hazard, so it does not propagate.
+    DeprecatedWithReplacement,
+    /// The target's current interface id differs from the one recorded on the
+    /// edge when the dependency was declared.
+    InterfaceIncompatibility,
+}
+
+impl RiskRule {
+    /// Stable wire identifier. Used as a sort key and as part of the dedup
+    /// identity, so it must never change for an existing rule.
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::OpenVulnerability => "open_vulnerability",
+            Self::SignatureRevoked => "signature_revoked",
+            Self::ArtifactQuarantined => "artifact_quarantined",
+            Self::ArtifactUnsigned => "artifact_unsigned",
+            Self::DeprecatedNoReplacement => "deprecated_no_replacement",
+            Self::DeprecatedWithReplacement => "deprecated_with_replacement",
+            Self::InterfaceIncompatibility => "interface_incompatibility",
+        }
+    }
+
+    /// Severity when the condition is on the contract being asked about.
+    ///
+    /// `OpenVulnerability` returns `None`: its severity comes from the recorded
+    /// issue, not from this table, and inventing one here would overwrite what
+    /// a scanner actually found.
+    pub fn direct_severity(self) -> Option<IssueSeverity> {
+        match self {
+            Self::OpenVulnerability => None,
+            Self::SignatureRevoked => Some(IssueSeverity::High),
+            Self::ArtifactQuarantined => Some(IssueSeverity::High),
+            Self::ArtifactUnsigned => Some(IssueSeverity::Medium),
+            Self::DeprecatedNoReplacement => Some(IssueSeverity::Medium),
+            Self::DeprecatedWithReplacement => Some(IssueSeverity::Low),
+            Self::InterfaceIncompatibility => Some(IssueSeverity::High),
+        }
+    }
+
+    /// Severity when the condition is on a transitive dependency.
+    /// `None` means the condition does not propagate at all.
+    pub fn inherited_severity(self, direct: IssueSeverity) -> Option<IssueSeverity> {
+        match self {
+            // A vulnerable dependency is exactly as exploitable through the
+            // caller as it is directly, so severity is carried unchanged.
+            Self::OpenVulnerability => Some(direct),
+            Self::SignatureRevoked => Some(IssueSeverity::High),
+            Self::ArtifactQuarantined => Some(IssueSeverity::Medium),
+            Self::ArtifactUnsigned => Some(IssueSeverity::Low),
+            Self::DeprecatedNoReplacement => Some(IssueSeverity::Low),
+            Self::DeprecatedWithReplacement => None,
+            Self::InterfaceIncompatibility => None,
+        }
+    }
+}
+
+/// One severity-bearing security condition, with provenance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Finding {
+    pub rule_id: String,
+    pub severity: IssueSeverity,
+    /// The contract the condition is actually on.
+    pub origin_contract_id: Uuid,
+    /// Stable identity of the underlying record (a `security_issues` row, a CVE
+    /// id, or the rule id when the condition is a property of the contract
+    /// itself). Part of the dedup key.
+    pub finding_id: String,
+    /// Root-to-origin path. `[root]` for a direct finding.
+    pub path: Vec<Uuid>,
+    /// Hops from the root. `0` for a direct finding. Always emitted so
+    /// consumers can gate on distance.
+    pub inherited_via_depth: u32,
+    pub detail: String,
+}
+
+impl Finding {
+    pub fn is_direct(&self) -> bool {
+        self.inherited_via_depth == 0
+    }
+
+    /// Identity for deduplication: the same underlying condition on the same
+    /// contract, however many paths reach it.
+    fn dedup_key(&self) -> (&str, Uuid, &str) {
+        (
+            self.rule_id.as_str(),
+            self.origin_contract_id,
+            self.finding_id.as_str(),
+        )
+    }
+}
+
+// ── Aggregation ─────────────────────────────────────────────────────────────
+
+/// Count of findings at each severity.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SeverityCounts {
+    pub critical: u32,
+    pub high: u32,
+    pub medium: u32,
+    pub low: u32,
+}
+
+impl SeverityCounts {
+    pub fn tally(findings: &[Finding]) -> Self {
+        let mut counts = Self::default();
+        for finding in findings {
+            match finding.severity {
+                IssueSeverity::Critical => counts.critical += 1,
+                IssueSeverity::High => counts.high += 1,
+                IssueSeverity::Medium => counts.medium += 1,
+                IssueSeverity::Low => counts.low += 1,
+            }
+        }
+        counts
+    }
+
+    pub fn total(&self) -> u32 {
+        self.critical + self.high + self.medium + self.low
+    }
+
+    /// Ordering key: most severe bucket first, then counts within it.
+    /// Float-free and total, so two identical inputs always compare equal.
+    fn ordering_key(&self) -> (u32, u32, u32, u32) {
+        (self.critical, self.high, self.medium, self.low)
+    }
+}
+
+/// The overall risk of a contract and its dependency closure.
+///
+/// Compared as `(effective_severity, counts)` lexicographically rather than a
+/// bare `max()`. `max()` alone ranks one High identically to forty Highs, which
+/// is exactly the distinction an operator triaging an upgrade needs; and
+/// severity is ordinal, so summing or averaging it is meaningless. The tuple is
+/// deterministic, float-free, and is also what the CLI table renders.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EffectiveRisk {
+    /// `None` means no findings at all -- a state that stays reachable only
+    /// because diagnostics are kept out of `findings`.
+    pub effective_severity: Option<IssueSeverity>,
+    pub counts: SeverityCounts,
+}
+
+impl EffectiveRisk {
+    pub fn from_findings(findings: &[Finding]) -> Self {
+        Self {
+            effective_severity: findings.iter().map(|f| f.severity).max(),
+            counts: SeverityCounts::tally(findings),
+        }
+    }
+
+    /// True when this risk meets or exceeds `threshold`. This is what a CLI
+    /// `--fail-on` gate calls.
+    pub fn meets_threshold(&self, threshold: IssueSeverity) -> bool {
+        self.effective_severity
+            .is_some_and(|severity| severity >= threshold)
+    }
+}
+
+impl PartialOrd for EffectiveRisk {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for EffectiveRisk {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.effective_severity
+            .cmp(&other.effective_severity)
+            .then_with(|| self.counts.ordering_key().cmp(&other.counts.ordering_key()))
+    }
+}
+
+// ── Dedup and ordering ──────────────────────────────────────────────────────
+
+/// Collapse findings that describe the same condition reached by several paths,
+/// keeping the **shortest** path.
+///
+/// Without this the output is non-deterministic: a diamond reaches the same
+/// vulnerable contract twice, and which path survives depends on traversal
+/// order. Ties break on the path itself (lexicographically), so the result is a
+/// total function of the input set rather than of the order it arrived in.
+///
+/// The shortest path is kept because it is the most actionable: it is the
+/// closest route from the contract you asked about to the problem.
+pub fn dedup_findings(findings: Vec<Finding>) -> Vec<Finding> {
+    let mut best: BTreeMap<(String, Uuid, String), Finding> = BTreeMap::new();
+
+    for finding in findings {
+        let key = {
+            let (rule, origin, id) = finding.dedup_key();
+            (rule.to_string(), origin, id.to_string())
+        };
+
+        match best.get(&key) {
+            Some(existing)
+                if (existing.path.len(), &existing.path) <= (finding.path.len(), &finding.path) => {
+            }
+            _ => {
+                best.insert(key, finding);
+            }
+        }
+    }
+
+    let mut out: Vec<Finding> = best.into_values().collect();
+    sort_findings(&mut out);
+    out
+}
+
+/// Deterministic report order: most severe first, then rule id, then path.
+///
+/// No floats anywhere in the key, and every component is total, so two calls
+/// with the same input serialize to identical bytes.
+pub fn sort_findings(findings: &mut [Finding]) {
+    findings.sort_by(|a, b| {
+        b.severity
+            .cmp(&a.severity)
+            .then_with(|| a.rule_id.cmp(&b.rule_id))
+            .then_with(|| a.path.cmp(&b.path))
+            .then_with(|| a.origin_contract_id.cmp(&b.origin_contract_id))
+            .then_with(|| a.finding_id.cmp(&b.finding_id))
+    });
+}
+
+/// Deterministic diagnostic order, on the same principle as [`sort_findings`].
+pub fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
+    diagnostics.sort_by(|a, b| {
+        a.kind
+            .cmp(&b.kind)
+            .then_with(|| a.path.cmp(&b.path))
+            .then_with(|| a.detail.cmp(&b.detail))
+    });
+}
+
+// ── Cycles ──────────────────────────────────────────────────────────────────
+
+/// Extract the cyclic segment of a path that has revisited `repeated`.
+///
+/// The recursive CTE stops descending when the next target is already on the
+/// path; this turns "we stopped here" into the actual cycle, so the diagnostic
+/// names the loop rather than the whole path leading into it.
+/// Returns `None` when `repeated` is not on `path` (no cycle).
+pub fn cycle_segment(path: &[Uuid], repeated: Uuid) -> Option<Vec<Uuid>> {
+    let start = path.iter().position(|node| *node == repeated)?;
+    let mut segment = path[start..].to_vec();
+    segment.push(repeated);
+    Some(segment)
+}
+
+// ── Version conflicts ───────────────────────────────────────────────────────
+
+/// Do two constraints on the same target have a commonly satisfying published
+/// version?
+///
+/// `version_constraint` is opaque and defaults to `"*"`, for which
+/// [`VersionConstraint::parse`] returns `None`; and the target has no version on
+/// `contracts` at all -- versions live in `contract_versions`. So a conflict
+/// cannot be decided from the constraints alone. It is defined against the
+/// target's actually-published versions: two constraints conflict when **no**
+/// published version satisfies both.
+///
+/// An unparseable constraint (including `"*"`) is treated as "matches
+/// everything" and therefore never creates a conflict. Reporting a conflict
+/// because a constraint could not be parsed would flag a parser gap as a
+/// dependency problem.
+pub fn constraints_conflict(a: &str, b: &str, published_versions: &[String]) -> bool {
+    let (Some(ca), Some(cb)) = (VersionConstraint::parse(a), VersionConstraint::parse(b)) else {
+        return false;
+    };
+
+    // A target with no published versions cannot be shown to conflict: there is
+    // nothing to satisfy either constraint, so any claim would be speculation.
+    if published_versions.is_empty() {
+        return false;
+    }
+
+    !published_versions
+        .iter()
+        .filter_map(|version| SemVer::parse(version))
+        .any(|version| ca.matches(&version) && cb.matches(&version))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uuid(n: u8) -> Uuid {
+        Uuid::from_bytes([n; 16])
+    }
+
+    fn finding(rule: RiskRule, severity: IssueSeverity, origin: u8, path: &[u8]) -> Finding {
+        Finding {
+            rule_id: rule.id().to_string(),
+            severity,
+            origin_contract_id: uuid(origin),
+            finding_id: format!("{}-{origin}", rule.id()),
+            path: path.iter().copied().map(uuid).collect(),
+            inherited_via_depth: path.len().saturating_sub(1) as u32,
+            detail: String::new(),
+        }
+    }
+
+    // ── Budget ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn depth_defaults_and_clamps() {
+        assert_eq!(clamp_depth(None), DEFAULT_MAX_DEPTH);
+        assert_eq!(clamp_depth(Some(3)), 3);
+        assert_eq!(clamp_depth(Some(0)), 1, "zero depth would return nothing");
+        assert_eq!(clamp_depth(Some(u32::MAX)), MAX_DEPTH_CAP);
+    }
+
+    #[test]
+    fn node_budget_defaults_and_clamps() {
+        assert_eq!(clamp_max_nodes(None), DEFAULT_MAX_NODES);
+        assert_eq!(clamp_max_nodes(Some(50)), 50);
+        assert_eq!(clamp_max_nodes(Some(0)), 1);
+        assert_eq!(clamp_max_nodes(Some(usize::MAX)), MAX_NODES_CAP);
+    }
+
+    #[test]
+    fn node_cap_justifies_offset_pagination() {
+        // Offset pagination is only defensible because the result set is
+        // bounded. If this ever grows unbounded, revisit the pagination mode.
+        assert!(MAX_NODES_CAP <= 10_000);
+    }
+
+    // ── Rule table ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn open_vulnerability_severity_comes_from_the_record_not_the_table() {
+        assert_eq!(RiskRule::OpenVulnerability.direct_severity(), None);
+        for severity in [
+            IssueSeverity::Low,
+            IssueSeverity::Medium,
+            IssueSeverity::High,
+            IssueSeverity::Critical,
+        ] {
+            assert_eq!(
+                RiskRule::OpenVulnerability.inherited_severity(severity),
+                Some(severity),
+                "a vulnerable dependency is as exploitable through the caller"
+            );
+        }
+    }
+
+    #[test]
+    fn inherited_severity_never_exceeds_direct() {
+        for rule in [
+            RiskRule::SignatureRevoked,
+            RiskRule::ArtifactQuarantined,
+            RiskRule::ArtifactUnsigned,
+            RiskRule::DeprecatedNoReplacement,
+            RiskRule::DeprecatedWithReplacement,
+            RiskRule::InterfaceIncompatibility,
+        ] {
+            let direct = rule.direct_severity().expect("has a direct severity");
+            if let Some(inherited) = rule.inherited_severity(direct) {
+                assert!(
+                    inherited <= direct,
+                    "{} inherited {inherited:?} > direct {direct:?}",
+                    rule.id()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn edge_specific_rules_do_not_propagate() {
+        assert_eq!(
+            RiskRule::InterfaceIncompatibility.inherited_severity(IssueSeverity::High),
+            None,
+            "incompatibility is a fact about one edge"
+        );
+        assert_eq!(
+            RiskRule::DeprecatedWithReplacement.inherited_severity(IssueSeverity::Low),
+            None,
+            "an in-grace-period deprecation with a replacement is a migration task"
+        );
+    }
+
+    #[test]
+    fn rule_ids_are_unique_and_stable() {
+        let rules = [
+            RiskRule::OpenVulnerability,
+            RiskRule::SignatureRevoked,
+            RiskRule::ArtifactQuarantined,
+            RiskRule::ArtifactUnsigned,
+            RiskRule::DeprecatedNoReplacement,
+            RiskRule::DeprecatedWithReplacement,
+            RiskRule::InterfaceIncompatibility,
+        ];
+        let mut ids: Vec<&str> = rules.iter().map(|r| r.id()).collect();
+        ids.sort_unstable();
+        let count = ids.len();
+        ids.dedup();
+        assert_eq!(ids.len(), count, "rule ids must be unique");
+    }
+
+    // ── Combinator ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn zero_findings_is_reachable() {
+        let risk = EffectiveRisk::from_findings(&[]);
+        assert_eq!(risk.effective_severity, None);
+        assert_eq!(risk.counts.total(), 0);
+        assert!(!risk.meets_threshold(IssueSeverity::Low));
+    }
+
+    #[test]
+    fn many_highs_outrank_one_high() {
+        let one = EffectiveRisk::from_findings(&[finding(
+            RiskRule::SignatureRevoked,
+            IssueSeverity::High,
+            1,
+            &[0, 1],
+        )]);
+        let many = EffectiveRisk::from_findings(&[
+            finding(RiskRule::SignatureRevoked, IssueSeverity::High, 1, &[0, 1]),
+            finding(
+                RiskRule::ArtifactQuarantined,
+                IssueSeverity::High,
+                2,
+                &[0, 2],
+            ),
+        ]);
+        assert_eq!(one.effective_severity, many.effective_severity);
+        assert!(many > one, "a bare max() would rank these equal");
+    }
+
+    #[test]
+    fn one_critical_outranks_many_highs() {
+        let critical = EffectiveRisk::from_findings(&[finding(
+            RiskRule::OpenVulnerability,
+            IssueSeverity::Critical,
+            1,
+            &[0, 1],
+        )]);
+        let highs = EffectiveRisk::from_findings(
+            &(1..=40)
+                .map(|n| finding(RiskRule::SignatureRevoked, IssueSeverity::High, n, &[0, n]))
+                .collect::<Vec<_>>(),
+        );
+        assert!(
+            critical > highs,
+            "severity is ordinal; forty Highs must not sum into a Critical"
+        );
+    }
+
+    #[test]
+    fn threshold_gate_is_inclusive() {
+        let risk = EffectiveRisk::from_findings(&[finding(
+            RiskRule::SignatureRevoked,
+            IssueSeverity::High,
+            1,
+            &[0, 1],
+        )]);
+        assert!(risk.meets_threshold(IssueSeverity::Low));
+        assert!(risk.meets_threshold(IssueSeverity::High));
+        assert!(!risk.meets_threshold(IssueSeverity::Critical));
+    }
+
+    // ── Dedup ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn same_finding_via_two_paths_keeps_the_shortest() {
+        let short = finding(RiskRule::OpenVulnerability, IssueSeverity::High, 9, &[0, 9]);
+        let long = finding(
+            RiskRule::OpenVulnerability,
+            IssueSeverity::High,
+            9,
+            &[0, 1, 2, 9],
+        );
+
+        let from_long_first = dedup_findings(vec![long.clone(), short.clone()]);
+        let from_short_first = dedup_findings(vec![short.clone(), long]);
+
+        assert_eq!(from_long_first.len(), 1);
+        assert_eq!(from_long_first, from_short_first, "order must not matter");
+        assert_eq!(from_long_first[0].path, short.path);
+        assert_eq!(from_long_first[0].inherited_via_depth, 1);
+    }
+
+    #[test]
+    fn equal_length_paths_break_ties_lexicographically() {
+        let via_one = finding(
+            RiskRule::OpenVulnerability,
+            IssueSeverity::High,
+            9,
+            &[0, 1, 9],
+        );
+        let via_two = finding(
+            RiskRule::OpenVulnerability,
+            IssueSeverity::High,
+            9,
+            &[0, 2, 9],
+        );
+
+        let a = dedup_findings(vec![via_one.clone(), via_two.clone()]);
+        let b = dedup_findings(vec![via_two, via_one.clone()]);
+        assert_eq!(a, b);
+        assert_eq!(a[0].path, via_one.path, "lower path sorts first");
+    }
+
+    #[test]
+    fn distinct_conditions_on_one_contract_are_not_collapsed() {
+        let out = dedup_findings(vec![
+            finding(RiskRule::OpenVulnerability, IssueSeverity::High, 9, &[0, 9]),
+            finding(RiskRule::ArtifactUnsigned, IssueSeverity::Low, 9, &[0, 9]),
+        ]);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn same_rule_on_different_contracts_is_not_collapsed() {
+        let out = dedup_findings(vec![
+            finding(RiskRule::ArtifactUnsigned, IssueSeverity::Low, 8, &[0, 8]),
+            finding(RiskRule::ArtifactUnsigned, IssueSeverity::Low, 9, &[0, 9]),
+        ]);
+        assert_eq!(out.len(), 2);
+    }
+
+    // ── Ordering ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn findings_order_by_severity_then_rule_then_path() {
+        let mut findings = vec![
+            finding(RiskRule::ArtifactUnsigned, IssueSeverity::Low, 3, &[0, 3]),
+            finding(
+                RiskRule::OpenVulnerability,
+                IssueSeverity::Critical,
+                1,
+                &[0, 1],
+            ),
+            finding(RiskRule::SignatureRevoked, IssueSeverity::High, 2, &[0, 2]),
+            finding(
+                RiskRule::ArtifactQuarantined,
+                IssueSeverity::High,
+                4,
+                &[0, 4],
+            ),
+        ];
+        sort_findings(&mut findings);
+
+        let ids: Vec<&str> = findings.iter().map(|f| f.rule_id.as_str()).collect();
+        assert_eq!(
+            ids,
+            [
+                "open_vulnerability",   // Critical
+                "artifact_quarantined", // High, rule id sorts before signature_revoked
+                "signature_revoked",    // High
+                "artifact_unsigned",    // Low
+            ]
+        );
+    }
+
+    #[test]
+    fn ordering_is_stable_across_input_permutations() {
+        let base = vec![
+            finding(RiskRule::SignatureRevoked, IssueSeverity::High, 2, &[0, 2]),
+            finding(RiskRule::SignatureRevoked, IssueSeverity::High, 1, &[0, 1]),
+            finding(RiskRule::ArtifactUnsigned, IssueSeverity::Low, 3, &[0, 3]),
+        ];
+        let mut forward = base.clone();
+        let mut reverse: Vec<Finding> = base.into_iter().rev().collect();
+        sort_findings(&mut forward);
+        sort_findings(&mut reverse);
+        assert_eq!(forward, reverse);
+    }
+
+    // ── Cycles ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn cycle_segment_names_the_loop_not_the_lead_in() {
+        // 0 -> 1 -> 2 -> 3, and 3 depends on 1 again.
+        let path = [uuid(0), uuid(1), uuid(2), uuid(3)];
+        let segment = cycle_segment(&path, uuid(1)).expect("cycle");
+        assert_eq!(segment, vec![uuid(1), uuid(2), uuid(3), uuid(1)]);
+    }
+
+    #[test]
+    fn self_loop_is_a_cycle_of_one() {
+        let segment = cycle_segment(&[uuid(0), uuid(5)], uuid(5)).expect("cycle");
+        assert_eq!(segment, vec![uuid(5), uuid(5)]);
+    }
+
+    #[test]
+    fn no_cycle_when_the_node_is_not_on_the_path() {
+        assert_eq!(cycle_segment(&[uuid(0), uuid(1)], uuid(7)), None);
+    }
+
+    // ── Version conflicts ───────────────────────────────────────────────────
+
+    #[test]
+    fn disjoint_major_ranges_conflict() {
+        let published = vec!["1.0.0".to_string(), "2.0.0".to_string()];
+        assert!(constraints_conflict("^1.0.0", "^2.0.0", &published));
+    }
+
+    #[test]
+    fn overlapping_ranges_do_not_conflict() {
+        let published = vec!["1.2.0".to_string()];
+        assert!(!constraints_conflict("^1.0.0", "~1.2.0", &published));
+    }
+
+    #[test]
+    fn wildcard_never_conflicts() {
+        // "*" does not parse as a constraint, and treating a parser gap as a
+        // dependency problem would flood the report with false conflicts.
+        let published = vec!["1.0.0".to_string()];
+        assert!(!constraints_conflict("*", "^2.0.0", &published));
+        assert!(!constraints_conflict("*", "*", &published));
+    }
+
+    #[test]
+    fn no_published_versions_means_no_provable_conflict() {
+        assert!(!constraints_conflict("^1.0.0", "^2.0.0", &[]));
+    }
+
+    #[test]
+    fn unparseable_published_versions_are_skipped_not_matched() {
+        let published = vec!["not-a-version".to_string()];
+        assert!(constraints_conflict("^1.0.0", "^2.0.0", &published));
+    }
+
+    // ── Edge vocabulary ─────────────────────────────────────────────────────
+
+    #[test]
+    fn only_resolved_edges_are_traversed() {
+        assert!(EdgeState::Resolved.is_traversable());
+        assert!(!EdgeState::Unresolved.is_traversable());
+        assert!(!EdgeState::NetworkMismatch.is_traversable());
+    }
+
+    #[test]
+    fn edge_vocabulary_serializes_as_the_database_spells_it() {
+        assert_eq!(
+            serde_json::to_string(&EdgeSource::Telemetry).unwrap(),
+            "\"telemetry\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EdgeState::NetworkMismatch).unwrap(),
+            "\"network_mismatch\""
+        );
+    }
+}

--- a/backend/shared/src/interface_fingerprint.rs
+++ b/backend/shared/src/interface_fingerprint.rs
@@ -14,7 +14,7 @@
 
 use crate::contract_spec::{
     ScSpecEntry, ScSpecEventDataFormat, ScSpecEventParamLocationV0, ScSpecTypeDef,
-    ScSpecUdtUnionCaseV0,
+    ScSpecUdtUnionCaseV0, SpecParseError,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -269,6 +269,185 @@ pub fn fingerprint_spec(entries: &[ScSpecEntry]) -> InterfaceFingerprint {
         types,
         events,
         errors,
+    }
+}
+
+/// Why a WASM artifact yielded no interface fingerprint.
+///
+/// None of these are errors in the "the caller did something wrong" sense: a
+/// contract may legitimately ship without a spec section. Callers persisting an
+/// interface id should record "unknown", not reject the artifact.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FingerprintWasmError {
+    /// The module embeds no [`crate::wasm::CONTRACT_SPEC_SECTION`] custom section.
+    NoSpecSection,
+    /// The section is present but is not a well-formed spec.
+    MalformedSpec(SpecParseError),
+    /// The section parsed but declares nothing. Fingerprinting an empty spec
+    /// would give every such contract the same id and make "the interfaces
+    /// match" a meaningless statement, so it is reported instead.
+    EmptySpec,
+}
+
+impl std::fmt::Display for FingerprintWasmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoSpecSection => write!(
+                f,
+                "no {} section: this module embeds no Soroban contract spec",
+                crate::wasm::CONTRACT_SPEC_SECTION
+            ),
+            Self::MalformedSpec(err) => write!(
+                f,
+                "malformed {} section: {err}",
+                crate::wasm::CONTRACT_SPEC_SECTION
+            ),
+            Self::EmptySpec => write!(
+                f,
+                "empty {} section: no interface to identify",
+                crate::wasm::CONTRACT_SPEC_SECTION
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FingerprintWasmError {}
+
+/// Derive an [`InterfaceFingerprint`] straight from WASM bytes.
+///
+/// Composes [`crate::wasm::extract_contract_spec_bytes`],
+/// [`crate::contract_spec::parse_contract_spec`], and [`fingerprint_spec`].
+/// Every step is pure and offline — **no WASM is executed**; the module is only
+/// walked for custom sections, and the section is read by a dependency-free XDR
+/// reader. That matters because artifacts are untrusted input.
+pub fn fingerprint_wasm(wasm_bytes: &[u8]) -> Result<InterfaceFingerprint, FingerprintWasmError> {
+    let spec_bytes = crate::wasm::extract_contract_spec_bytes(wasm_bytes)
+        .ok_or(FingerprintWasmError::NoSpecSection)?;
+
+    let entries = crate::contract_spec::parse_contract_spec(&spec_bytes)
+        .map_err(FingerprintWasmError::MalformedSpec)?;
+
+    if entries.is_empty() {
+        return Err(FingerprintWasmError::EmptySpec);
+    }
+
+    Ok(fingerprint_spec(&entries))
+}
+
+#[cfg(test)]
+mod wasm_tests {
+    use super::*;
+
+    /// Minimal valid WASM module header, no custom sections.
+    const EMPTY_MODULE: &[u8] = &[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+
+    #[test]
+    fn module_without_spec_section_has_no_fingerprint() {
+        assert!(matches!(
+            fingerprint_wasm(EMPTY_MODULE),
+            Err(FingerprintWasmError::NoSpecSection)
+        ));
+    }
+
+    #[test]
+    fn garbage_bytes_never_panic() {
+        for bytes in [b"".as_slice(), b"not wasm".as_slice(), &[0xff; 64]] {
+            assert!(fingerprint_wasm(bytes).is_err());
+        }
+    }
+
+    #[test]
+    fn spec_section_is_fingerprinted_with_the_published_algorithm() {
+        let wasm = wasm_with_spec_section(&function_entry_xdr("transfer"));
+        let fp = fingerprint_wasm(&wasm).expect("spec section should fingerprint");
+        assert_eq!(fp.algorithm, ALGORITHM);
+        assert_eq!(fp.interface_id.len(), 64, "expected hex sha256");
+        assert_eq!(fp.functions.len(), 1);
+        assert_eq!(fp.functions[0].name, "transfer");
+    }
+
+    #[test]
+    fn different_interfaces_get_different_ids() {
+        let a = fingerprint_wasm(&wasm_with_spec_section(&function_entry_xdr("transfer"))).unwrap();
+        let b = fingerprint_wasm(&wasm_with_spec_section(&function_entry_xdr("burn"))).unwrap();
+        assert_ne!(a.interface_id, b.interface_id);
+    }
+
+    #[test]
+    fn identical_interfaces_get_identical_ids() {
+        let a = fingerprint_wasm(&wasm_with_spec_section(&function_entry_xdr("transfer"))).unwrap();
+        let b = fingerprint_wasm(&wasm_with_spec_section(&function_entry_xdr("transfer"))).unwrap();
+        assert_eq!(a.interface_id, b.interface_id);
+    }
+
+    #[test]
+    fn empty_spec_section_is_not_an_interface() {
+        let wasm = wasm_with_spec_section(&[]);
+        assert!(matches!(
+            fingerprint_wasm(&wasm),
+            Err(FingerprintWasmError::EmptySpec)
+        ));
+    }
+
+    #[test]
+    fn malformed_spec_section_is_reported_not_panicked() {
+        // A valid FunctionV0 discriminant followed by a truncated body.
+        let wasm = wasm_with_spec_section(&[0, 0, 0, 0]);
+        assert!(matches!(
+            fingerprint_wasm(&wasm),
+            Err(FingerprintWasmError::MalformedSpec(_))
+        ));
+    }
+
+    // ── Fixtures ────────────────────────────────────────────────────────────
+
+    /// XDR for `ScSpecEntry::FunctionV0` with no doc, no inputs, no outputs.
+    /// Hand-encoded so these tests stay free of `stellar-xdr`, which this crate
+    /// deliberately does not depend on.
+    fn function_entry_xdr(name: &str) -> Vec<u8> {
+        let mut out = 0u32.to_be_bytes().to_vec(); // discriminant: FunctionV0
+        out.extend_from_slice(&xdr_string("")); // doc
+        out.extend_from_slice(&xdr_string(name)); // name
+        out.extend_from_slice(&0u32.to_be_bytes()); // inputs: empty vec
+        out.extend_from_slice(&0u32.to_be_bytes()); // outputs: empty vec
+        out
+    }
+
+    /// XDR variable-length string: 4-byte big-endian length, bytes, zero pad to 4.
+    fn xdr_string(value: &str) -> Vec<u8> {
+        let bytes = value.as_bytes();
+        let mut out = (bytes.len() as u32).to_be_bytes().to_vec();
+        out.extend_from_slice(bytes);
+        out.resize(out.len() + (4 - bytes.len() % 4) % 4, 0);
+        out
+    }
+
+    fn wasm_with_spec_section(payload: &[u8]) -> Vec<u8> {
+        let name = crate::wasm::CONTRACT_SPEC_SECTION.as_bytes();
+        let mut body = leb128(name.len() as u64);
+        body.extend_from_slice(name);
+        body.extend_from_slice(payload);
+
+        let mut out = EMPTY_MODULE.to_vec();
+        out.push(0); // custom section id
+        out.extend_from_slice(&leb128(body.len() as u64));
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn leb128(mut value: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            out.push(byte);
+            if value == 0 {
+                return out;
+            }
+        }
     }
 }
 

--- a/backend/shared/src/lib.rs
+++ b/backend/shared/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod abi;
 pub mod contract_spec;
+pub mod dependency_graph;
 pub mod error;
 pub mod interface_fingerprint;
 pub mod logging;

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -4403,8 +4403,12 @@ pub enum ScanStatus {
 }
 
 /// Security issue severity
+// Copy/Eq/Ord/Hash so severities can be compared, counted, and used as map keys
+// by the dependency risk combinator (Issue #1147) without cloning. The variant
+// order below IS the severity order; do not reorder it.
 #[derive(
-    Debug, Clone, Serialize, Deserialize, sqlx::Type, utoipa::ToSchema, PartialEq, PartialOrd,
+    Debug, Clone, Copy, Serialize, Deserialize, sqlx::Type, utoipa::ToSchema, PartialEq, Eq,
+    PartialOrd, Ord, Hash,
 )]
 #[sqlx(type_name = "issue_severity_type", rename_all = "lowercase")]
 pub enum IssueSeverity {

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -3649,7 +3649,7 @@ pub struct CollaborativeReviewDetails {
 // ADVANCED CONTRACT DEPENDENCIES (issue #417)
 // ═══════════════════════════════════════════════════════════════════════════
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DependencyNode {
     pub contract_id: String,
     pub resolved_id: Option<Uuid>,
@@ -3661,7 +3661,7 @@ pub struct DependencyNode {
     pub visualization_hints: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DependencyResponse {
     pub root: DependencyNode,
     pub total_dependencies: usize,

--- a/backend/shared/src/models.rs
+++ b/backend/shared/src/models.rs
@@ -4407,8 +4407,18 @@ pub enum ScanStatus {
 // by the dependency risk combinator (Issue #1147) without cloning. The variant
 // order below IS the severity order; do not reorder it.
 #[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, sqlx::Type, utoipa::ToSchema, PartialEq, Eq,
-    PartialOrd, Ord, Hash,
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    sqlx::Type,
+    utoipa::ToSchema,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
 )]
 #[sqlx(type_name = "issue_severity_type", rename_all = "lowercase")]
 pub enum IssueSeverity {

--- a/backend/shared/src/snapshot.rs
+++ b/backend/shared/src/snapshot.rs
@@ -24,7 +24,28 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 /// Bumped when the payload shape changes in a way that alters canonical bytes.
+/// Schema emitted for a snapshot with no dependency graph. Still the default,
+/// so an existing consumer sees byte-identical output for the same contract.
 pub const SNAPSHOT_SCHEMA_VERSION: &str = "1.0";
+
+/// Schema emitted **only** for a snapshot that carries `dependency_graph`
+/// (Issue #1147).
+///
+/// Bumping is not optional here. `SnapshotPayload` has no
+/// `deny_unknown_fields`, so an old CLI handed a graph-bearing "1.0" snapshot
+/// would silently drop the field, recanonicalize without it, and report
+/// **"signature invalid"** -- telling the operator their snapshot was tampered
+/// with, which is the worst possible message from a correctness-critical tool.
+/// With a distinct version it returns `UnsupportedSchema("1.1")` instead: true,
+/// actionable, and impossible to mistake for tampering.
+///
+/// Gating the field behind a query parameter does not help, because the file
+/// that reaches the old CLI is exactly the gated one.
+pub const SNAPSHOT_SCHEMA_VERSION_WITH_GRAPH: &str = "1.1";
+
+/// Every schema version this build can verify.
+pub const SUPPORTED_SCHEMA_VERSIONS: &[&str] =
+    &[SNAPSHOT_SCHEMA_VERSION, SNAPSHOT_SCHEMA_VERSION_WITH_GRAPH];
 
 pub const SNAPSHOT_ALGORITHM: &str = "ed25519";
 
@@ -58,6 +79,25 @@ pub struct SnapshotPayload {
     /// `replacement_contract_id` transitively. Empty when nothing supersedes
     /// this contract.
     pub lineage: Vec<LineageLink>,
+    /// Dependency graph and transitive risk report (Issue #1147), present only
+    /// when explicitly requested. Its presence is what makes the payload
+    /// schema 1.1; see [`SNAPSHOT_SCHEMA_VERSION_WITH_GRAPH`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dependency_graph: Option<Value>,
+}
+
+impl SnapshotPayload {
+    /// The schema version this payload must declare.
+    ///
+    /// Derived from the content rather than passed in, so a caller cannot
+    /// produce a graph-bearing payload that claims to be 1.0.
+    pub fn required_schema_version(&self) -> &'static str {
+        if self.dependency_graph.is_some() {
+            SNAPSHOT_SCHEMA_VERSION_WITH_GRAPH
+        } else {
+            SNAPSHOT_SCHEMA_VERSION
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -229,7 +269,9 @@ pub fn verify_snapshot(
     expected_fingerprint: Option<&str>,
     max_age_days: Option<i64>,
 ) -> Result<(), SnapshotError> {
-    if snapshot.payload.schema_version != SNAPSHOT_SCHEMA_VERSION {
+    // A known-versions set, not equality against one constant. Equality would
+    // make every future schema indistinguishable from a corrupt file.
+    if !SUPPORTED_SCHEMA_VERSIONS.contains(&snapshot.payload.schema_version.as_str()) {
         return Err(SnapshotError::UnsupportedSchema(
             snapshot.payload.schema_version.clone(),
         ));
@@ -244,10 +286,9 @@ pub fn verify_snapshot(
     let key_bytes = BASE64
         .decode(&snapshot.signature.public_key)
         .map_err(|e| SnapshotError::MalformedKey(e.to_string()))?;
-    let key_array: [u8; 32] = key_bytes
-        .as_slice()
-        .try_into()
-        .map_err(|_| SnapshotError::MalformedKey(format!("expected 32 bytes, got {}", key_bytes.len())))?;
+    let key_array: [u8; 32] = key_bytes.as_slice().try_into().map_err(|_| {
+        SnapshotError::MalformedKey(format!("expected 32 bytes, got {}", key_bytes.len()))
+    })?;
     let verifying = VerifyingKey::from_bytes(&key_array)
         .map_err(|e| SnapshotError::MalformedKey(e.to_string()))?;
 
@@ -322,6 +363,7 @@ mod tests {
             },
             dependency_scan: Some(serde_json::json!({"findings": [], "scanned": true})),
             deprecation: None,
+            dependency_graph: None,
             lineage: vec![LineageLink {
                 contract_id: "CBBBB".into(),
                 name: Some("token-v2".into()),
@@ -474,6 +516,79 @@ mod tests {
     }
 
     #[test]
+    fn graph_bearing_payload_declares_schema_1_1() {
+        let mut payload = sample_payload();
+        assert_eq!(payload.required_schema_version(), SNAPSHOT_SCHEMA_VERSION);
+
+        payload.dependency_graph = Some(serde_json::json!({"total_dependencies": 2}));
+        assert_eq!(
+            payload.required_schema_version(),
+            SNAPSHOT_SCHEMA_VERSION_WITH_GRAPH
+        );
+    }
+
+    #[test]
+    fn a_graph_bearing_snapshot_verifies_under_1_1() {
+        let key = test_key(1);
+        let mut payload = sample_payload();
+        payload.dependency_graph = Some(serde_json::json!({"total_dependencies": 2}));
+        payload.schema_version = payload.required_schema_version().to_string();
+
+        let snapshot = sign_snapshot(payload, &key).unwrap();
+        assert_eq!(snapshot.payload.schema_version, "1.1");
+        assert!(verify_snapshot(&snapshot, None, None).is_ok());
+    }
+
+    #[test]
+    fn a_graphless_snapshot_still_verifies_under_1_0() {
+        // The default must not move: an existing consumer sees the same bytes
+        // for the same contract as before Issue #1147.
+        let key = test_key(1);
+        let snapshot = sign_snapshot(sample_payload(), &key).unwrap();
+        assert_eq!(snapshot.payload.schema_version, "1.0");
+        assert!(verify_snapshot(&snapshot, None, None).is_ok());
+    }
+
+    #[test]
+    fn dropping_the_graph_field_breaks_the_signature() {
+        // This is exactly the failure the version bump exists to prevent: an old
+        // reader that ignores `dependency_graph` recanonicalizes without it and
+        // sees an invalid signature. Asserting it here documents *why* a
+        // graph-bearing snapshot must not claim to be 1.0.
+        let key = test_key(1);
+        let mut payload = sample_payload();
+        payload.dependency_graph = Some(serde_json::json!({"total_dependencies": 2}));
+        payload.schema_version = payload.required_schema_version().to_string();
+        let mut snapshot = sign_snapshot(payload, &key).unwrap();
+
+        snapshot.payload.dependency_graph = None;
+        assert!(
+            matches!(
+                verify_snapshot(&snapshot, None, None),
+                Err(SnapshotError::SignatureMismatch)
+            ),
+            "silently losing the field must not look like a valid snapshot"
+        );
+    }
+
+    #[test]
+    fn every_supported_version_is_accepted() {
+        for version in SUPPORTED_SCHEMA_VERSIONS {
+            let key = test_key(1);
+            let mut payload = sample_payload();
+            if *version == SNAPSHOT_SCHEMA_VERSION_WITH_GRAPH {
+                payload.dependency_graph = Some(serde_json::json!({}));
+            }
+            payload.schema_version = (*version).to_string();
+            let snapshot = sign_snapshot(payload, &key).unwrap();
+            assert!(
+                verify_snapshot(&snapshot, None, None).is_ok(),
+                "{version} should verify"
+            );
+        }
+    }
+
+    #[test]
     fn schema_version_mismatch_is_rejected() {
         let key = test_key(1);
         let mut snapshot = sign_snapshot(sample_payload(), &key).unwrap();
@@ -523,6 +638,9 @@ mod tests {
         let contract = text.find("\"contract\"").unwrap();
         let exported = text.find("\"exported_at\"").unwrap();
         let schema = text.find("\"schema_version\"").unwrap();
-        assert!(contract < exported && exported < schema, "keys must be sorted: {text}");
+        assert!(
+            contract < exported && exported < schema,
+            "keys must be sorted: {text}"
+        );
     }
 }

--- a/backend/verifier/src/deps.rs
+++ b/backend/verifier/src/deps.rs
@@ -69,13 +69,19 @@ pub fn resolve(graph: &HashMap<String, Vec<String>>) -> Result<Vec<String>, Depe
         }
     }
 
-    // Build in-degree map.
-    let mut in_degree: HashMap<&str, usize> = graph.keys().map(|k| (k.as_str(), 0)).collect();
-    for deps in graph.values() {
-        for dep in deps {
-            *in_degree.entry(dep.as_str()).or_insert(0) += 1;
-        }
-    }
+    // Build in-degree map. Edges point dependency -> dependent, so a node's
+    // in-degree is the number of *distinct* dependencies it declares. Seeding it
+    // from the dependent count instead would be inconsistent with the decrement
+    // below, which walks dependents, and reports acyclic graphs as circular.
+    // Distinct matters: the decrement uses `any`, so a dependency listed twice
+    // would otherwise never drain to zero.
+    let mut in_degree: HashMap<&str, usize> = graph
+        .iter()
+        .map(|(k, deps)| {
+            let distinct: HashSet<&str> = deps.iter().map(|d| d.as_str()).collect();
+            (k.as_str(), distinct.len())
+        })
+        .collect();
 
     // Enqueue zero-in-degree nodes (sorted for deterministic output).
     let mut queue: VecDeque<&str> = {

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -266,6 +266,48 @@ pub async fn access_token_for_requests(api_url: &str) -> Result<Option<String>> 
     Ok(Some(session.access_token))
 }
 
+/// Read-only view of the stored session, for diagnostics such as
+/// `soroban-registry publisher doctor`.
+///
+/// Deliberately does **not** refresh the access token the way
+/// [`access_token_for_requests`] does: a diagnostic must report the current
+/// state, not mutate it, and a refresh would hide exactly the expiry problem
+/// the operator is trying to see.
+#[derive(Debug, Clone)]
+pub struct SessionDiagnostics {
+    pub method: String,
+    pub identity: String,
+    pub token_present: bool,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub expired: bool,
+    /// A Stellar secret seed is held for this session, so the CLI can sign
+    /// publish payloads and re-issue tokens without an interactive login.
+    pub signing_secret_present: bool,
+    pub legacy_storage: bool,
+}
+
+/// Load the active session for reporting. `Ok(None)` means no session is stored.
+pub async fn session_diagnostics() -> Result<Option<SessionDiagnostics>> {
+    let Some(session) = load_active_session().await? else {
+        return Ok(None);
+    };
+
+    let expired = session
+        .record
+        .access_token_expires_at
+        .is_some_and(|expires_at| Utc::now() >= expires_at);
+
+    Ok(Some(SessionDiagnostics {
+        method: session.record.method.to_string(),
+        identity: session.record.identity.clone(),
+        token_present: !session.access_token.trim().is_empty(),
+        expires_at: session.record.access_token_expires_at,
+        expired,
+        signing_secret_present: session.refresh_secret.is_some(),
+        legacy_storage: session.legacy,
+    }))
+}
+
 async fn refresh_stellar_session(api_url: &str, session: &mut LoadedSession) -> Result<()> {
     let refresh_secret = session.refresh_secret.clone().ok_or_else(|| {
         anyhow::anyhow!("Missing refresh secret. Run `soroban-registry auth login` again.")

--- a/cli/src/contract_dependency_graph.rs
+++ b/cli/src/contract_dependency_graph.rs
@@ -1,0 +1,445 @@
+//! `soroban-registry contract dependencies|dependents|dependency-risk` (Issue #1147).
+//!
+//! Thin, faithful clients for the four dependency endpoints. Two conventions
+//! are load-bearing:
+//!
+//! - **`--json` prints the API response unmodified.** Reshaping it here would
+//!   mean two schemas to keep in step, and the documented one is the API's.
+//!   Scripts get exactly what `docs/dependency-graph.md` describes.
+//! - **`--fail-on` compares against `overall_risk.effective_severity`,** which
+//!   the server computes. Recomputing a severity client-side would let the CLI
+//!   and the registry disagree about whether a deploy should be blocked.
+//!
+//! The address is positional, matching the other 18 `contract` subcommands.
+
+use crate::net::RequestBuilderExt;
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde_json::Value;
+
+/// Severity ordering for `--fail-on`. Deliberately the same four levels as the
+/// server's `IssueSeverity`, parsed from the same lowercase spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Severity {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl Severity {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_lowercase().as_str() {
+            "low" => Ok(Self::Low),
+            "medium" => Ok(Self::Medium),
+            "high" => Ok(Self::High),
+            "critical" => Ok(Self::Critical),
+            other => anyhow::bail!(
+                "invalid severity '{other}'. Expected one of: low, medium, high, critical"
+            ),
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Low => "LOW",
+            Self::Medium => "MEDIUM",
+            Self::High => "HIGH",
+            Self::Critical => "CRITICAL",
+        }
+    }
+}
+
+/// Query options shared by the traversal commands.
+#[derive(Debug, Default, Clone)]
+pub struct GraphOptions {
+    pub network: Option<String>,
+    pub depth: Option<u32>,
+    pub transitive: bool,
+    pub include_telemetry: bool,
+    pub json: bool,
+}
+
+/// `contract dependencies <ADDRESS>`
+pub async fn dependencies(api_url: &str, address: &str, opts: &GraphOptions) -> Result<()> {
+    let value = fetch(api_url, address, "dependencies", opts).await?;
+    if opts.json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+    print_tree(&value, "Dependencies");
+    Ok(())
+}
+
+/// `contract dependents <ADDRESS>`
+pub async fn dependents(api_url: &str, address: &str, opts: &GraphOptions) -> Result<()> {
+    let value = fetch(api_url, address, "dependents", opts).await?;
+    if opts.json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+    print_tree(&value, "Dependents");
+    Ok(())
+}
+
+/// `contract dependency-risk <ADDRESS> [--fail-on <severity>]`
+///
+/// Returns `Ok(true)` when the report meets or exceeds `fail_on`. Exiting is
+/// left to the caller so this stays testable without a process boundary.
+pub async fn risk(
+    api_url: &str,
+    address: &str,
+    opts: &GraphOptions,
+    fail_on: Option<Severity>,
+) -> Result<bool> {
+    let value = fetch(api_url, address, "dependency-risk", opts).await?;
+
+    if opts.json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        print_risk(&value);
+    }
+
+    let effective = value
+        .get("overall_risk")
+        .and_then(|r| r.get("effective_severity"))
+        .and_then(Value::as_str)
+        .map(Severity::parse)
+        .transpose()?;
+
+    let breached = match (fail_on, effective) {
+        (Some(threshold), Some(actual)) => actual >= threshold,
+        // No findings at all can never breach a threshold. This is only
+        // reachable because diagnostics are kept out of `findings`.
+        (Some(_), None) => false,
+        (None, _) => false,
+    };
+
+    if breached && !opts.json {
+        let threshold = fail_on.expect("breached implies a threshold");
+        eprintln!(
+            "\n  {} Overall risk {} meets or exceeds --fail-on {}. Exiting with code 1.",
+            "!".red().bold(),
+            effective
+                .expect("breached implies a severity")
+                .label()
+                .red()
+                .bold(),
+            threshold.label().yellow()
+        );
+    }
+
+    Ok(breached)
+}
+
+async fn fetch(api_url: &str, address: &str, endpoint: &str, opts: &GraphOptions) -> Result<Value> {
+    let mut url = format!(
+        "{}/api/contracts/{}/{}",
+        api_url.trim_end_matches('/'),
+        address,
+        endpoint
+    );
+
+    let mut params: Vec<String> = Vec::new();
+    if let Some(network) = &opts.network {
+        params.push(format!("network={network}"));
+    }
+    if let Some(depth) = opts.depth {
+        params.push(format!("depth={depth}"));
+    }
+    params.push(format!("transitive={}", opts.transitive));
+    if opts.include_telemetry {
+        params.push("include_telemetry=true".to_string());
+    }
+    if !params.is_empty() {
+        url.push('?');
+        url.push_str(&params.join("&"));
+    }
+
+    log::debug!("GET {url}");
+    let response = crate::net::client()
+        .get(&url)
+        .send_with_retry()
+        .await
+        .context("Failed to reach the registry API. Is the registry running?")?;
+
+    let status = response.status();
+    let value: Value = response.json().await.unwrap_or(Value::Null);
+
+    if status.is_success() {
+        return Ok(value);
+    }
+
+    // 409 means the address exists on more than one network. Surfacing the
+    // candidates is the whole point of that status, so they are printed rather
+    // than collapsed into a generic failure.
+    if status.as_u16() == 409 {
+        let candidates = value
+            .get("details")
+            .and_then(|d| d.get("candidates"))
+            .and_then(Value::as_array)
+            .map(|rows| {
+                rows.iter()
+                    .filter_map(|row| row.get("network").and_then(Value::as_str))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .unwrap_or_default();
+        anyhow::bail!(
+            "'{address}' is registered on more than one network ({candidates}). Re-run with --network <NETWORK>."
+        );
+    }
+
+    let message = value
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("no message");
+    anyhow::bail!("request failed ({status}): {message}");
+}
+
+// ── Human-readable output ───────────────────────────────────────────────────
+
+fn print_tree(value: &Value, title: &str) {
+    let root = value.get("root");
+    println!("\n{}", title.bold().cyan());
+    println!("{}", "=".repeat(72).cyan());
+
+    if let Some(root) = root {
+        println!(
+            "{:<14}{}",
+            "Contract:".bold(),
+            root.get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+        );
+        println!(
+            "{:<14}{}",
+            "Address:".bold(),
+            root.get("contract_id")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .bright_black()
+        );
+    }
+
+    println!(
+        "{:<14}{}",
+        "Total:".bold(),
+        value
+            .get("total_dependencies")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+    );
+    println!(
+        "{:<14}{}",
+        "Max depth:".bold(),
+        value.get("max_depth").and_then(Value::as_u64).unwrap_or(0)
+    );
+
+    if value
+        .get("has_circular")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        println!("{:<14}{}", "Cycles:".bold(), "detected".yellow());
+    }
+
+    println!();
+    if let Some(children) = root
+        .and_then(|r| r.get("dependencies"))
+        .and_then(Value::as_array)
+    {
+        if children.is_empty() {
+            println!("  {}", "none".bright_black());
+        }
+        for child in children {
+            print_node(child, 1);
+        }
+    }
+
+    print_diagnostics(
+        root.and_then(|r| r.get("visualization_hints"))
+            .and_then(|h| h.get("diagnostics")),
+    );
+    println!();
+}
+
+fn print_node(node: &Value, depth: usize) {
+    let indent = "  ".repeat(depth);
+    let id = node
+        .get("contract_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let name = node.get("name").and_then(Value::as_str);
+    let status = node.get("status").and_then(Value::as_str).unwrap_or("");
+    let circular = node
+        .get("is_circular")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let label = match name {
+        Some(name) => format!("{name} ({id})"),
+        None => id.to_string(),
+    };
+    let marker = if circular {
+        " [cycle]".yellow().to_string()
+    } else {
+        String::new()
+    };
+
+    println!("{indent}- {label} {}{marker}", status.bright_black());
+
+    if let Some(children) = node.get("dependencies").and_then(Value::as_array) {
+        for child in children {
+            print_node(child, depth + 1);
+        }
+    }
+}
+
+fn print_risk(value: &Value) {
+    println!("\n{}", "Dependency Risk".bold().cyan());
+    println!("{}", "=".repeat(72).cyan());
+
+    let overall = severity_of(value.get("overall_risk"));
+    let direct = severity_of(value.get("direct_risk"));
+    println!("{:<16}{}", "Overall:".bold(), colorize(overall));
+    println!("{:<16}{}", "Direct only:".bold(), colorize(direct));
+    println!(
+        "{:<16}{}",
+        "Dependencies:".bold(),
+        value
+            .get("total_dependencies")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+    );
+    if value
+        .get("truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        println!(
+            "{:<16}{}",
+            "Note:".bold(),
+            "graph was truncated; findings may be incomplete".yellow()
+        );
+    }
+
+    print_findings("Direct findings", value.get("direct_findings"));
+    print_findings("Inherited findings", value.get("inherited_findings"));
+    print_diagnostics(value.get("diagnostics"));
+    println!();
+}
+
+fn print_findings(title: &str, findings: Option<&Value>) {
+    let Some(findings) = findings.and_then(Value::as_array) else {
+        return;
+    };
+    println!("\n{}", title.bold());
+    if findings.is_empty() {
+        println!("  {}", "none".green());
+        return;
+    }
+    for finding in findings {
+        let severity = finding
+            .get("severity")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let rule = finding
+            .get("rule_id")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let depth = finding
+            .get("inherited_via_depth")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let detail = finding.get("detail").and_then(Value::as_str).unwrap_or("");
+        println!(
+            "  [{}] {} (depth {depth}) {}",
+            colorize(Some(severity.to_string())),
+            rule,
+            detail.bright_black()
+        );
+        // The path is the reason this feature exists: it is not enough to say a
+        // dependency is vulnerable, the operator has to know which chain reaches
+        // it in order to fix it.
+        if let Some(path) = finding.get("path").and_then(Value::as_array) {
+            if path.len() > 1 {
+                let hops: Vec<&str> = path.iter().filter_map(Value::as_str).collect();
+                println!("      via {}", hops.join(" -> ").bright_black());
+            }
+        }
+    }
+}
+
+fn print_diagnostics(diagnostics: Option<&Value>) {
+    let Some(diagnostics) = diagnostics.and_then(Value::as_array) else {
+        return;
+    };
+    if diagnostics.is_empty() {
+        return;
+    }
+    println!("\n{}", "Diagnostics".bold());
+    for diagnostic in diagnostics {
+        let kind = diagnostic
+            .get("kind")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let detail = diagnostic
+            .get("detail")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        println!("  {} {}", kind.yellow(), detail.bright_black());
+        // Two diagnostics of the same kind differ only by their path -- two
+        // distinct cycles through the same graph, say -- so printing the detail
+        // alone makes genuinely different findings look like duplicates.
+        if let Some(path) = diagnostic.get("path").and_then(Value::as_array) {
+            if path.len() > 1 {
+                let hops: Vec<&str> = path.iter().filter_map(Value::as_str).collect();
+                println!("      {}", hops.join(" -> ").bright_black());
+            }
+        }
+    }
+}
+
+fn severity_of(risk: Option<&Value>) -> Option<String> {
+    risk?
+        .get("effective_severity")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn colorize(severity: Option<String>) -> String {
+    match severity.as_deref() {
+        Some("Critical") | Some("critical") => "CRITICAL".red().bold().to_string(),
+        Some("High") | Some("high") => "HIGH".red().to_string(),
+        Some("Medium") | Some("medium") => "MEDIUM".yellow().to_string(),
+        Some("Low") | Some("low") => "LOW".to_string(),
+        _ => "none".green().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_parses_case_insensitively() {
+        assert_eq!(Severity::parse("HIGH").unwrap(), Severity::High);
+        assert_eq!(Severity::parse(" critical ").unwrap(), Severity::Critical);
+        assert!(Severity::parse("catastrophic").is_err());
+    }
+
+    #[test]
+    fn severity_orders_low_to_critical() {
+        assert!(Severity::Low < Severity::Medium);
+        assert!(Severity::Medium < Severity::High);
+        assert!(Severity::High < Severity::Critical);
+    }
+
+    #[test]
+    fn colorize_reports_no_severity_as_none() {
+        // A report with zero findings has no effective severity. It must not be
+        // rendered as "LOW", which would imply a finding exists.
+        assert!(colorize(None).contains("none"));
+    }
+}

--- a/cli/src/contract_register.rs
+++ b/cli/src/contract_register.rs
@@ -2,6 +2,8 @@ use crate::io_utils::compute_sha256_streaming;
 use crate::net::RequestBuilderExt;
 use crate::wizard::{confirm, prompt, prompt_with_validation};
 use anyhow::{Context, Result};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
 use colored::Colorize;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -18,6 +20,14 @@ use stellar_xdr::curr::{
 
 const MAX_BATCH_SIZE: usize = 50;
 const REGISTER_TIMEOUT_SECS: u64 = 60;
+
+/// Largest WASM file the CLI will inline as `wasm_artifact_base64`.
+///
+/// Base64 inflates by 4/3, so 3 MiB encodes to ~4 MiB and stays under the API's
+/// default 5 MB body limit (`MAX_PAYLOAD_SIZE_MB`). A whole batch is resolved
+/// before anything is sent, so this also bounds peak CLI memory at
+/// `MAX_BATCH_SIZE` x this value.
+const MAX_INLINE_ARTIFACT_BYTES: u64 = 3 * 1024 * 1024;
 
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
@@ -370,6 +380,7 @@ async fn resolve_drafts(
         contract_id = contract_id.trim().to_uppercase();
 
         let wasm_hash = resolve_wasm_hash(draft)?;
+        let wasm_artifact_base64 = resolve_wasm_artifact(draft)?;
         let name = take_required(&mut draft.name, "name")?;
         let publisher_address = draft
             .publisher_address
@@ -398,6 +409,7 @@ async fn resolve_drafts(
             request: PublishRequest {
                 contract_id,
                 wasm_hash,
+                wasm_artifact_base64,
                 name,
                 slug,
                 description,
@@ -433,6 +445,32 @@ fn resolve_wasm_hash(draft: &RegistrationDraft) -> Result<String> {
     }
 
     Ok(wasm_hash.trim().to_lowercase())
+}
+
+/// Inline the WASM artifact when the draft supplied a local file.
+///
+/// A draft carrying only a `wasm_hash` has no bytes to send, so the artifact is
+/// omitted and the registry records the contract as scan-pending — the same
+/// semantics as any other publish without an artifact.
+fn resolve_wasm_artifact(draft: &RegistrationDraft) -> Result<Option<String>> {
+    let Some(path) = draft.wasm_path.as_ref() else {
+        return Ok(None);
+    };
+
+    let metadata = fs::metadata(path)
+        .with_context(|| format!("Failed to read WASM file: {}", path.display()))?;
+    if metadata.len() > MAX_INLINE_ARTIFACT_BYTES {
+        anyhow::bail!(
+            "WASM artifact {} is {} bytes, above the {} byte inline limit. Register with `wasm_hash` instead, or raise MAX_PAYLOAD_SIZE_MB on the registry and retry.",
+            path.display(),
+            metadata.len(),
+            MAX_INLINE_ARTIFACT_BYTES
+        );
+    }
+
+    let bytes =
+        fs::read(path).with_context(|| format!("Failed to read WASM file: {}", path.display()))?;
+    Ok(Some(BASE64.encode(bytes)))
 }
 
 fn trim_optional(value: Option<String>) -> Option<String> {

--- a/cli/src/contract_snapshot.rs
+++ b/cli/src/contract_snapshot.rs
@@ -270,6 +270,7 @@ mod tests {
             },
             dependency_scan: None,
             deprecation: None,
+            dependency_graph: None,
             lineage: vec![LineageLink {
                 contract_id: "CNEXT".into(),
                 name: None,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,6 +59,7 @@ mod package_signing;
 mod patch;
 mod plugins;
 mod profiler;
+mod publisher;
 mod release_notes;
 mod shell;
 mod sla;
@@ -1144,6 +1145,12 @@ pub enum Commands {
     Env {
         #[command(subcommand)]
         action: EnvCommands,
+    },
+
+    /// Publisher environment diagnostics
+    Publisher {
+        #[command(subcommand)]
+        action: PublisherCommands,
     },
 
     /// External command (may be provided by an installed plugin)
@@ -2449,6 +2456,19 @@ pub enum EnvCommands {
     Switch {
         /// Environment name to activate
         environment: String,
+    },
+}
+
+/// Sub-commands for the `publisher` group
+#[derive(Debug, Subcommand)]
+pub enum PublisherCommands {
+    /// Diagnose the local publishing environment (config, session, signing key, connectivity)
+    ///
+    /// Usage: soroban-registry publisher doctor [--json]
+    Doctor {
+        /// Output results as machine-readable JSON
+        #[arg(long)]
+        json: bool,
     },
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3002,15 +3002,15 @@ pub async fn dispatch_command(
                 }
                 PluginConfigCommands::Set { name, json } => {
                     plugins::set_plugin_config_json(&name, &json)?;
-                    println!("{} Updated config for {}", "✓".green(), name.bold());
+                    println!("{} Updated config for {}", "[OK]".green(), name.bold());
                 }
                 PluginConfigCommands::Disable { name } => {
                     plugins::set_plugin_enabled(&name, false)?;
-                    println!("{} Disabled {}", "✓".green(), name.bold());
+                    println!("{} Disabled {}", "[OK]".green(), name.bold());
                 }
                 PluginConfigCommands::Enable { name } => {
                     plugins::set_plugin_enabled(&name, true)?;
-                    println!("{} Enabled {}", "✓".green(), name.bold());
+                    println!("{} Enabled {}", "[OK]".green(), name.bold());
                 }
             },
         },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -26,6 +26,7 @@ mod completion;
 mod config;
 mod contract_audit;
 mod contract_dependency;
+mod contract_dependency_graph;
 mod contract_deploy;
 mod contract_deprecate;
 mod contract_snapshot;
@@ -2135,6 +2136,81 @@ pub enum ContractCommands {
         /// Compact summary mode: show aggregate counts without the full tree
         #[arg(long)]
         summary: bool,
+    },
+
+    /// List what a contract depends on (#1147)
+    ///
+    /// Usage: soroban-registry contract dependencies <ADDRESS> [--network <NET>]
+    ///        [--transitive] [--depth N] [--json]
+    ///
+    /// A bare contract address registered on more than one network is ambiguous;
+    /// pass --network to disambiguate.
+    Dependencies {
+        /// On-chain contract address or registry UUID
+        address: String,
+        /// Stellar network (mainnet | testnet | futurenet)
+        #[arg(long)]
+        network: Option<String>,
+        /// Walk the whole dependency closure, not just direct edges
+        #[arg(long)]
+        transitive: bool,
+        /// Maximum traversal depth (capped server-side)
+        #[arg(long)]
+        depth: Option<u32>,
+        /// Include on-chain call edges alongside declared ones
+        #[arg(long)]
+        include_telemetry: bool,
+        /// Print the registry response as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List what depends on a contract (#1147)
+    ///
+    /// Usage: soroban-registry contract dependents <ADDRESS> [--network <NET>]
+    ///        [--transitive] [--depth N] [--json]
+    Dependents {
+        /// On-chain contract address or registry UUID
+        address: String,
+        /// Stellar network (mainnet | testnet | futurenet)
+        #[arg(long)]
+        network: Option<String>,
+        /// Walk the whole dependent closure, not just direct edges
+        #[arg(long)]
+        transitive: bool,
+        /// Maximum traversal depth (capped server-side)
+        #[arg(long)]
+        depth: Option<u32>,
+        /// Include on-chain call edges alongside declared ones
+        #[arg(long)]
+        include_telemetry: bool,
+        /// Print the registry response as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Report direct and inherited risk across a contract's dependencies (#1147)
+    ///
+    /// Usage: soroban-registry contract dependency-risk <ADDRESS> [--network <NET>]
+    ///        [--depth N] [--fail-on low|medium|high|critical] [--json]
+    ///
+    /// Each finding carries the shortest dependency path that reaches it.
+    /// With --fail-on, exits 1 when the overall risk meets or exceeds the level.
+    DependencyRisk {
+        /// On-chain contract address or registry UUID
+        address: String,
+        /// Stellar network (mainnet | testnet | futurenet)
+        #[arg(long)]
+        network: Option<String>,
+        /// Maximum traversal depth (capped server-side)
+        #[arg(long)]
+        depth: Option<u32>,
+        /// Exit 1 when overall risk meets or exceeds this level
+        #[arg(long)]
+        fail_on: Option<String>,
+        /// Print the registry response as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Update contract metadata after registration (#828)
@@ -4412,6 +4488,86 @@ pub async fn dispatch_command(
             } => {
                 log::debug!("Command: contract interaction | address={}", address);
                 contract_interaction::run(&cli.api_url, &address, limit, json).await?;
+            }
+            ContractCommands::Dependencies {
+                address,
+                network,
+                transitive,
+                depth,
+                include_telemetry,
+                json,
+            } => {
+                log::debug!(
+                    "Command: contract dependencies | address={} network={:?} transitive={}",
+                    address,
+                    network,
+                    transitive
+                );
+                let opts = contract_dependency_graph::GraphOptions {
+                    network,
+                    depth,
+                    transitive,
+                    include_telemetry,
+                    json,
+                };
+                contract_dependency_graph::dependencies(&cli.api_url, &address, &opts).await?;
+            }
+            ContractCommands::Dependents {
+                address,
+                network,
+                transitive,
+                depth,
+                include_telemetry,
+                json,
+            } => {
+                log::debug!(
+                    "Command: contract dependents | address={} network={:?} transitive={}",
+                    address,
+                    network,
+                    transitive
+                );
+                let opts = contract_dependency_graph::GraphOptions {
+                    network,
+                    depth,
+                    transitive,
+                    include_telemetry,
+                    json,
+                };
+                contract_dependency_graph::dependents(&cli.api_url, &address, &opts).await?;
+            }
+            ContractCommands::DependencyRisk {
+                address,
+                network,
+                depth,
+                fail_on,
+                json,
+            } => {
+                log::debug!(
+                    "Command: contract dependency-risk | address={} network={:?} fail_on={:?}",
+                    address,
+                    network,
+                    fail_on
+                );
+                let threshold = fail_on
+                    .as_deref()
+                    .map(contract_dependency_graph::Severity::parse)
+                    .transpose()?;
+                let opts = contract_dependency_graph::GraphOptions {
+                    network,
+                    depth,
+                    // Risk is only meaningful over the closure: a direct-only
+                    // report would omit exactly the inherited findings this
+                    // command exists to surface.
+                    transitive: true,
+                    include_telemetry: false,
+                    json,
+                };
+                let breached =
+                    contract_dependency_graph::risk(&cli.api_url, &address, &opts, threshold)
+                        .await?;
+                if breached {
+                    std::process::exit(1);
+                }
             }
             ContractCommands::Dependency {
                 address,

--- a/cli/src/publisher.rs
+++ b/cli/src/publisher.rs
@@ -1,11 +1,22 @@
+//! Publisher environment diagnostics (`soroban-registry publisher doctor`).
+//!
+//! Reports whether the local machine is ready to publish: a config file, a
+//! stored session, a signing secret, and a reachable registry. Every check is
+//! read-only — the command must never repair, refresh, or overwrite state,
+//! because an operator running it is trying to see what is actually there.
+
 use anyhow::Result;
 use colored::Colorize;
 use serde::Serialize;
-use std::path::Path;
 
-#[derive(Serialize)]
+/// Connectivity probe timeout. Shorter than [`crate::net`]'s 30s default: a
+/// doctor command reports a down registry, it does not wait one out.
+const PROBE_TIMEOUT_SECS: u64 = 5;
+
+#[derive(Debug, Serialize)]
 pub struct DoctorReport {
     pub config_file_exists: bool,
+    pub session_present: bool,
     pub session_valid: bool,
     pub signing_key_present: bool,
     pub registry_reachable: bool,
@@ -16,6 +27,7 @@ pub struct DoctorReport {
 pub async fn doctor(api_url: &str, json: bool) -> Result<()> {
     let mut report = DoctorReport {
         config_file_exists: false,
+        session_present: false,
         session_valid: false,
         signing_key_present: false,
         registry_reachable: false,
@@ -29,113 +41,10 @@ pub async fn doctor(api_url: &str, json: bool) -> Result<()> {
         println!("Diagnosing local configuration...\n");
     }
 
-    // 1. Check local config file existence
-    let config_path = crate::config::config_file_path();
-    if let Some(path) = &config_path {
-        if path.exists() {
-            report.config_file_exists = true;
-            if !json {
-                println!("  {} Config file found: {}", "[OK]".green(), path.display());
-            }
-        } else {
-            report.errors.push("Config file not found. Run 'soroban-registry config set' or 'soroban-registry wizard'".into());
-            if !json {
-                println!("  {} Config file missing: {}", "[ERR]".red(), path.display());
-            }
-        }
-    } else {
-        report.errors.push("Could not determine config path".into());
-        if !json {
-            println!("  {} Could not determine config path", "[ERR]".red());
-        }
-    }
+    check_config_file(&mut report, json);
+    check_session(&mut report, json).await;
+    check_registry(&mut report, api_url, json).await;
 
-    // 2. Check Auth / Session state
-    let auth = crate::config::load_auth_section().unwrap_or_default();
-    if let Some(token) = &auth.session_token {
-        if !token.trim().is_empty() {
-            report.session_valid = true;
-            if !json {
-                println!("  {} Session token is present", "[OK]".green());
-            }
-        } else {
-            report.errors.push("Session token is empty. Try logging in again.".into());
-            if !json {
-                println!("  {} Session token is empty", "[ERR]".red());
-            }
-        }
-    } else {
-        report.errors.push("No session token found. Publisher may not be able to authenticate.".into());
-        if !json {
-            println!("  {} No session token found", "[ERR]".red());
-        }
-    }
-
-    // 3. Check Signing Key presence
-    if let Some(key_path) = &auth.signing_key_path {
-        if Path::new(key_path).exists() {
-            report.signing_key_present = true;
-            if !json {
-                println!("  {} Signing key found at: {}", "[OK]".green(), key_path);
-            }
-        } else {
-            report.errors.push(format!("Signing key file not found at: {}", key_path));
-            if !json {
-                println!("  {} Signing key file missing at: {}", "[ERR]".red(), key_path);
-            }
-        }
-    } else {
-        report.errors.push("No signing key configured. Please set 'signing_key_path' in your config.".into());
-        if !json {
-            println!("  {} No signing key configured", "[ERR]".red());
-        }
-    }
-
-    // 4. Check Registry Connectivity
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()?;
-        
-    // We check /health if available, else /api/health-monitor/status or fallback to /api/contracts
-    let url = format!("{}/health", api_url);
-    if !json {
-        print!("  {} Checking registry connectivity... ", "[~]".bright_black());
-    }
-    
-    match client.get(&url).send().await {
-        Ok(res) if res.status().is_success() => {
-            report.registry_reachable = true;
-            if !json {
-                println!("\r  {} Registry reachable at {}", "[OK]".green(), api_url);
-            }
-        }
-        Ok(res) => {
-            // Fallback for if /health is 404 or something, test base api_url
-            match client.get(api_url).send().await {
-                Ok(_) => {
-                    // even if not 200, if we can connect, it's reachable
-                    report.registry_reachable = true;
-                    if !json {
-                        println!("\r  {} Registry reachable at {} (health endpoint returned {})", "[OK]".green(), api_url, res.status());
-                    }
-                }
-                Err(e) => {
-                    report.errors.push(format!("Registry connection failed: {}", e));
-                    if !json {
-                        println!("\r  {} Registry connection failed: {}", "[ERR]".red(), e);
-                    }
-                }
-            }
-        }
-        Err(e) => {
-            report.errors.push(format!("Registry connection failed: {}", e));
-            if !json {
-                println!("\r  {} Registry connection failed: {}", "[ERR]".red(), e);
-            }
-        }
-    }
-
-    // Determine overall status
     report.overall_status = report.config_file_exists
         && report.session_valid
         && report.signing_key_present
@@ -147,15 +56,229 @@ pub async fn doctor(api_url: &str, json: bool) -> Result<()> {
     }
 
     println!("\n{}", "=".repeat(80).cyan());
-    
     if report.overall_status {
-        println!("\n{} All checks passed! The publisher environment is healthy.", "[OK]".green().bold());
+        println!(
+            "\n{} All checks passed. The publisher environment is healthy.",
+            "[OK]".green().bold()
+        );
     } else {
-        println!("\n{} Environment has issues. See remediation steps below:\n", "[ERR]".red().bold());
+        println!(
+            "\n{} Environment has issues. See remediation steps below:\n",
+            "[ERR]".red().bold()
+        );
         for err in &report.errors {
             println!("  {} {}", "-".yellow(), err);
         }
     }
 
     Ok(())
+}
+
+fn check_config_file(report: &mut DoctorReport, json: bool) {
+    match crate::config::config_file_path() {
+        Some(path) if path.exists() => {
+            report.config_file_exists = true;
+            if !json {
+                println!("  {} Config file found: {}", "[OK]".green(), path.display());
+            }
+        }
+        Some(path) => {
+            report.errors.push(format!(
+                "Config file not found at {}. Run 'soroban-registry wizard' or 'soroban-registry config edit'.",
+                path.display()
+            ));
+            if !json {
+                println!(
+                    "  {} Config file missing: {}",
+                    "[ERR]".red(),
+                    path.display()
+                );
+            }
+        }
+        None => {
+            report
+                .errors
+                .push("Could not determine the config path (no home directory).".into());
+            if !json {
+                println!("  {} Could not determine config path", "[ERR]".red());
+            }
+        }
+    }
+}
+
+async fn check_session(report: &mut DoctorReport, json: bool) {
+    let session = match crate::auth::session_diagnostics().await {
+        Ok(session) => session,
+        Err(err) => {
+            report
+                .errors
+                .push(format!("Could not read the stored session: {err}"));
+            if !json {
+                println!("  {} Could not read stored session: {}", "[ERR]".red(), err);
+            }
+            return;
+        }
+    };
+
+    let Some(session) = session else {
+        report
+            .errors
+            .push("No session found. Run 'soroban-registry auth login' before publishing.".into());
+        if !json {
+            println!("  {} No session found", "[ERR]".red());
+        }
+        return;
+    };
+
+    report.session_present = true;
+
+    if !session.token_present {
+        report.errors.push(
+            "Stored session has an empty access token. Run 'soroban-registry auth login' again."
+                .into(),
+        );
+        if !json {
+            println!("  {} Stored access token is empty", "[ERR]".red());
+        }
+    } else if session.expired {
+        report.errors.push(
+            "Access token has expired. Run 'soroban-registry auth login' to re-authenticate."
+                .into(),
+        );
+        if !json {
+            println!("  {} Access token has expired", "[ERR]".red());
+        }
+    } else {
+        report.session_valid = true;
+        if !json {
+            println!(
+                "  {} Session valid ({} as {})",
+                "[OK]".green(),
+                session.method,
+                session.identity
+            );
+        }
+    }
+
+    if session.signing_secret_present {
+        report.signing_key_present = true;
+        if !json {
+            println!(
+                "  {} Signing key available for this session",
+                "[OK]".green()
+            );
+        }
+    } else {
+        report.errors.push(
+            "No signing key stored for this session. Log in with 'soroban-registry auth login --method stellar' so publishes can be signed.".into(),
+        );
+        if !json {
+            println!("  {} No signing key stored for this session", "[ERR]".red());
+        }
+    }
+
+    if session.legacy_storage && !json {
+        println!(
+            "  {} Credentials are in the legacy config file, not the OS keychain",
+            "[WARN]".yellow()
+        );
+    }
+}
+
+async fn check_registry(report: &mut DoctorReport, api_url: &str, json: bool) {
+    let base = api_url.trim_end_matches('/');
+    let url = format!("{base}/health");
+
+    if !json {
+        print!(
+            "  {} Checking registry connectivity... ",
+            "[~]".bright_black()
+        );
+    }
+
+    // Plain send, not `send_with_retry`: retries would triple the wait on a
+    // registry that is simply down, and would attach an auth header the
+    // connectivity probe does not need.
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(PROBE_TIMEOUT_SECS))
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            report
+                .errors
+                .push(format!("Could not build an HTTP client: {err}"));
+            if !json {
+                println!("\r  {} Could not build HTTP client: {}", "[ERR]".red(), err);
+            }
+            return;
+        }
+    };
+
+    match client.get(&url).send().await {
+        Ok(response) if response.status().is_success() => {
+            report.registry_reachable = true;
+            if !json {
+                println!("\r  {} Registry reachable at {}", "[OK]".green(), base);
+            }
+        }
+        Ok(response) => {
+            // A non-2xx from /health still proves the host answered, but it is
+            // not a healthy registry, so it is reported as a failure with the
+            // status attached rather than being smoothed over.
+            report.errors.push(format!(
+                "Registry at {base} answered {} on /health. It is reachable but not healthy.",
+                response.status()
+            ));
+            if !json {
+                println!(
+                    "\r  {} Registry at {} returned {} on /health",
+                    "[ERR]".red(),
+                    base,
+                    response.status()
+                );
+            }
+        }
+        Err(err) => {
+            report
+                .errors
+                .push(format!("Registry connection to {base} failed: {err}"));
+            if !json {
+                println!("\r  {} Registry connection failed: {}", "[ERR]".red(), err);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report() -> DoctorReport {
+        DoctorReport {
+            config_file_exists: true,
+            session_present: true,
+            session_valid: true,
+            signing_key_present: true,
+            registry_reachable: true,
+            overall_status: false,
+            errors: vec![],
+        }
+    }
+
+    #[test]
+    fn report_serializes_every_check() {
+        let value = serde_json::to_value(report()).unwrap();
+        for key in [
+            "config_file_exists",
+            "session_present",
+            "session_valid",
+            "signing_key_present",
+            "registry_reachable",
+            "overall_status",
+            "errors",
+        ] {
+            assert!(value.get(key).is_some(), "missing field {key}");
+        }
+    }
 }

--- a/cli/tests/contract_dependency_graph_tests.rs
+++ b/cli/tests/contract_dependency_graph_tests.rs
@@ -1,0 +1,185 @@
+// tests/contract_dependency_graph_tests.rs
+//
+// Issue #1147 — CLI surface for dependency graphs and transitive risk.
+//
+// Black-box subprocess tests. Everything here runs without a registry: help
+// text, argument parsing, and the failure path when the API is unreachable.
+// The behaviour that needs a live registry -- tree shape, risk propagation,
+// --fail-on exit codes against real data -- is covered by
+// `backend/api/tests/dependency_graph_tests.rs`, which drives the same code
+// paths through HTTP.
+//
+// To run:
+//   cd cli && cargo test --test contract_dependency_graph_tests
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn get_binary_path() -> PathBuf {
+    let name = "soroban-registry";
+    if let Ok(path) = env::var(format!("CARGO_BIN_EXE_{}", name.replace('-', "_"))) {
+        return PathBuf::from(path);
+    }
+    if let Ok(path) = env::var(format!("CARGO_BIN_EXE_{name}")) {
+        return PathBuf::from(path);
+    }
+    let mut path = env::current_dir().expect("cwd");
+    path.push("target/debug/soroban-registry");
+    path
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let output = Command::new(get_binary_path())
+        .args(args)
+        .output()
+        .expect("run the CLI");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+/// A port nothing is listening on, so the request fails fast and locally.
+const UNREACHABLE: &str = "http://127.0.0.1:1";
+
+const VALID_ADDRESS: &str = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+// ── Help and discoverability ────────────────────────────────────────────────
+
+#[test]
+fn dependencies_help_documents_the_network_flag() {
+    // --network is not optional decoration: a bare address registered on more
+    // than one network is a 409, and the help is where a user learns the fix.
+    let (ok, stdout, _) = run(&["contract", "dependencies", "--help"]);
+    assert!(ok);
+    assert!(stdout.contains("--network"), "{stdout}");
+    assert!(stdout.contains("--transitive"), "{stdout}");
+    assert!(stdout.contains("--json"), "{stdout}");
+}
+
+#[test]
+fn dependents_help_is_available() {
+    let (ok, stdout, _) = run(&["contract", "dependents", "--help"]);
+    assert!(ok);
+    assert!(stdout.contains("--network"), "{stdout}");
+}
+
+#[test]
+fn dependency_risk_help_documents_fail_on() {
+    let (ok, stdout, _) = run(&["contract", "dependency-risk", "--help"]);
+    assert!(ok);
+    assert!(stdout.contains("--fail-on"), "{stdout}");
+}
+
+#[test]
+fn the_three_commands_appear_in_the_contract_group() {
+    let (ok, stdout, _) = run(&["contract", "--help"]);
+    assert!(ok);
+    for command in ["dependencies", "dependents", "dependency-risk"] {
+        assert!(stdout.contains(command), "missing {command} in:\n{stdout}");
+    }
+}
+
+#[test]
+fn the_address_is_positional() {
+    // Matching the other contract subcommands. An `--id` flag would be the odd
+    // one out across the whole `contract` group.
+    let (ok, stdout, _) = run(&["contract", "dependencies", "--help"]);
+    assert!(ok);
+    assert!(
+        stdout.contains("<ADDRESS>"),
+        "address should be positional:\n{stdout}"
+    );
+}
+
+// ── Argument validation ─────────────────────────────────────────────────────
+
+#[test]
+fn a_missing_address_is_rejected() {
+    let (ok, _, stderr) = run(&["contract", "dependencies"]);
+    assert!(!ok);
+    assert!(
+        stderr.contains("required") || stderr.contains("ADDRESS"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn an_invalid_fail_on_level_is_rejected_before_any_request() {
+    // Validated client-side so a typo fails immediately with the valid values,
+    // rather than after a round trip.
+    let (ok, _, stderr) = run(&[
+        "--api-url",
+        UNREACHABLE,
+        "contract",
+        "dependency-risk",
+        VALID_ADDRESS,
+        "--fail-on",
+        "catastrophic",
+    ]);
+    assert!(!ok);
+    assert!(stderr.contains("invalid severity"), "{stderr}");
+    assert!(
+        stderr.contains("low, medium, high, critical"),
+        "the error should name the valid values: {stderr}"
+    );
+}
+
+#[test]
+fn every_documented_fail_on_level_parses() {
+    for level in ["low", "medium", "high", "critical", "HIGH", " critical "] {
+        let (_, _, stderr) = run(&[
+            "--api-url",
+            UNREACHABLE,
+            "contract",
+            "dependency-risk",
+            VALID_ADDRESS,
+            "--fail-on",
+            level,
+        ]);
+        assert!(
+            !stderr.contains("invalid severity"),
+            "'{level}' should parse: {stderr}"
+        );
+    }
+}
+
+// ── Failure paths ───────────────────────────────────────────────────────────
+
+#[test]
+fn an_unreachable_registry_fails_with_an_actionable_message() {
+    let (ok, _, stderr) = run(&[
+        "--api-url",
+        UNREACHABLE,
+        "contract",
+        "dependencies",
+        VALID_ADDRESS,
+    ]);
+    assert!(!ok);
+    assert!(
+        stderr.contains("registry") || stderr.contains("Network request failed"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn an_unreachable_registry_does_not_report_a_risk_verdict() {
+    // Exiting 0 on a failed request would let a CI gate pass silently when the
+    // registry is down -- the exact scenario --fail-on exists to catch.
+    let (ok, stdout, _) = run(&[
+        "--api-url",
+        UNREACHABLE,
+        "contract",
+        "dependency-risk",
+        VALID_ADDRESS,
+        "--fail-on",
+        "low",
+    ]);
+    assert!(!ok, "a failed request must not exit 0");
+    assert!(
+        !stdout.contains("Overall:"),
+        "no verdict should be printed: {stdout}"
+    );
+}

--- a/database/migrations/20260819000000_issue1147_contract_interface_id.sql
+++ b/database/migrations/20260819000000_issue1147_contract_interface_id.sql
@@ -1,0 +1,32 @@
+-- Issue #1147: persist the deterministic interface fingerprint of each contract.
+--
+-- `shared::interface_fingerprint::fingerprint_spec` already derives a stable
+-- `soroban-interface-v1` identifier from a parsed contractspecv0 section, but
+-- until now its only consumer was the CLI, computing it from a locally supplied
+-- WASM file. Nothing on the server recorded it, so "the interface changed" was
+-- not a question the registry could answer.
+--
+-- The dependency graph needs exactly that: an edge records the interface id its
+-- target had when the edge was declared, and an incompatibility is drift between
+-- that recorded id and the target's current one. Without a persisted column
+-- every recorded id would be NULL and the rule could never fire.
+--
+-- Both columns are nullable. A publish without `wasm_artifact_base64` has no
+-- bytes to fingerprint, matching the existing `artifact_scan_status = 'pending'`
+-- semantics; so does an artifact that embeds no contract spec section.
+
+ALTER TABLE contracts
+    ADD COLUMN IF NOT EXISTS interface_id        TEXT,
+    ADD COLUMN IF NOT EXISTS interface_algorithm TEXT;
+
+COMMENT ON COLUMN contracts.interface_id IS
+    'Deterministic interface fingerprint derived from the contractspecv0 section at publish time. NULL when no artifact or no spec section was supplied.';
+COMMENT ON COLUMN contracts.interface_algorithm IS
+    'Algorithm that produced interface_id (currently soroban-interface-v1). Stored alongside the id so fingerprints from a future algorithm are never compared against v1 ones.';
+
+-- Comparisons are always equality against a known id, never a range scan, and
+-- the column is NULL for every artifact-less contract, so a partial index keeps
+-- it small.
+CREATE INDEX IF NOT EXISTS idx_contracts_interface_id
+    ON contracts (interface_id)
+    WHERE interface_id IS NOT NULL;

--- a/database/migrations/20260819010000_issue1147_dependency_graph.sql
+++ b/database/migrations/20260819010000_issue1147_dependency_graph.sql
@@ -1,0 +1,190 @@
+-- Issue #1147: canonical contract dependency edges, plus a compatibility view.
+--
+-- ## Why a new table
+--
+-- Eleven call sites in `backend/api` query a table named `contract_dependencies`
+-- that no migration has ever created, under two mutually incompatible schemas:
+-- a "static" shape (contract_id / dependency_name / dependency_contract_id /
+-- version_constraint) and a "call" shape (caller_id / callee_contract_id /
+-- call_volume). Migration 062 documents the phantom in its own comment and
+-- guards its ALTER behind `to_regclass(...) IS NOT NULL`.
+--
+-- This migration introduces one canonical edge model and, separately, ships a
+-- VIEW literally named `contract_dependencies` projecting the legacy static
+-- shape, so the existing static-shaped call sites work unchanged.
+--
+-- ## Landmine: migration 062 vs. this view
+--
+-- `062_add_dependency_type.sql` runs `ALTER TABLE contract_dependencies ...`
+-- when `to_regclass('public.contract_dependencies')` is non-NULL. ALTER TABLE
+-- against a *view* fails. Lexicographic ordering puts `062_` before
+-- `20260819010000_`, so on a fresh database 062 sees nothing and no-ops, and we
+-- are safe. Anyone who reorders, renumbers, or squashes migrations such that 062
+-- runs after this file will break their deploy. 062's import/call/data taxonomy
+-- survives here as `dep_kind`.
+--
+-- ## What is NOT changed
+--
+-- `contract_static_dependencies` (migration 006) stays the write-through source
+-- for declared edges. It backs six live, working endpoints through
+-- `dependency::build_dependency_graph`, and this table is an additive read model
+-- backfilled from it, so the working path carries no regression risk.
+--
+-- `contract_call_dependencies` (migration 007) is NOT backfilled: it has zero
+-- readers and zero writers, so it would contribute a permanently empty subtree.
+-- Telemetry edges are instead read live from
+-- `contract_call_edge_daily_aggregates`, which stores both endpoints as UUID
+-- foreign keys, is already network-scoped, and is already the historical record.
+
+-- ── Enums ───────────────────────────────────────────────────────────────────
+
+-- Two values, not three. Spec-derived data never produces an edge (dependencies
+-- are never inferred from ABI strings; see Issue #1147 D3), so a 'spec' value
+-- could never be emitted -- and Postgres enum values are painful to remove.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'dependency_edge_source') THEN
+        CREATE TYPE dependency_edge_source AS ENUM ('declared', 'telemetry');
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'dependency_edge_state') THEN
+        CREATE TYPE dependency_edge_state AS ENUM ('resolved', 'unresolved', 'network_mismatch');
+    END IF;
+END $$;
+
+-- ── Canonical edge table ────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS contract_dependency_edges (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_contract_id    UUID NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,
+    -- NULL means the reference did not resolve to a registered contract. The
+    -- row is retained anyway: the operator declared something real, and
+    -- dropping it would silently shrink the graph.
+    --
+    -- CASCADE, not SET NULL. SET NULL would blank this column while leaving
+    -- edge_state = 'resolved', violating
+    -- contract_dependency_edges_state_matches_target and making it impossible
+    -- to delete any contract that something depends on. CASCADE also matches
+    -- the source-side FK and contract_call_edge_daily_aggregates, which
+    -- cascades on both endpoints.
+    target_contract_id    UUID REFERENCES contracts(id) ON DELETE CASCADE,
+    -- Exactly what was declared, preserved verbatim so an unresolved edge can
+    -- still be reported and can resolve later without re-declaring.
+    target_ref            TEXT NOT NULL,
+    network               network_type NOT NULL,
+    edge_source           dependency_edge_source NOT NULL,
+    edge_state            dependency_edge_state NOT NULL,
+    -- Migration 062's import|call|data taxonomy.
+    dep_kind              TEXT,
+    version_constraint    TEXT,
+    -- The target's interface fingerprint and wasm hash *at the time the edge was
+    -- recorded*. Current state is always JOINed from `contracts`, never
+    -- denormalized here: an incompatibility is precisely the drift between these
+    -- recorded values and the target's current ones.
+    expected_interface_id TEXT,
+    expected_wasm_hash    TEXT,
+    recorded_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- NULL means this row is the current state of the edge. Bitemporal history
+    -- applies to declared edges only; telemetry is already day-bucketed at the
+    -- source and is read live.
+    superseded_at         TIMESTAMPTZ,
+    CONSTRAINT contract_dependency_edges_no_self_edge
+        CHECK (source_contract_id IS DISTINCT FROM target_contract_id),
+    -- A resolved edge must name its target; an unresolved or cross-network one
+    -- must not, or it would be indistinguishable from a real dependency.
+    CONSTRAINT contract_dependency_edges_state_matches_target
+        CHECK (
+            (edge_state = 'resolved' AND target_contract_id IS NOT NULL)
+            OR (edge_state <> 'resolved' AND target_contract_id IS NULL)
+        )
+);
+
+-- One current row per (source, declared reference, network, source-of-truth).
+-- Partial, so superseded history rows are exempt.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_contract_dependency_edges_current
+    ON contract_dependency_edges (source_contract_id, target_ref, network, edge_source)
+    WHERE superseded_at IS NULL;
+
+-- Forward traversal: the recursive CTE walks source -> target over current rows.
+CREATE INDEX IF NOT EXISTS idx_contract_dependency_edges_forward
+    ON contract_dependency_edges (source_contract_id, network)
+    WHERE superseded_at IS NULL;
+
+-- Reverse traversal for /dependents.
+CREATE INDEX IF NOT EXISTS idx_contract_dependency_edges_reverse
+    ON contract_dependency_edges (target_contract_id, network)
+    WHERE superseded_at IS NULL AND target_contract_id IS NOT NULL;
+
+-- `as_of` replay reads history by recording time.
+CREATE INDEX IF NOT EXISTS idx_contract_dependency_edges_recorded_at
+    ON contract_dependency_edges (source_contract_id, recorded_at DESC);
+
+COMMENT ON TABLE contract_dependency_edges IS
+    'Canonical, network-scoped, bitemporal contract dependency edges (Issue #1147). superseded_at IS NULL selects current state.';
+COMMENT ON COLUMN contract_dependency_edges.target_ref IS
+    'The dependency reference exactly as declared. Retained even when it does not resolve.';
+COMMENT ON COLUMN contract_dependency_edges.expected_interface_id IS
+    'contracts.interface_id of the target when this edge was recorded. Drift from the target current value is an interface incompatibility.';
+
+-- ── Backfill from the existing declared-dependency table ────────────────────
+--
+-- Additive and idempotent. `contract_static_dependencies` has no network column
+-- of its own; an edge belongs to the declaring contract's network, which is also
+-- the only network its target could legitimately have been resolved against.
+--
+-- Legacy rows that resolved by *name* (dropped in Issue #1147 D3, because
+-- contracts.name has no UNIQUE constraint) are re-recorded as 'unresolved'
+-- rather than silently rebound: the recorded binding cannot be trusted, and
+-- inventing a new one from the same ambiguous name would repeat the defect.
+INSERT INTO contract_dependency_edges (
+    source_contract_id, target_contract_id, target_ref, network,
+    edge_source, edge_state, version_constraint,
+    expected_interface_id, expected_wasm_hash, recorded_at
+)
+SELECT
+    csd.contract_id,
+    CASE WHEN target.id IS NOT NULL THEN target.id END,
+    csd.dependency_name,
+    src.network,
+    'declared'::dependency_edge_source,
+    CASE WHEN target.id IS NOT NULL
+         THEN 'resolved'::dependency_edge_state
+         ELSE 'unresolved'::dependency_edge_state
+    END,
+    csd.version_constraint,
+    target.interface_id,
+    target.wasm_hash,
+    csd.created_at
+FROM contract_static_dependencies csd
+JOIN contracts src ON src.id = csd.contract_id
+-- Network-qualified join. Without it, a strkey deployed on two networks yields
+-- two rows, producing duplicate edges and silent cross-network contamination.
+LEFT JOIN contracts target
+       ON target.id = csd.dependency_contract_id
+      AND target.network = src.network
+WHERE csd.contract_id <> COALESCE(csd.dependency_contract_id, '00000000-0000-0000-0000-000000000000'::uuid)
+ON CONFLICT DO NOTHING;
+
+-- ── Compatibility view ──────────────────────────────────────────────────────
+--
+-- Named exactly `contract_dependencies` and projecting the legacy static shape,
+-- so the static-shaped call sites resolve against real data with no Rust change.
+-- Only current, declared edges are exposed: the legacy shape has no vocabulary
+-- for supersession or for telemetry-derived edges.
+CREATE OR REPLACE VIEW contract_dependencies AS
+SELECT
+    e.id,
+    e.source_contract_id AS contract_id,
+    e.target_ref         AS dependency_name,
+    e.target_contract_id AS dependency_contract_id,
+    COALESCE(e.version_constraint, '*') AS version_constraint,
+    e.recorded_at        AS created_at
+FROM contract_dependency_edges e
+WHERE e.superseded_at IS NULL
+  AND e.edge_source = 'declared';
+
+COMMENT ON VIEW contract_dependencies IS
+    'Compatibility projection of contract_dependency_edges in the legacy static shape (Issue #1147). Read-only; write through contract_dependency_edges.';

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -1,0 +1,410 @@
+# Contract dependency graphs and transitive risk
+
+Issue #1147.
+
+Consumers can see individual contract metadata and vulnerability findings, but
+not how contracts depend on one another, or how a vulnerable dependency affects
+downstream deployments. This document is the contract for the four endpoints
+that answer those questions: their JSON shapes, the rules that decide what
+counts as a risk, and the guarantees you can rely on.
+
+## Endpoints
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/contracts/:id/dependencies` | What this contract depends on, as a tree |
+| GET | `/api/contracts/:id/dependents` | What depends on this contract |
+| GET | `/api/contracts/:id/dependency-graph` | Flat counts, cycles, diagnostics, truncation |
+| GET | `/api/contracts/:id/dependency-risk` | Direct vs inherited findings, with paths |
+
+`:id` accepts a registry UUID **or** a Stellar contract address (`C...`).
+
+### Query parameters
+
+| Parameter | Applies to | Default | Meaning |
+| --- | --- | --- | --- |
+| `network` | all | none | `mainnet`, `testnet`, or `futurenet`. Required to disambiguate an address registered on more than one network. |
+| `transitive` | dependencies, dependents, graph | `true` | `false` walks direct edges only. |
+| `depth` | all | 10 | Maximum traversal depth. Capped at 32. |
+| `max_nodes` | dependencies, dependents, graph | 1000 | Maximum nodes returned. Capped at 10000. |
+| `as_of` | dependencies, dependents, graph | now | RFC3339 instant; replays the graph as it stood then. |
+| `include_telemetry` | dependencies, dependents, graph | `false` | Include on-chain call edges alongside declared ones. |
+
+### Resolving `:id`
+
+Because `contracts` is `UNIQUE(contract_id, network)`, a bare address is not a
+unique identifier.
+
+| Input | Result |
+| --- | --- |
+| UUID that exists | resolved |
+| UUID that does not exist | `404 ContractNotFound` |
+| UUID plus a `network` naming a different network | `400 NetworkMismatch` |
+| Address registered on exactly one network | resolved |
+| Address registered on several, with `network` | resolved |
+| Address registered on several, without `network` | **`409 AmbiguousContractRef`**, with the candidates in `details.candidates` |
+| Address that is not registered | `404 ContractNotFound` |
+| Neither a UUID nor a well-formed address | `400 InvalidContractRef` |
+
+The 409 is deliberate. Picking a network silently would answer a question about
+a *different contract* than the caller meant, and nothing in the response would
+reveal it.
+
+```json
+{
+  "code": "AMBIGUOUSCONTRACTREF",
+  "message": "Contract address CB... is registered on 2 networks. Retry with ?network=",
+  "details": {
+    "candidates": [
+      { "id": "…", "contract_id": "CB…", "network": "mainnet" },
+      { "id": "…", "contract_id": "CB…", "network": "testnet" }
+    ]
+  }
+}
+```
+
+## The edge model
+
+Edges live in `contract_dependency_edges`, one canonical, network-scoped,
+bitemporal table.
+
+| Column | Meaning |
+| --- | --- |
+| `source_contract_id` | The dependent. |
+| `target_contract_id` | The dependency. `NULL` when the reference did not resolve. |
+| `target_ref` | Exactly what was declared, kept verbatim. |
+| `network` | The network both ends belong to. |
+| `edge_source` | `declared` or `telemetry`. |
+| `edge_state` | `resolved`, `unresolved`, or `network_mismatch`. |
+| `version_constraint` | As declared. Opaque; defaults to `*`. |
+| `expected_interface_id` | The target's interface id **when the edge was recorded**. |
+| `recorded_at` / `superseded_at` | `superseded_at IS NULL` selects current state. |
+
+A read-only view named `contract_dependencies` projects current declared edges
+into the legacy `(id, contract_id, dependency_name, dependency_contract_id,
+version_constraint, created_at)` shape. Write through
+`contract_dependency_edges`, never the view.
+
+### Declared vs telemetry edges
+
+**Declared** edges come from `POST /api/contracts/:id/dependencies`. They are
+versioned: changing a declaration supersedes the old row rather than deleting
+it, so `as_of` can replay history exactly. Only genuine changes are superseded —
+re-saving an unchanged declaration leaves its `recorded_at` alone, so history
+does not fill with no-op churn.
+
+**Telemetry** edges are derived live from
+`contract_call_edge_daily_aggregates` and are never materialized. That table
+stores both endpoints as UUID foreign keys, is already network-scoped, and is
+already day-bucketed — it *is* the historical record. Copying it into the
+bitemporal table would add a supersede-and-insert to the hottest write path in
+the system for no information gain. The consequence for `as_of`: declared edges
+replay to the instant, telemetry edges replay to the day.
+
+### References are never inferred
+
+Dependencies are only ever recorded from an explicit declaration. A reference
+must be a Stellar contract address and is resolved with
+`SELECT id FROM contracts WHERE contract_id = $1 AND network = $2`.
+
+- No match on any network → `edge_state = 'unresolved'`.
+- Match on a different network → `edge_state = 'network_mismatch'`.
+
+Neither is bound to a contract, and neither is walked. Both are retained and
+reported: the operator declared something real, and dropping it would silently
+shrink the graph.
+
+Resolution by `contracts.name` was removed. `name` has no UNIQUE constraint, so
+a name lookup bound a dependency to whichever row happened to share a name.
+**Legacy rows that resolved by name are re-recorded as `unresolved`** rather
+than silently rebound — a behaviour change, and an intentional one.
+
+## Traversal guarantees
+
+**Bounded three ways.** A cycle guard (the walk carries its root-to-here path and
+stops on a repeat), a depth bound, and a node budget plus a
+`SET LOCAL statement_timeout`. The timeout is not redundant: dropping an axum
+future does **not** cancel an in-flight sqlx query, so without it a client that
+disconnects mid-traversal would hold a pooled connection for the full runtime of
+the query. Exceeding it returns `503 DependencyTraversalTimeout`.
+
+**Truncation is always reported.** `truncated` plus a `truncation_reason` of
+`depth_limit`, `node_limit`, or `time_limit`, and a `truncated` diagnostic. A
+graph that fits exactly within `depth` and ends in terminal rows is **not**
+reported as truncated.
+
+**Deterministic.** Rows come back ordered by
+`(depth, network, target_contract_id, target_ref, edge_source)` — total, and with
+no floats in any sort key. Two identical requests against an unchanged graph
+return byte-identical JSON.
+
+**Cycles terminate and are reported.** The guard emits the loop-closing edge once
+and then stops. Without that the cycle would be invisible and would look like
+depth truncation.
+
+**Tenancy is enforced inside the walk.** A node the caller may not see is
+returned as `[redacted]` — counted, so totals stay honest, but with no address,
+name, or interface id — and the walk **stops there**. A private contract is never
+a stepping stone to enumerating what it depends on.
+
+## Response shapes
+
+### `/dependencies` and `/dependents`
+
+Field-stable: fields may be added with serde defaults, never renamed or removed
+(GraphQL's `Contract.dependencies` resolves through this type).
+
+```json
+{
+  "root": {
+    "contract_id": "CA…",
+    "resolved_id": "…uuid…",
+    "name": "A",
+    "call_volume": 0,
+    "status": "unverified",
+    "is_circular": false,
+    "dependencies": [
+      {
+        "contract_id": "CB…",
+        "resolved_id": "…uuid…",
+        "name": "B",
+        "status": "resolved",
+        "is_circular": false,
+        "dependencies": [],
+        "visualization_hints": {
+          "depth": 1,
+          "node_type": "standard",
+          "edge_source": "declared",
+          "edge_state": "resolved",
+          "redacted": false
+        }
+      }
+    ],
+    "visualization_hints": {
+      "node_type": "root",
+      "depth": 0,
+      "truncated": false,
+      "truncation_reason": null,
+      "diagnostics": []
+    }
+  },
+  "total_dependencies": 3,
+  "max_depth": 2,
+  "has_circular": false
+}
+```
+
+`status` is one of `resolved`, `unresolved`, `network_mismatch`, or `redacted`.
+
+### `/dependency-graph`
+
+```json
+{
+  "contract_id": "…uuid…",
+  "network": "testnet",
+  "total_dependencies": 6,
+  "resolved": 4,
+  "unresolved": 2,
+  "redacted": 0,
+  "max_depth": 4,
+  "has_circular": true,
+  "truncated": false,
+  "diagnostics": []
+}
+```
+
+### `/dependency-risk`
+
+```json
+{
+  "contract_id": "…uuid…",
+  "network": "testnet",
+  "direct_findings": [ … ],
+  "inherited_findings": [ … ],
+  "diagnostics": [ … ],
+  "direct_risk":  { "effective_severity": "Medium",   "counts": { "critical": 0, "high": 0, "medium": 1, "low": 0 } },
+  "overall_risk": { "effective_severity": "Critical", "counts": { "critical": 1, "high": 0, "medium": 1, "low": 3 } },
+  "total_dependencies": 3,
+  "max_depth": 3,
+  "truncated": false
+}
+```
+
+A finding:
+
+```json
+{
+  "rule_id": "open_vulnerability",
+  "severity": "Critical",
+  "origin_contract_id": "…uuid…",
+  "finding_id": "…uuid…",
+  "path": ["…root…", "…dependency…"],
+  "inherited_via_depth": 1,
+  "detail": "Reentrancy in withdraw"
+}
+```
+
+`severity` is capitalized (`Low`, `Medium`, `High`, `Critical`) because it
+reuses `IssueSeverity`, whose wire form predates this feature and is shared with
+the security endpoints.
+
+## Findings and diagnostics are separate arrays
+
+**Findings carry a severity. Diagnostics do not.**
+
+This is the single most important rule in the design. A cycle, an unresolved
+edge, or a truncated walk is a fact about the *graph*, not a security condition.
+If they carried a severity, `max()` would drag every cyclic graph to at least
+Low, "zero findings" would be unreachable, and the report would be useless as a
+CI gate.
+
+### Findings
+
+| Condition | `rule_id` | Source | Direct | Inherited |
+| --- | --- | --- | --- | --- |
+| Open vulnerability | `open_vulnerability` | `security_issues` (status `open`) | as recorded | **same severity** |
+| Signature revoked | `signature_revoked` | `package_signatures.status='revoked'` for the current wasm hash | High | High |
+| Artifact quarantined | `artifact_quarantined` | `contracts.artifact_scan_status='quarantined'` | High | Medium |
+| Artifact unsigned | `artifact_unsigned` | no `valid` signature for the current wasm hash | Medium | Low |
+| Deprecated, no replacement or superseded | `deprecated_no_replacement` | `contracts.deprecation_status` | Medium | Low |
+| Deprecated with replacement, in grace period | `deprecated_with_replacement` | `contract_deprecations.grace_period_days` | Low | *not inherited* |
+| Interface incompatibility | `interface_incompatibility` | `expected_interface_id != contracts.interface_id` | High | *not inherited* |
+
+An open vulnerability keeps its recorded severity when inherited: a vulnerable
+dependency is exactly as exploitable through its caller. Everything else
+attenuates, because a problem you can only reach through someone else's code is
+a planning problem rather than an immediate one.
+
+Two rules do not propagate at all. An interface incompatibility is a fact about
+one specific edge — the expectation recorded on it versus the target now — so
+re-reporting it two hops away would be meaningless. A deprecation that has a
+named replacement and is still inside its grace period is a scheduled migration.
+
+### Diagnostics
+
+| `kind` | Meaning |
+| --- | --- |
+| `cycle` | The walk re-encountered a contract already on its path. `path` names the loop, not the lead-in. |
+| `unresolved_edge` | A declared reference that binds to nothing. |
+| `network_mismatch` | A reference that names a contract on a different network. |
+| `truncated` | A depth, node, or time budget was hit. |
+| `version_conflict` | Two edges target one contract under constraints no published version satisfies. |
+| `redacted_node` | A node hidden by tenancy, counted but not named. |
+
+**Unresolved edges are split by shape.** A well-formed contract address that is
+not registered is a genuine gap in the graph. A free-form string is an
+undeclared library and merely informational. Treating both alike would bury the
+real signal, since most unresolved references are the second kind.
+
+## Interface incompatibility
+
+An edge records the target's `interface_id` at declaration time. An
+incompatibility is drift between that recorded value and the target's current
+one.
+
+`interface_id` is the existing `soroban-interface-v1` fingerprint
+(`shared::interface_fingerprint`), derived at publish time from the
+`contractspecv0` custom section of the submitted artifact. It normalizes away doc
+comments, library names, and entry ordering, so cosmetic changes do not register
+as drift.
+
+**No WASM is ever executed.** The module is walked for custom sections and the
+section is read by a dependency-free XDR reader.
+
+`NULL` on either side means *unknown*, not *different*. A contract published
+without an artifact, or whose artifact embeds no spec section, has no interface
+id, and no incompatibility is reported against it. Reporting drift against an
+unknown would flag most of the registry.
+
+## Version conflicts
+
+`version_constraint` is opaque and defaults to `*`, which does not parse as a
+constraint. The target carries no version on `contracts` either — versions live
+in `contract_versions`. So a conflict cannot be decided from the constraints
+alone.
+
+**Definition:** two edges target the same contract under constraints for which no
+row in `contract_versions.version` satisfies both.
+
+- An unparseable constraint (including `*`) never creates a conflict. Reporting
+  one would flag a parser gap as a dependency problem.
+- A target with no published versions never conflicts: there is nothing to
+  satisfy either constraint, so any claim would be speculation.
+
+## Combining severities
+
+Risk is `(effective_severity, counts_by_severity)`, compared lexicographically —
+not a bare `max()`.
+
+- `max()` alone ranks one High identically to forty Highs, which is exactly the
+  distinction someone triaging an upgrade needs.
+- Severity is ordinal, so summing or averaging it is meaningless. Forty Highs
+  must never add up to a Critical.
+- The tuple is float-free and total, so the ordering is deterministic and
+  reproducible.
+
+`effective_severity` is `null` when there are no findings. That state is
+reachable precisely because diagnostics are excluded from `findings`.
+
+### Deduplication
+
+A finding reachable by several paths is reported once, keyed by
+`(rule_id, origin_contract_id, finding_id)`. The **shortest** path is kept —
+it is the most actionable route from the contract you asked about to the
+problem — with ties broken lexicographically so the result is a function of the
+graph rather than of row arrival order.
+
+Findings are ordered by `(severity DESC, rule_id ASC, path ASC)`.
+
+## Pagination
+
+Offset pagination, via the shared `page`/`per_page` parameters. This is
+defensible here only because `max_nodes` hard-caps the result set at 10000 rows.
+It is **not** justified by the total ordering: the graph mutates between
+requests, and offsetting into a full CTE costs the whole graph per page
+regardless. Cursor pagination is not available — `shared::pagination::Cursor` is
+hardcoded to `(DateTime<Utc>, Uuid)` and cannot express graph order.
+
+## Snapshots
+
+`GET /api/contracts/:id/snapshot?include_dependency_graph=true` embeds the risk
+report and raises the payload to **schema 1.1**. The default remains 1.0 with no
+`dependency_graph` field, byte-identical to before this feature.
+
+The version bump is not cosmetic. `SnapshotPayload` has no
+`deny_unknown_fields`, so an older CLI handed a graph-bearing payload that
+claimed to be 1.0 would drop the field, recanonicalize without it, and report
+**"signature invalid"** — telling the operator their snapshot was tampered with.
+With a distinct version it returns `UnsupportedSchema("1.1")`: true, actionable,
+and impossible to mistake for tampering. The version is derived from the payload
+content, so a graph-bearing snapshot cannot claim to be 1.0.
+
+## CLI
+
+```bash
+soroban-registry contract dependencies <ADDRESS> [--network N] [--transitive] [--depth N] [--json]
+soroban-registry contract dependents   <ADDRESS> [--network N] [--transitive] [--depth N] [--json]
+soroban-registry contract dependency-risk <ADDRESS> [--network N] [--depth N] [--fail-on LEVEL] [--json]
+```
+
+`--json` prints the API response unmodified, so scripts get exactly the shapes
+documented above.
+
+`--fail-on low|medium|high|critical` exits 1 when
+`overall_risk.effective_severity` meets or exceeds the level, and 0 otherwise —
+including when there are no findings at all. The comparison uses the severity
+the server computed; recomputing it client-side would let the CLI and the
+registry disagree about whether a deploy should be blocked. A failed request
+never exits 0, so a gate cannot pass silently because the registry was down.
+
+## Testing
+
+- `cargo test -p shared` — the pure rules: severity table, combinator, dedup and
+  shortest-path, ordering, version conflicts, budget clamping, cycle segments.
+  No database.
+- `cargo test -p api --test dependency_graph_tests -- --ignored --test-threads=1`
+  — the traversal against real Postgres: cycles, diamonds, truncation, tenancy,
+  propagation, determinism, and the compatibility view. See the file header for
+  the required environment.
+- `cd cli && cargo test --test contract_dependency_graph_tests` — CLI surface,
+  argument validation, and failure paths. No registry needed.

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -29,6 +29,8 @@ counts as a risk, and the guarantees you can rely on.
 | `max_nodes` | dependencies, dependents, graph | 1000 | Maximum nodes returned. Capped at 10000. |
 | `as_of` | dependencies, dependents, graph | now | RFC3339 instant; replays the graph as it stood then. |
 | `include_telemetry` | dependencies, dependents, graph | `false` | Include on-chain call edges alongside declared ones. |
+| `page` | graph | 1 | 1-based page of the flat `nodes` list. |
+| `per_page` | graph | 50 | Nodes per page. Capped at 200. |
 
 ### Resolving `:id`
 
@@ -209,7 +211,25 @@ Field-stable: fields may be added with serde defaults, never renamed or removed
   "max_depth": 4,
   "has_circular": true,
   "truncated": false,
-  "diagnostics": []
+  "diagnostics": [],
+  "nodes": {
+    "items": [
+      {
+        "contract_id": "CB…",
+        "resolved_id": "…uuid…",
+        "name": "B",
+        "depth": 1,
+        "edge_source": "declared",
+        "edge_state": "resolved",
+        "path": ["…root…", "…b…"],
+        "redacted": false
+      }
+    ],
+    "total": 6,
+    "page": 1,
+    "per_page": 50,
+    "pages": 1
+  }
 }
 ```
 
@@ -358,12 +378,28 @@ Findings are ordered by `(severity DESC, rule_id ASC, path ASC)`.
 
 ## Pagination
 
-Offset pagination, via the shared `page`/`per_page` parameters. This is
-defensible here only because `max_nodes` hard-caps the result set at 10000 rows.
-It is **not** justified by the total ordering: the graph mutates between
-requests, and offsetting into a full CTE costs the whole graph per page
-regardless. Cursor pagination is not available — `shared::pagination::Cursor` is
-hardcoded to `(DateTime<Utc>, Uuid)` and cannot express graph order.
+Pagination applies to **`/dependency-graph` only**, over its flat `nodes` list:
+
+```
+GET /api/contracts/:id/dependency-graph?page=2&per_page=50
+```
+
+`nodes` is a standard `PaginatedResponse` (`items`, `total`, `page`, `per_page`,
+`pages`). `per_page` defaults to 50 and is capped at 200; `page` is 1-based, and
+out-of-range values are clamped rather than rejected. A page past the end
+returns an empty `items` with `total` unchanged.
+
+The tree endpoints `/dependencies` and `/dependents` are **not** paginated,
+because a tree cannot be coherently paged — page 2 of a tree is not a tree.
+They return the whole traversal, which is already bounded by `max_nodes`. Use
+`/dependency-graph` when you want to walk the reachable set incrementally.
+
+Offset (rather than cursor) pagination is defensible here only because the
+traversal hard-caps its result set at 10000 rows. It is **not** justified by the
+total ordering: the graph mutates between requests, and offsetting into a full
+CTE costs the whole graph per page regardless. Cursor pagination is unavailable
+anyway — `shared::pagination::Cursor` is hardcoded to `(DateTime<Utc>, Uuid)`
+and cannot express graph order.
 
 ## Snapshots
 


### PR DESCRIPTION
## Summary

Adds contract dependency graphs and transitive risk analysis: consumers can now see how contracts depend on one another, and how a vulnerable, revoked, quarantined, or deprecated dependency propagates to everything downstream, with the exact dependency path named.

This is not a greenfield build. Roughly 4,200 lines of partially-overlapping dependency code already existed, and the foundation under it was broken in four verified ways:

1. **The primary endpoint could never succeed.** `GET /api/contracts/:id/dependencies` was mounted on a handler taking `Path<Uuid>` while the CLI sends a `C...` strkey, so axum rejected with **400 before any SQL ran**. And with a UUID it queried `contract_dependencies` — a table **no migration has ever created**. Eleven call sites referenced that phantom name under **two mutually incompatible schemas**; `migrations/062_add_dependency_type.sql` documents the phantom in its own comment.
2. **Every version publish silently wiped operator-declared dependencies.** `create_contract_version` scraped `type == "interface"` strings out of submitted ABI JSON and fed them to `save_dependencies`, whose first statement is `DELETE FROM contract_static_dependencies WHERE contract_id = $1`.
3. **Dependencies were resolved from arbitrary strings.** `resolve_contract_id` fell through to `SELECT id FROM contracts WHERE name = $1`. `contracts.name` has no UNIQUE constraint and the query was not network-scoped, so a mainnet contract could be bound as a dependency of a testnet one.
4. **Private and cross-tenant contracts would leak.** Any transitive walk without a tenancy predicate would expose private names, wasm hashes, and publisher IDs to any caller.

The result is one canonical, network-scoped, historically-preserved edge model; a single bounded recursive CTE replacing three N+1 walks; a risk report separating direct from inherited findings with the reaching path; and CLI commands with documented, stable JSON.

## Related Issue

Closes #1147

## Type of Change

- [x] Feature — new functionality
- [ ] Bug fix — fixes an issue without changing existing behavior
- [ ] Documentation — updates or adds documentation only
- [ ] Refactor — code restructuring with no behavior change
- [ ] Test — adds or updates tests only
- [ ] Chore — build, CI, or tooling changes

Primarily a feature, but it necessarily carries five bug fixes (listed under **Changes Made**), because the feature could not be built on the existing foundation without them.

## Changes Made

### Database — two migrations, both additive

- `20260819000000_issue1147_contract_interface_id.sql` — adds `contracts.interface_id` and `contracts.interface_algorithm` with a partial index.
- `20260819010000_issue1147_dependency_graph.sql` — adds `contract_dependency_edges` (canonical, network-scoped, bitemporal), the `dependency_edge_source` / `dependency_edge_state` enums, four indexes, a backfill from `contract_static_dependencies`, and a compatibility **VIEW literally named `contract_dependencies`** projecting the legacy static shape. **That view alone makes 8 of the 11 phantom-table call sites work with zero Rust changes.**
- `contract_static_dependencies` (migration 006) is retained as the write-through source and is **not** migrated, so the six live endpoints backed by `build_dependency_graph` carry no regression risk.
- `contract_call_dependencies` (migration 007) is deliberately **not** backfilled: it has zero readers and zero writers, so it would contribute a permanently empty subtree.

### Backend — new modules

- `shared/src/dependency_graph.rs` (831 lines) — all pure logic: risk rule table, the `(severity, counts)` combinator, dedup / shortest-path, ordering, cycle segments, version-conflict resolution, budget clamping. In `shared` so the API, CLI, and verifier share one definition, and so it is covered with no database.
- `api/src/dependency_graph.rs` (644 lines) — the bounded `WITH RECURSIVE` traversal (the first in this repo), forward and reverse.
- `api/src/dependency_risk.rs` (510 lines) — propagation with provenance; one traversal then one batched query per risk source, so query count is constant in graph size.
- `api/src/contract_ref.rs` (153 lines) — UUID-or-strkey resolution with 409 on ambiguity.
- `api/src/interface_id.rs` (50 lines) — thin persistence adapter over the shared fingerprint.

### Backend — endpoints

| Method | Path | Notes |
| --- | --- | --- |
| GET | `/api/contracts/:id/dependencies` | rebuilt on the CTE; was 400/500 |
| GET | `/api/contracts/:id/dependents` | repointed off the phantom table |
| GET | `/api/contracts/:id/dependency-graph` | new; counts, diagnostics, truncation, paginated node list |
| GET | `/api/contracts/:id/dependency-risk` | new; direct vs inherited findings with paths |

- `GET /api/contracts/:id/snapshot?include_dependency_graph=true` embeds the risk report and raises the payload to **schema 1.1**.
- Deleted three unrouted handlers that queried both the phantom table *and* `cd.dep_type` (doubly unroutable), plus a dead `handlers::get_contract_dependencies`.
- Fixed `openapi.rs`, which documented a handler that was not the one mounted.
- `DependencyResponse` / `DependencyNode` kept **field-stable** — `graphql/types.rs` resolves `Contract.dependencies` through them.
- `ContractGetResponse` and the publish response body are **untouched**: `interface_id` is stored as a column but deliberately not added to `shared::models::Contract`.

### Backend — bug fixes required by the feature

- **`fix(verifier)`** — `deps.rs` seeded in-degree from the *dependent* count then decremented *dependents*, reporting acyclic graphs as circular. Three failing tests go green. Also handles duplicate dependency entries.
- **`fix(api)`** — removed the ABI-string scraper and its call site; a version publish no longer touches dependencies at all.
- **`fix(api)`** — `resolve_contract_id` replaced by `resolve_dependency_target` (strkey-only, network-scoped) plus `lookup_contract_by_identifier` for general path lookups; dropped name resolution and the unchecked `Uuid::parse_str` fast path that returned an id for a row that did not exist.
- **`fix(api)`** — `save_dependencies` delete-then-insert now runs in **one transaction**; previously a mid-loop failure left a truncated dependency set with no signal.
- **`fix(cli)`** — registered the orphaned `publisher` module (`src/publisher.rs` existed but `mod publisher;` was never added, so the binary did not compile); added the missing `wasm_artifact_base64`; replaced three `U+2713` glyphs that fail the no-emoji gate.

### CLI

- `contract dependencies <ADDRESS>` / `contract dependents <ADDRESS>` — `--network`, `--transitive`, `--depth`, `--include-telemetry`, `--json`.
- `contract dependency-risk <ADDRESS>` — `--fail-on low|medium|high|critical`, exits 1 when overall risk meets or exceeds the level.
- Positional address, matching all 18 existing `contract` subcommands.
- Added a non-mutating `auth::session_diagnostics()` so `publisher doctor` reports session state without refreshing it.

### Documentation

- `docs/dependency-graph.md` (446 lines) — endpoint contract, resolution table, edge model, traversal guarantees, response shapes, the full risk rule table, and the propagation rules. This is itself an acceptance criterion for the issue.
- `ASSUMPTIONS.md` — every judgement call, plus pre-existing problems found and deliberately not fixed.

## How Has This Been Tested?

Against a disposable `postgres:16` container and a real `api` process. Not mocks — the interesting behaviour lives in a recursive CTE and in SQL three-valued logic, neither of which a mock exercises.

### Test Commands

```bash
# Pure rules, no database
cd backend && cargo test -p shared            # 150 passed
cargo test -p verifier --lib                  # 32 passed (was 29 pass / 3 fail)
cargo test -p api --test dependency_tests     # 6 passed

# Live HTTP + real Postgres
docker run -d --name sr-test-pg -e POSTGRES_PASSWORD=postgres \
  -e POSTGRES_DB=soroban_registry -p 5432:5432 postgres:16
export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/soroban_registry"
export JWT_SECRET="test-jwt-secret-at-least-32-characters-long"
export ELASTICSEARCH_URL="http://localhost:9200"
export RATE_LIMIT_IP_PER_MINUTE=100000 RATE_LIMIT_ANON_PER_MINUTE=100000
cargo run --bin api &
export TEST_API_BASE_URL="http://localhost:3001"
cargo test --test dependency_graph_tests -- --ignored --test-threads=1   # 35 passed

# CLI, no registry required
cd cli && cargo test --test contract_dependency_graph_tests              # 10 passed

# CI gates, replayed locally
bash .github/scripts/validate-migrations.sh
cd cli/imported && cargo fmt --all --check \
  && cargo build --release --target wasm32-unknown-unknown --locked \
  && cargo test --locked
```

### Test Coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing completed

### Testing Notes

**90 tests added or rewritten**, split by where the behaviour actually lives:

| Suite | Count | Covers |
| --- | --- | --- |
| `shared::dependency_graph` | 27 | rule table, combinator, dedup/shortest-path, ordering, cycles, version conflicts, budget clamping |
| `shared::interface_fingerprint::wasm_tests` | 7 | fingerprint derivation from hand-encoded XDR, no `stellar-xdr` dependency |
| `shared::snapshot` | 5 new | schema 1.0 vs 1.1, and that dropping the graph field breaks the signature |
| `api/tests/dependency_graph_tests.rs` | 35 | live HTTP against real Postgres |
| `api/tests/dependency_tests.rs` | 6 | rewritten |
| `cli/tests/contract_dependency_graph_tests.rs` | 10 | black-box subprocess |

Acceptance cases all covered: empty graphs, 4-deep chains, cycles, diamonds with duplicate edges, conflicting `^1.0.0` vs `^2.0.0`, revoked dependencies, vulnerability propagation, private/cross-org redaction, pagination boundary stability, and byte-identical output across repeated calls.

**`api/tests/dependency_tests.rs` was rewritten, not extended.** It asserted against helper functions defined in the file itself — including `get_transitive_dependencies_in_memory`, whose entire body was `vec![]`, and a check that a version-constraint string is non-empty. None of it exercised shipping code, so it passed regardless of what the implementation did. It now tests the real shared functions.

**Five defects were found by testing, not by compiling:**

1. `ON DELETE SET NULL` on `target_contract_id` (as originally designed) is unimplementable — it fires as an UPDATE, violates the `edge_state='resolved' => target IS NOT NULL` check, and made it impossible to delete any contract something depended on. Changed to CASCADE.
2. SQL three-valued logic broke the tenancy predicate: `c.organization_id = $5` is NULL (not false) when either side is NULL, so `visible` came back NULL for a private contract read by a caller with no organization — which neither decodes as `bool` nor means "hidden". Fixed with COALESCE.
3. The first CTE silently dropped unresolved edges below depth 1 and never reported cycles, because the guard prevented the row that would prove the loop. Restructured to carry `terminal` and `cycle_with`.
4. Tree nesting keyed on parent contract id duplicated shared subtrees in a diamond. Re-keyed on parent path.
5. Pagination was specified and documented but never implemented. Caught during a post-merge self-review; now implemented on `/dependency-graph` with six tests.

## Screenshots / Recordings

Not applicable — backend and CLI only, no frontend changes.

## Checklist

- [x] My code follows the project's [style guidelines](CONTRIBUTING.md#code-standards)
- [x] I have performed a self-review of my code
- [x] I have added/updated comments for complex logic
- [x] I have updated documentation where applicable
- [ ] My changes generate no new warnings (`cargo clippy`, `pnpm lint`) — **see note**
- [x] I have added tests that prove my fix/feature works
- [ ] All existing tests pass locally (`cargo test`, `pnpm test`) — **see note**
- [ ] My branch is rebased on the latest `main` with no merge conflicts — **see note**
- [ ] I have not introduced any breaking changes (or have documented them above) — **behaviour changes, documented below**

Four boxes are deliberately unchecked rather than glossed:

- **Warnings.** `cargo clippy --workspace` reports **0 errors**, but the new modules add **6 `result_large_err` warnings** on `ApiError` — the same pattern as every other handler in the tree (the `api` lib carries ~780 warnings on `main`). No new warning categories.
- **`cargo test`.** The full command does not pass, and did not before this PR: the `api` lib-test target and two CLI test targets fail to compile on `main` today (documented in `CLAUDE.md`). I verified `cargo check --workspace --all-targets` produces an **error set byte-identical to `main`** for both `backend` and `cli`, so this PR introduces none of it. Every suite that *can* run does pass.
- **Rebase.** The branch was **merged** with `main` (`ed65e33`), not rebased, to keep the 18-commit narrative reviewable. Two conflicts occurred and were resolved by integration — see **Additional Context**.
- **Breaking changes.** No wire-format breaks, but three behaviour changes, documented below.

## Additional Context

### Behaviour changes reviewers should know about

1. **A version publish no longer touches dependencies.** The response body is unchanged, so this will not show up in a diff of the publish contract — but it is the fix for defect (2), and reviewers should not read it as violating the "publish response unchanged" acceptance criterion.
2. **Name-based dependency resolution is gone.** Legacy rows that resolved by name are backfilled as `unresolved` rather than silently rebound; the recorded binding cannot be trusted, and re-deriving one from the same ambiguous name would repeat the defect.
3. **Two live response bodies change shape.** `/api/contracts/:id/interoperability` previously returned 200 with a degraded warning (the error was caught); edges now appear and the warning disappears. GraphQL `Contract.dependencies` previously errored.

### Design decisions worth a reviewer's attention

- **Findings and diagnostics are separate arrays.** Findings carry a severity; diagnostics do not. A cycle or an unresolved edge is a fact about the graph, not a security condition — if they carried severity, `max()` would drag every cyclic graph to at least Low, "zero findings" would be unreachable, and the report would be useless as a CI gate.
- **Risk is `(effective_severity, counts)` compared lexicographically, not `max()`.** A bare `max()` ranks one High identically to forty Highs. Severity is ordinal, so summing is meaningless — forty Highs must never add up to a Critical.
- **Interface incompatibility needed a data source that did not exist.** `fingerprint_spec` had exactly one consumer (the CLI, on a local file) and there was no column. That is why persisting `interface_id` lands first: without it every `expected_interface_id` would be NULL and the rule could never fire.
- **Telemetry edges are live-derived, never materialized.** `contract_call_edge_daily_aggregates` is upserted on every contract invocation; copying it into the bitemporal table would add a supersede-and-insert to the hottest write path in the system for zero information gain. Consequence: `as_of` replays declared edges to the instant and telemetry by day.
- **A private node stops the traversal**, it is not merely redacted in the output. Otherwise a caller could learn what a private contract depends on, which is nearly as revealing as the node itself. The redacted placeholder still keeps `total_dependencies` honest.
- **`statement_timeout` is not redundant with the node cap.** Dropping an axum future does not cancel an in-flight sqlx query — the Postgres backend keeps running and the pooled connection stays checked out.
- **Snapshot schema 1.1 is not cosmetic.** `SnapshotPayload` has no `deny_unknown_fields`, so an older CLI handed a graph-bearing payload claiming to be 1.0 would drop the field, recanonicalize, and report **"signature invalid"** — telling an operator their snapshot was tampered with. With a distinct version it returns `UnsupportedSchema("1.1")`: true and actionable. The version is derived from payload content, so a graph-bearing snapshot cannot claim to be 1.0.

### Migration landmine

`062_add_dependency_type.sql` runs `ALTER TABLE contract_dependencies ...` when `to_regclass(...)` is non-NULL. **`ALTER TABLE` against a view fails.** Lexicographic ordering puts `062_` before `20260819010000_`, so on a fresh database 062 sees nothing and no-ops. Anyone who renumbers or squashes migrations such that 062 runs *after* this one will break their deploy. There is a comment saying so in the new migration. 062's import/call/data taxonomy survives as `dep_kind`.

### Merge conflicts and how they were resolved

- **`cli/src/contract_register.rs`** — genuine semantic clash. Both branches fixed the same missing `wasm_artifact_base64`: this one reads and base64-encodes the WASM when the draft supplies `wasm_path`; `main` hardcoded `None` with "there is no artifact to upload." That premise only holds for the hash-only case — `RegistrationDraft.wasm_path` exists and `resolve_wasm_hash` already reads it. Kept the superset and folded `main`'s rationale into the comment. Hardcoding `None` would mean batch-registered contracts never get an interface fingerprint, silently disabling incompatibility detection for that path.
- **`cli/src/main.rs`** — trivial; both added a `mod` line at the same spot, kept both.
- **One silent loss the auto-merge did not flag:** git cleanly merged `main.rs` but **dropped the `Commands::Publisher` dispatch arm**, because `main` rewrote the tail of that `match`. It surfaced only as a non-exhaustive-match error. Restored, and every other addition was then audited.

### Pre-existing problems found, deliberately not fixed

Flagging the significant one:

- **`sqlx migrate` cannot apply this migration set to a fresh database.** Two pairs of existing migrations share a numeric prefix (`20260726000000_*`, `20260727000001_*`), and sqlx keys by that prefix, so the API aborts on boot against an empty DB with `duplicate key value violates unique constraint "_sqlx_migrations_pkey"`. **Reproduced on `main` at `6f1306d`.** CI validates filename format and ordering but not uniqueness. The two migrations added here have unique prefixes and sort last, so they are not implicated — the failure happens before they are reached. Verification here applied migrations directly via `psql`.
- The `openapi` cargo feature is broken (`SwaggerUi`/axum mismatch at `routes.rs:852`); the dependency handler entries now resolve correctly, but the feature still does not build.
- GraphQL is never mounted — `routes::application_routes` takes `_schema` and never uses it, so `Contract.dependencies` is unreachable over HTTP. The resolver is corrected and compiles but could not be exercised end to end.
- The `notify_security_issue` trigger references `sub.` inside the query that defines `sub`, so any `INSERT INTO security_issues` fails. The integration test disables it around its seed.
- `backend/Cargo.lock` carries a stale orphan `registry_client` entry (the crate's package name is `soroban-registry-client`) that `cargo check` prunes. Pre-existing from #1157; left alone.

### Follow-ups this PR deliberately leaves open

- `build_dependency_graph` and its six live endpoints still read `contract_static_dependencies`. Migrating them onto the new edge model is a separate change with real regression risk.
- The CLI's new `registry.rs` client says every command should go through it, but only 5 of 39 modules do, and `registry_client` has no typed methods for these four endpoints. When that migration finishes, these commands should move too.
- With #1143's compatibility engine now landed, `interface_incompatibility` could report *breaking* vs *potentially breaking* instead of a blanket High, if the registry retained the historical spec.


