### PR TITLE
fix: canonicalize WASM artifact verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
               - 'backend/**/*.rs'
               - 'backend/Cargo.toml'
               - 'backend/Cargo.lock'
+              - 'cli/imported/**'
               - 'soroban-registry/**/*.rs'
               - 'soroban-registry/Cargo.toml'
               - 'soroban-registry/Cargo.lock'
@@ -34,6 +35,43 @@ jobs:
               - 'frontend/**'
 
   # Rust backend checks removed: fmt, clippy, test, build (not having effect)
+
+  artifact-reproducibility:
+    name: WASM artifact reproducibility boundary
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup show
+          rustup target add wasm32-unknown-unknown
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: backend
+      - name: Compare canonical double-build fixtures
+        run: |
+          set -euo pipefail
+          CARGO_TARGET_DIR="${RUNNER_TEMP}/fixture-build-one" \
+            cargo build --locked --manifest-path cli/imported/Cargo.toml \
+              --release --target wasm32-unknown-unknown
+          CARGO_TARGET_DIR="${RUNNER_TEMP}/fixture-build-two" \
+            cargo build --locked --manifest-path cli/imported/Cargo.toml \
+              --release --target wasm32-unknown-unknown
+          cargo run --manifest-path backend/Cargo.toml -p shared \
+            --example compare_canonical_wasm -- \
+            "${RUNNER_TEMP}/fixture-build-one/wasm32-unknown-unknown/release/hello_world.wasm" \
+            "${RUNNER_TEMP}/fixture-build-two/wasm32-unknown-unknown/release/hello_world.wasm"
+
+      - name: Run artifact-boundary regressions
+        working-directory: backend
+        run: |
+          cargo test -p shared wasm::tests
+          cargo test -p shared interface_fingerprint::wasm_tests
+          cargo test -p verifier artifact_verification
+          cargo check -p api --lib
 
   # Frontend checks removed: lint, test, build (push) — not running in CI
 

--- a/backend/api/src/batch_verify_handlers.rs
+++ b/backend/api/src/batch_verify_handlers.rs
@@ -274,7 +274,7 @@ async fn run_single_item(
     .map(|v| v.to_string());
 
     let on_chain = match onchain_verifier
-        .verify_contract(&state.cache, &contract, abi_json.as_deref())
+        .verify_contract_with_artifact(&state.cache, &contract, abi_json.as_deref())
         .await
     {
         Ok(r) => r,
@@ -292,14 +292,28 @@ async fn run_single_item(
 
     let source_ok = match (&item.source_code, &item.compiler_version) {
         (Some(src), Some(ver)) if !src.trim().is_empty() => {
-            match verifier::verify_contract(
-                src,
-                &contract.wasm_hash,
-                Some(ver),
-                item.build_params.as_ref(),
-            )
-            .await
-            {
+            let verification = match on_chain.deployed_wasm.as_deref() {
+                Some(deployed_wasm) => {
+                    verifier::verify_contract_artifact(
+                        src,
+                        deployed_wasm,
+                        &contract.wasm_hash,
+                        Some(ver),
+                        item.build_params.as_ref(),
+                    )
+                    .await
+                }
+                None => {
+                    verifier::verify_contract(
+                        src,
+                        &contract.wasm_hash,
+                        Some(ver),
+                        item.build_params.as_ref(),
+                    )
+                    .await
+                }
+            };
+            match verification {
                 Ok(r) => r.verified,
                 Err(_) => false,
             }
@@ -420,7 +434,7 @@ async fn verify_batch_item(
     .map(|value| value.to_string());
 
     let on_chain = match onchain_verifier
-        .verify_contract(&state.cache, &contract, abi_json.as_deref())
+        .verify_contract_with_artifact(&state.cache, &contract, abi_json.as_deref())
         .await
     {
         Ok(result) => result,
@@ -434,15 +448,29 @@ async fn verify_batch_item(
     };
 
     let source_verification = match (&item.source_code, &item.compiler_version) {
-        (Some(source_code), Some(compiler_version)) if !source_code.trim().is_empty() => Some(
-            verifier::verify_contract(
-                source_code,
-                &contract.wasm_hash,
-                Some(compiler_version),
-                item.build_params.as_ref(),
-            )
-            .await,
-        ),
+        (Some(source_code), Some(compiler_version)) if !source_code.trim().is_empty() => {
+            Some(match on_chain.deployed_wasm.as_deref() {
+                Some(deployed_wasm) => {
+                    verifier::verify_contract_artifact(
+                        source_code,
+                        deployed_wasm,
+                        &contract.wasm_hash,
+                        Some(compiler_version),
+                        item.build_params.as_ref(),
+                    )
+                    .await
+                }
+                None => {
+                    verifier::verify_contract(
+                        source_code,
+                        &contract.wasm_hash,
+                        Some(compiler_version),
+                        item.build_params.as_ref(),
+                    )
+                    .await
+                }
+            })
+        }
         _ => None,
     };
 
@@ -468,7 +496,8 @@ async fn verify_batch_item(
                 "compiled_wasm_hash": v.compiled_wasm_hash,
                 "deployed_wasm_hash": v.deployed_wasm_hash,
                 "message": v.message,
-                "failure_kind": v.failure_kind
+                "failure_kind": v.failure_kind,
+                "match_kind": v.match_kind
             }),
             Err(err) => json!({
                 "verified": false,

--- a/backend/api/src/handlers.rs
+++ b/backend/api/src/handlers.rs
@@ -5961,18 +5961,43 @@ pub async fn verify_contract(
     .await
     .map_err(|err| db_internal_error("insert verification record", err))?;
 
-    let verification_result = verifier::verify_contract(
-        &req.source_code,
-        &contract.wasm_hash,
-        Some(&req.compiler_version),
-        Some(&req.build_params),
-    )
-    .await;
     let onchain_verifier = OnChainVerifier::new();
     let abi_json = resolve_abi(&state, &contract.contract_id, false).await.ok();
     let onchain_result = onchain_verifier
-        .verify_contract(&state.cache, &contract, abi_json.as_deref())
+        .verify_contract_with_artifact(&state.cache, &contract, abi_json.as_deref())
         .await;
+    let verification_result = match &onchain_result {
+        Ok(onchain) => match onchain.deployed_wasm.as_deref() {
+            Some(deployed_wasm) => {
+                verifier::verify_contract_artifact(
+                    &req.source_code,
+                    deployed_wasm,
+                    &contract.wasm_hash,
+                    Some(&req.compiler_version),
+                    Some(&req.build_params),
+                )
+                .await
+            }
+            None => {
+                verifier::verify_contract(
+                    &req.source_code,
+                    &contract.wasm_hash,
+                    Some(&req.compiler_version),
+                    Some(&req.build_params),
+                )
+                .await
+            }
+        },
+        Err(_) => {
+            verifier::verify_contract(
+                &req.source_code,
+                &contract.wasm_hash,
+                Some(&req.compiler_version),
+                Some(&req.build_params),
+            )
+            .await
+        }
+    };
 
     let ip_address = extract_ip_address(&headers);
     let before_status = previous_status.unwrap_or_else(|| "pending".to_string());
@@ -6009,7 +6034,8 @@ pub async fn verify_contract(
                 "compiler_version": { "before": Value::Null, "after": req.compiler_version },
                 "verified_at": { "before": Value::Null, "after": chrono::Utc::now() },
                 "compiled_wasm_hash": { "before": Value::Null, "after": result.compiled_wasm_hash },
-                "deployed_wasm_hash": { "before": Value::Null, "after": result.deployed_wasm_hash }
+                "deployed_wasm_hash": { "before": Value::Null, "after": result.deployed_wasm_hash },
+                "match_kind": { "before": Value::Null, "after": result.match_kind }
             });
 
             write_contract_audit_log(
@@ -6091,6 +6117,7 @@ pub async fn verify_contract(
                 "contract_id": contract.id,
                 "compiled_wasm_hash": result.compiled_wasm_hash,
                 "deployed_wasm_hash": result.deployed_wasm_hash,
+                "match_kind": result.match_kind,
                 "on_chain": onchain
             })))
         }
@@ -6132,7 +6159,8 @@ pub async fn verify_contract(
                 "compiler_version": { "before": Value::Null, "after": req.compiler_version },
                 "error_message": { "before": Value::Null, "after": failure_message },
                 "compiled_wasm_hash": { "before": Value::Null, "after": result.compiled_wasm_hash },
-                "deployed_wasm_hash": { "before": Value::Null, "after": result.deployed_wasm_hash }
+                "deployed_wasm_hash": { "before": Value::Null, "after": result.deployed_wasm_hash },
+                "match_kind": { "before": Value::Null, "after": result.match_kind }
             });
             write_contract_audit_log(
                 &state.db,

--- a/backend/api/src/onchain_verification.rs
+++ b/backend/api/src/onchain_verification.rs
@@ -92,6 +92,10 @@ pub struct OnChainVerificationResult {
     /// Structured failure reasons collected during verification.
     /// Empty when verification passes; contains at least one entry on failure.
     pub failure_reasons: Vec<OnChainFailureReason>,
+    /// Raw contract code used as source-verification evidence. It is never
+    /// serialized into API responses or the verification cache.
+    #[serde(skip)]
+    pub(crate) deployed_wasm: Option<Vec<u8>>,
 }
 
 impl OnChainVerificationResult {
@@ -219,6 +223,7 @@ impl OnChainVerifier {
                     abi_matches_deployed_contract: false,
                     warnings,
                     failure_reasons,
+                    deployed_wasm: None,
                 };
                 cache
                     .put_verification(
@@ -360,6 +365,7 @@ impl OnChainVerifier {
             abi_matches_deployed_contract,
             warnings,
             failure_reasons,
+            deployed_wasm: on_chain_code_bytes,
         };
 
         cache
@@ -374,6 +380,33 @@ impl OnChainVerifier {
             )
             .await;
 
+        Ok(result)
+    }
+
+    /// Run the on-chain checks and retain the fetched contract bytes for the
+    /// source verifier. Cached public results are hydrated with a fresh code
+    /// lookup because artifact bytes are intentionally excluded from cache.
+    pub(crate) async fn verify_contract_with_artifact(
+        &self,
+        cache: &CacheLayer,
+        contract: &Contract,
+        abi_json: Option<&str>,
+    ) -> Result<OnChainVerificationResult, RegistryError> {
+        let mut result = self.verify_contract(cache, contract, abi_json).await?;
+        if result.deployed_wasm.is_none() {
+            if let Some(wasm_hash) = result.on_chain_wasm_hash.as_deref() {
+                let config = NetworkConfig::from_env(&contract.network);
+                match self.fetch_contract_code_entry(&config, wasm_hash).await {
+                    Ok(Some((bytes, _))) => result.deployed_wasm = Some(bytes),
+                    Ok(None) => result.warnings.push(
+                        "On-chain contract code was unavailable for source comparison".to_string(),
+                    ),
+                    Err(err) => result.warnings.push(format!(
+                        "On-chain contract code could not be refreshed for source comparison: {err}"
+                    )),
+                }
+            }
+        }
         Ok(result)
     }
 

--- a/backend/shared/examples/compare_canonical_wasm.rs
+++ b/backend/shared/examples/compare_canonical_wasm.rs
@@ -1,0 +1,40 @@
+use std::{env, fs, process::ExitCode};
+
+use shared::wasm::{canonical_wasm_hash_v1, CANONICAL_WASM_HASH_V1};
+
+fn main() -> ExitCode {
+    let paths = env::args().skip(1).collect::<Vec<_>>();
+    if paths.len() != 2 {
+        eprintln!("usage: compare_canonical_wasm <first.wasm> <second.wasm>");
+        return ExitCode::FAILURE;
+    }
+
+    let read =
+        |path: &str| fs::read(path).map_err(|err| format!("failed to read artifact {path}: {err}"));
+    let result = (|| {
+        let first = read(&paths[0])?;
+        let second = read(&paths[1])?;
+        let first_hash = canonical_wasm_hash_v1(&first)
+            .map_err(|err| format!("failed to canonicalize {}: {err}", paths[0]))?;
+        let second_hash = canonical_wasm_hash_v1(&second)
+            .map_err(|err| format!("failed to canonicalize {}: {err}", paths[1]))?;
+
+        println!("algorithm={CANONICAL_WASM_HASH_V1}");
+        println!("raw_equal={}", first == second);
+        println!("first_canonical_hash={first_hash}");
+        println!("second_canonical_hash={second_hash}");
+
+        if first_hash != second_hash {
+            return Err("independent builds differ inside the V1 trust boundary".to_string());
+        }
+        Ok(())
+    })();
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("{err}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/backend/shared/src/interface_fingerprint.rs
+++ b/backend/shared/src/interface_fingerprint.rs
@@ -381,6 +381,18 @@ mod wasm_tests {
     }
 
     #[test]
+    fn toolchain_metadata_drift_does_not_change_interface_id() {
+        let base = wasm_with_spec_section(&function_entry_xdr("transfer"));
+        let first = append_custom_section(base.clone(), "producers", b"build-one");
+        let second = append_custom_section(base, "producers", b"build-two");
+
+        assert_eq!(
+            fingerprint_wasm(&first).unwrap().interface_id,
+            fingerprint_wasm(&second).unwrap().interface_id
+        );
+    }
+
+    #[test]
     fn empty_spec_section_is_not_an_interface() {
         let wasm = wasm_with_spec_section(&[]);
         assert!(matches!(
@@ -433,6 +445,16 @@ mod wasm_tests {
         out.extend_from_slice(&leb128(body.len() as u64));
         out.extend_from_slice(&body);
         out
+    }
+
+    fn append_custom_section(mut wasm: Vec<u8>, name: &str, payload: &[u8]) -> Vec<u8> {
+        let mut body = leb128(name.len() as u64);
+        body.extend_from_slice(name.as_bytes());
+        body.extend_from_slice(payload);
+        wasm.push(0);
+        wasm.extend_from_slice(&leb128(body.len() as u64));
+        wasm.extend_from_slice(&body);
+        wasm
     }
 
     fn leb128(mut value: u64) -> Vec<u8> {

--- a/backend/shared/src/wasm.rs
+++ b/backend/shared/src/wasm.rs
@@ -5,7 +5,8 @@
 //! local `contract verify` command, so both apply identical checks.
 
 use serde::{Deserialize, Serialize};
-use wasmparser::Parser;
+use sha2::{Digest, Sha256};
+use wasmparser::{Parser, Validator};
 
 /// Soroban embeds its contract spec (the ABI) in a custom WASM section with
 /// this name. Its presence is what distinguishes a deployable Soroban contract
@@ -13,6 +14,123 @@ use wasmparser::Parser;
 pub const CONTRACT_SPEC_SECTION: &str = "contractspecv0";
 /// Custom section carrying the environment/SDK metadata (interface version).
 pub const CONTRACT_ENV_META_SECTION: &str = "contractenvmetav0";
+
+/// Identifier for the first canonical contract-artifact hashing scheme.
+///
+/// V1 removes only the standard debug/toolchain custom sections `name` and
+/// `producers`. All executable sections, Soroban metadata, and unknown custom
+/// sections remain byte-for-byte unchanged.
+pub const CANONICAL_WASM_HASH_V1: &str = "soroban-registry-wasm-canonical-v1";
+
+const CANONICAL_V1_IGNORED_CUSTOM_SECTIONS: [&str; 2] = ["name", "producers"];
+
+/// Error returned when an artifact cannot be safely canonicalized.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CanonicalWasmError {
+    InvalidWasm(String),
+    InvalidSectionEncoding,
+    InvalidCustomSectionName,
+}
+
+impl std::fmt::Display for CanonicalWasmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidWasm(detail) => write!(f, "invalid wasm: {detail}"),
+            Self::InvalidSectionEncoding => write!(f, "invalid wasm section encoding"),
+            Self::InvalidCustomSectionName => write!(f, "invalid custom section name"),
+        }
+    }
+}
+
+impl std::error::Error for CanonicalWasmError {}
+
+/// Produce the V1 canonical representation used only as a secondary,
+/// metadata-tolerant comparison.
+///
+/// The original artifact hash remains the authority for identifying deployed
+/// code. This function deliberately does not modify code, data, imports,
+/// exports, `contractspecv0`, `contractenvmetav0`, or unknown custom sections.
+pub fn canonicalize_wasm_v1(wasm_bytes: &[u8]) -> Result<Vec<u8>, CanonicalWasmError> {
+    Validator::new()
+        .validate_all(wasm_bytes)
+        .map_err(|err| CanonicalWasmError::InvalidWasm(err.to_string()))?;
+
+    const WASM_V1_HEADER: &[u8; 8] = b"\0asm\x01\0\0\0";
+    if !wasm_bytes.starts_with(WASM_V1_HEADER) {
+        return Err(CanonicalWasmError::InvalidWasm(
+            "expected a core WebAssembly v1 module".to_string(),
+        ));
+    }
+
+    let mut canonical = Vec::with_capacity(wasm_bytes.len());
+    canonical.extend_from_slice(WASM_V1_HEADER);
+    let mut cursor = WASM_V1_HEADER.len();
+
+    while cursor < wasm_bytes.len() {
+        let section_start = cursor;
+        let section_id = *wasm_bytes
+            .get(cursor)
+            .ok_or(CanonicalWasmError::InvalidSectionEncoding)?;
+        cursor += 1;
+
+        let section_len = read_u32_leb(wasm_bytes, &mut cursor)? as usize;
+        let payload_start = cursor;
+        let section_end = payload_start
+            .checked_add(section_len)
+            .filter(|end| *end <= wasm_bytes.len())
+            .ok_or(CanonicalWasmError::InvalidSectionEncoding)?;
+
+        let ignored = if section_id == 0 {
+            let mut name_cursor = payload_start;
+            let name_len = read_u32_leb(wasm_bytes, &mut name_cursor)? as usize;
+            let name_end = name_cursor
+                .checked_add(name_len)
+                .filter(|end| *end <= section_end)
+                .ok_or(CanonicalWasmError::InvalidSectionEncoding)?;
+            let name = std::str::from_utf8(&wasm_bytes[name_cursor..name_end])
+                .map_err(|_| CanonicalWasmError::InvalidCustomSectionName)?;
+            CANONICAL_V1_IGNORED_CUSTOM_SECTIONS.contains(&name)
+        } else {
+            false
+        };
+
+        if !ignored {
+            canonical.extend_from_slice(&wasm_bytes[section_start..section_end]);
+        }
+        cursor = section_end;
+    }
+
+    Ok(canonical)
+}
+
+/// SHA-256 of [`canonicalize_wasm_v1`]. The algorithm identifier must be
+/// stored or transmitted alongside this value so future schemes cannot be
+/// confused with V1.
+pub fn canonical_wasm_hash_v1(wasm_bytes: &[u8]) -> Result<String, CanonicalWasmError> {
+    let canonical = canonicalize_wasm_v1(wasm_bytes)?;
+    let mut hasher = Sha256::new();
+    hasher.update(canonical);
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn read_u32_leb(bytes: &[u8], cursor: &mut usize) -> Result<u32, CanonicalWasmError> {
+    let mut value = 0u32;
+    for shift in (0..=28).step_by(7) {
+        let byte = *bytes
+            .get(*cursor)
+            .ok_or(CanonicalWasmError::InvalidSectionEncoding)?;
+        *cursor += 1;
+
+        if shift == 28 && byte & 0xf0 != 0 {
+            return Err(CanonicalWasmError::InvalidSectionEncoding);
+        }
+        value |= u32::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err(CanonicalWasmError::InvalidSectionEncoding)
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WasmValidationResult {
@@ -253,5 +371,71 @@ mod tests {
     #[test]
     fn extract_returns_none_when_section_absent() {
         assert!(extract_contract_spec_bytes(MINIMAL_WASM).is_none());
+    }
+
+    #[test]
+    fn canonical_hash_ignores_only_allowlisted_toolchain_metadata() {
+        let first_build =
+            with_custom_section_payload(MINIMAL_WASM.to_vec(), "producers", b"rustc-build-one");
+        let second_build =
+            with_custom_section_payload(MINIMAL_WASM.to_vec(), "producers", b"rustc-build-two");
+
+        assert_ne!(first_build, second_build);
+        assert_eq!(
+            canonical_wasm_hash_v1(&first_build).unwrap(),
+            canonical_wasm_hash_v1(&second_build).unwrap()
+        );
+        assert_eq!(canonicalize_wasm_v1(&first_build).unwrap(), MINIMAL_WASM);
+
+        let named_build = with_custom_section(MINIMAL_WASM.to_vec(), "name");
+        assert_eq!(canonicalize_wasm_v1(&named_build).unwrap(), MINIMAL_WASM);
+    }
+
+    #[test]
+    fn canonical_hash_preserves_soroban_and_unknown_custom_sections() {
+        for section_name in [
+            CONTRACT_SPEC_SECTION,
+            CONTRACT_ENV_META_SECTION,
+            "vendor-security-metadata",
+        ] {
+            let first =
+                with_custom_section_payload(MINIMAL_WASM.to_vec(), section_name, b"payload-one");
+            let second =
+                with_custom_section_payload(MINIMAL_WASM.to_vec(), section_name, b"payload-two");
+
+            assert_ne!(
+                canonical_wasm_hash_v1(&first).unwrap(),
+                canonical_wasm_hash_v1(&second).unwrap(),
+                "{section_name} must remain inside the trust boundary"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_hash_preserves_executable_code() {
+        let mut changed_instruction = MINIMAL_WASM.to_vec();
+        // Change the exported function body from `end` to `nop; end` while
+        // keeping the module valid and fixing both section/body lengths.
+        let code_section = changed_instruction
+            .iter()
+            .position(|byte| *byte == 0x0a)
+            .expect("fixture has a code section");
+        changed_instruction[code_section + 1] = 0x05;
+        changed_instruction[code_section + 3] = 0x03;
+        changed_instruction.insert(code_section + 5, 0x01);
+
+        Validator::new()
+            .validate_all(&changed_instruction)
+            .expect("mutated fixture should remain valid");
+        assert_ne!(
+            canonical_wasm_hash_v1(MINIMAL_WASM).unwrap(),
+            canonical_wasm_hash_v1(&changed_instruction).unwrap()
+        );
+    }
+
+    #[test]
+    fn canonicalization_fails_closed_for_malformed_wasm() {
+        let err = canonicalize_wasm_v1(b"not wasm").unwrap_err();
+        assert!(matches!(err, CanonicalWasmError::InvalidWasm(_)));
     }
 }

--- a/backend/verifier/src/lib.rs
+++ b/backend/verifier/src/lib.rs
@@ -7,7 +7,10 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use shared::RegistryError;
+use shared::{
+    wasm::{canonical_wasm_hash_v1, CANONICAL_WASM_HASH_V1},
+    RegistryError,
+};
 use std::process::Stdio;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -65,6 +68,17 @@ pub enum VerificationFailureKind {
     NetworkMismatch { network: String },
     /// No on-chain wasm artifact was found to verify against.
     MissingArtifact,
+    /// The supplied artifact bytes do not hash to the authoritative raw hash
+    /// recorded for the deployed contract. Canonical comparison must not run
+    /// when this trust-boundary check fails.
+    ArtifactHashMismatch {
+        expected_hash: String,
+        actual_hash: String,
+        hint: String,
+    },
+    /// Either the deployed or compiled bytes are not a structurally valid
+    /// core WASM module, so neither exact nor canonical verification is safe.
+    InvalidWasmArtifact { artifact: String, detail: String },
     /// The passphrase supplied (or recorded at publish time) does not match
     /// the passphrase used during this verification attempt.
     ///
@@ -89,6 +103,12 @@ impl std::fmt::Display for VerificationFailureKind {
                 write!(f, "network_mismatch: contract not found on {network}")
             }
             Self::MissingArtifact => write!(f, "missing_artifact: no on-chain artifact found"),
+            Self::ArtifactHashMismatch { hint, .. } => {
+                write!(f, "artifact_hash_mismatch: {hint}")
+            }
+            Self::InvalidWasmArtifact { artifact, detail } => {
+                write!(f, "invalid_wasm_artifact: {artifact}: {detail}")
+            }
             Self::PassphraseMismatch {
                 recorded, provided, ..
             } => {
@@ -102,6 +122,17 @@ impl std::fmt::Display for VerificationFailureKind {
     }
 }
 
+/// Describes how a compiled artifact matched the deployed artifact.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum VerificationMatchKind {
+    /// Raw SHA-256 hashes are identical.
+    Exact,
+    /// Raw hashes differ, but the artifacts match after applying the named,
+    /// versioned metadata-only canonicalization scheme.
+    CanonicalMetadataOnly { algorithm: String, hash: String },
+}
+
 #[derive(Debug, Clone)]
 pub struct VerificationResult {
     pub verified: bool,
@@ -110,6 +141,9 @@ pub struct VerificationResult {
     pub message: Option<String>,
     /// Structured failure reason; `None` when `verified` is `true`.
     pub failure_kind: Option<VerificationFailureKind>,
+    /// `None` for failures; otherwise records whether the raw artifacts or
+    /// their versioned metadata-only representations matched.
+    pub match_kind: Option<VerificationMatchKind>,
 }
 
 /// Outcome of a passphrase compatibility check.
@@ -178,6 +212,7 @@ pub async fn verify_contract(
             deployed_wasm_hash: deployed_normalized,
             message: None,
             failure_kind: None,
+            match_kind: Some(VerificationMatchKind::Exact),
         });
     }
 
@@ -198,6 +233,146 @@ pub async fn verify_contract(
         }),
         compiled_wasm_hash: compiled_hash,
         deployed_wasm_hash: deployed_normalized,
+        match_kind: None,
+    })
+}
+
+/// Verify source against the actual deployed artifact bytes.
+///
+/// Unlike [`verify_contract`], this entry point can safely distinguish
+/// non-semantic toolchain metadata drift from executable drift. It first
+/// proves that `deployed_wasm` hashes to the authoritative raw deployed hash;
+/// only then may it use the versioned metadata-only comparison as a fallback.
+#[instrument(
+    skip(source_code, deployed_wasm, build_params),
+    fields(component = "verifier", deployed_wasm_hash = %deployed_wasm_hash)
+)]
+pub async fn verify_contract_artifact(
+    source_code: &str,
+    deployed_wasm: &[u8],
+    deployed_wasm_hash: &str,
+    compiler_version: Option<&str>,
+    build_params: Option<&Value>,
+) -> Result<VerificationResult, RegistryError> {
+    if source_code.trim().is_empty() {
+        return Err(RegistryError::invalid_input(
+            "source_code cannot be empty".to_string(),
+        ));
+    }
+
+    let deployed_normalized = normalize_hash(deployed_wasm_hash).ok_or_else(|| {
+        RegistryError::invalid_input("deployed_wasm_hash must be a 64-char hex hash".to_string())
+    })?;
+    let actual_deployed_hash = hash_wasm(deployed_wasm);
+
+    if actual_deployed_hash != deployed_normalized {
+        let hint = "The fetched artifact bytes do not match the authoritative deployed SHA-256; \
+                    refusing canonical comparison."
+            .to_string();
+        return Ok(VerificationResult {
+            verified: false,
+            compiled_wasm_hash: String::new(),
+            deployed_wasm_hash: deployed_normalized.clone(),
+            message: Some(format!(
+                "Deployed artifact hash mismatch: expected {}, got {}. {hint}",
+                deployed_normalized, actual_deployed_hash
+            )),
+            failure_kind: Some(VerificationFailureKind::ArtifactHashMismatch {
+                expected_hash: deployed_normalized,
+                actual_hash: actual_deployed_hash,
+                hint,
+            }),
+            match_kind: None,
+        });
+    }
+
+    let deployed_canonical = match canonical_wasm_hash_v1(deployed_wasm) {
+        Ok(hash) => hash,
+        Err(err) => {
+            let detail = err.to_string();
+            return Ok(VerificationResult {
+                verified: false,
+                compiled_wasm_hash: String::new(),
+                deployed_wasm_hash: actual_deployed_hash,
+                message: Some(format!(
+                    "The authoritative deployed artifact is not valid canonicalizable WASM: \
+                     {detail}"
+                )),
+                failure_kind: Some(VerificationFailureKind::InvalidWasmArtifact {
+                    artifact: "deployed".to_string(),
+                    detail,
+                }),
+                match_kind: None,
+            });
+        }
+    };
+
+    let compiled_wasm = compile_contract(source_code, compiler_version, build_params).await?;
+    let compiled_hash = hash_wasm(&compiled_wasm);
+    if compiled_hash == actual_deployed_hash {
+        return Ok(VerificationResult {
+            verified: true,
+            compiled_wasm_hash: compiled_hash,
+            deployed_wasm_hash: actual_deployed_hash,
+            message: None,
+            failure_kind: None,
+            match_kind: Some(VerificationMatchKind::Exact),
+        });
+    }
+
+    let compiled_canonical = match canonical_wasm_hash_v1(&compiled_wasm) {
+        Ok(hash) => hash,
+        Err(err) => {
+            let detail = err.to_string();
+            return Ok(VerificationResult {
+                verified: false,
+                compiled_wasm_hash: compiled_hash,
+                deployed_wasm_hash: actual_deployed_hash,
+                message: Some(format!(
+                    "The compiled artifact is not valid canonicalizable WASM: {detail}"
+                )),
+                failure_kind: Some(VerificationFailureKind::InvalidWasmArtifact {
+                    artifact: "compiled".to_string(),
+                    detail,
+                }),
+                match_kind: None,
+            });
+        }
+    };
+    if compiled_canonical == deployed_canonical {
+        return Ok(VerificationResult {
+            verified: true,
+            compiled_wasm_hash: compiled_hash,
+            deployed_wasm_hash: actual_deployed_hash,
+            message: Some(format!(
+                "Raw hashes differ only in allowlisted toolchain metadata; matched with {}.",
+                CANONICAL_WASM_HASH_V1
+            )),
+            failure_kind: None,
+            match_kind: Some(VerificationMatchKind::CanonicalMetadataOnly {
+                algorithm: CANONICAL_WASM_HASH_V1.to_string(),
+                hash: compiled_canonical,
+            }),
+        });
+    }
+
+    let hint = "Check that the compiler version, build flags, source code, and all trust-boundary \
+         sections match the deployed artifact."
+        .to_string();
+    Ok(VerificationResult {
+        verified: false,
+        message: Some(format!(
+            "Bytecode mismatch: compiled hash {} does not match deployed hash {}. {hint}",
+            compiled_hash, actual_deployed_hash
+        )),
+        failure_kind: Some(VerificationFailureKind::SourceMismatch {
+            compiled_hash: compiled_hash.clone(),
+            deployed_hash: actual_deployed_hash.clone(),
+            hint,
+        }),
+        compiled_wasm_hash: compiled_hash,
+        deployed_wasm_hash: actual_deployed_hash,
+        match_kind: None,
     })
 }
 
@@ -249,6 +424,7 @@ pub async fn verify_contract_with_passphrase(
                     provided: provided.clone(),
                     hint,
                 }),
+                match_kind: None,
             });
         }
         PassphraseCheckOutcome::Pass => {}
@@ -414,6 +590,24 @@ fn truncate_for_error(value: &str) -> String {
 mod tests {
     use super::*;
 
+    const MINIMAL_WASM: &[u8] = &[
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // header
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // type: () -> ()
+        0x03, 0x02, 0x01, 0x00, // function
+        0x07, 0x05, 0x01, 0x01, b'f', 0x00, 0x00, // export
+        0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b, // code
+    ];
+
+    fn with_custom_section(mut wasm: Vec<u8>, name: &str, payload: &[u8]) -> Vec<u8> {
+        assert!(name.len() < 128 && name.len() + payload.len() + 1 < 128);
+        wasm.push(0);
+        wasm.push((name.len() + payload.len() + 1) as u8);
+        wasm.push(name.len() as u8);
+        wasm.extend_from_slice(name.as_bytes());
+        wasm.extend_from_slice(payload);
+        wasm
+    }
+
     #[tokio::test]
     async fn test_verify_contract_invalid_hash() {
         let result = verify_contract("fn main() {}", "invalid_hash", None, None).await;
@@ -452,6 +646,145 @@ mod tests {
             .as_deref()
             .unwrap_or_default()
             .contains("Bytecode mismatch"));
+    }
+
+    #[tokio::test]
+    async fn artifact_verification_accepts_allowlisted_metadata_only_drift() {
+        let compiled = with_custom_section(MINIMAL_WASM.to_vec(), "producers", b"rustc-build-one");
+        let deployed = with_custom_section(MINIMAL_WASM.to_vec(), "producers", b"rustc-build-two");
+        let source = format!("wasm_base64:{}", BASE64.encode(&compiled));
+        let deployed_hash = hash_wasm(&deployed);
+
+        let result = verify_contract_artifact(&source, &deployed, &deployed_hash, None, None)
+            .await
+            .expect("metadata-only comparison should complete");
+
+        assert!(result.verified);
+        assert_ne!(result.compiled_wasm_hash, result.deployed_wasm_hash);
+        assert!(matches!(
+            result.match_kind,
+            Some(VerificationMatchKind::CanonicalMetadataOnly { ref algorithm, .. })
+                if algorithm == CANONICAL_WASM_HASH_V1
+        ));
+        assert!(result.failure_kind.is_none());
+    }
+
+    #[tokio::test]
+    async fn artifact_verification_rejects_executable_drift() {
+        let compiled = MINIMAL_WASM.to_vec();
+        let mut deployed = MINIMAL_WASM.to_vec();
+        let code_section = deployed
+            .iter()
+            .position(|byte| *byte == 0x0a)
+            .expect("fixture has code section");
+        deployed[code_section + 1] = 0x05;
+        deployed[code_section + 3] = 0x03;
+        deployed.insert(code_section + 5, 0x01); // nop
+        let source = format!("wasm_base64:{}", BASE64.encode(&compiled));
+        let deployed_hash = hash_wasm(&deployed);
+
+        let result = verify_contract_artifact(&source, &deployed, &deployed_hash, None, None)
+            .await
+            .expect("executable comparison should complete");
+
+        assert!(!result.verified);
+        assert!(matches!(
+            result.failure_kind,
+            Some(VerificationFailureKind::SourceMismatch { .. })
+        ));
+        assert!(result.match_kind.is_none());
+    }
+
+    #[tokio::test]
+    async fn artifact_verification_rejects_soroban_spec_drift() {
+        let compiled = with_custom_section(
+            MINIMAL_WASM.to_vec(),
+            shared::wasm::CONTRACT_SPEC_SECTION,
+            b"spec-one",
+        );
+        let deployed = with_custom_section(
+            MINIMAL_WASM.to_vec(),
+            shared::wasm::CONTRACT_SPEC_SECTION,
+            b"spec-two",
+        );
+        let source = format!("wasm_base64:{}", BASE64.encode(&compiled));
+        let deployed_hash = hash_wasm(&deployed);
+
+        let result = verify_contract_artifact(&source, &deployed, &deployed_hash, None, None)
+            .await
+            .expect("spec comparison should complete");
+
+        assert!(!result.verified);
+        assert!(matches!(
+            result.failure_kind,
+            Some(VerificationFailureKind::SourceMismatch { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn artifact_verification_checks_raw_deployed_hash_before_compiling() {
+        let deployed = with_custom_section(MINIMAL_WASM.to_vec(), "producers", b"deployed");
+        let wrong_authoritative_hash = hash_wasm(MINIMAL_WASM);
+
+        let result = verify_contract_artifact(
+            "wasm_base64:not-valid-base64",
+            &deployed,
+            &wrong_authoritative_hash,
+            None,
+            None,
+        )
+        .await
+        .expect("trust-boundary mismatch should be a structured result");
+
+        assert!(!result.verified);
+        assert!(matches!(
+            result.failure_kind,
+            Some(VerificationFailureKind::ArtifactHashMismatch { .. })
+        ));
+        assert!(result.compiled_wasm_hash.is_empty());
+    }
+
+    #[tokio::test]
+    async fn artifact_verification_fails_closed_for_invalid_wasm() {
+        let compiled = b"invalid-compiled-wasm";
+        let deployed = b"invalid-deployed-wasm";
+        let source = format!("wasm_base64:{}", BASE64.encode(compiled));
+        let deployed_hash = hash_wasm(deployed);
+
+        let result = verify_contract_artifact(&source, deployed, &deployed_hash, None, None)
+            .await
+            .expect("invalid artifacts should produce a mismatch, not panic");
+
+        assert!(!result.verified);
+        assert!(matches!(
+            result.failure_kind,
+            Some(VerificationFailureKind::InvalidWasmArtifact { ref artifact, .. })
+                if artifact == "deployed"
+        ));
+        assert!(result
+            .message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("not valid canonicalizable WASM"));
+    }
+
+    #[tokio::test]
+    async fn artifact_verification_rejects_invalid_compiled_wasm() {
+        let compiled = b"invalid-compiled-wasm";
+        let deployed = MINIMAL_WASM;
+        let source = format!("wasm_base64:{}", BASE64.encode(compiled));
+        let deployed_hash = hash_wasm(deployed);
+
+        let result = verify_contract_artifact(&source, deployed, &deployed_hash, None, None)
+            .await
+            .expect("invalid compiled artifact should not panic");
+
+        assert!(!result.verified);
+        assert!(matches!(
+            result.failure_kind,
+            Some(VerificationFailureKind::InvalidWasmArtifact { ref artifact, .. })
+                if artifact == "compiled"
+        ));
     }
 
     #[tokio::test]

--- a/docs/wasm-artifact-canonicalization.md
+++ b/docs/wasm-artifact-canonicalization.md
@@ -1,0 +1,79 @@
+# WASM artifact canonicalization
+
+Contract verification uses two separate identities for two separate purposes:
+
+1. **Authoritative artifact identity:** SHA-256 of the exact deployed WASM
+   bytes. This remains the registry and on-chain trust boundary.
+2. **Reproducibility comparison:** a versioned, metadata-tolerant SHA-256 used
+   only after the fetched deployed bytes have been proven to match the
+   authoritative artifact identity.
+
+This separation prevents harmless compiler metadata from causing false
+reproducibility failures without allowing different executable programs to be
+treated as the same deployment.
+
+## V1 algorithm
+
+Identifier: `soroban-registry-wasm-canonical-v1`
+
+V1 first validates that the input is a core WebAssembly v1 module. It then
+preserves the original module header, section order, section encodings, and
+payload bytes, except that it removes these complete custom sections:
+
+| Custom section | Reason excluded |
+| --- | --- |
+| `name` | Standard debug symbols; not executed by the WebAssembly runtime |
+| `producers` | Toolchain provenance/version metadata; not executed by the runtime |
+
+The canonical hash is SHA-256 of those canonical bytes. The algorithm
+identifier must always accompany the hash; a future allowlist change requires
+a new identifier rather than silently reinterpreting existing values.
+
+## Bytes that remain inside the trust boundary
+
+V1 does **not** alter or remove:
+
+- any standard section, including types, imports, functions, tables, memory,
+  globals, exports, elements, code, or data;
+- the Soroban `contractspecv0` ABI section;
+- the Soroban `contractenvmetav0` environment/SDK interface section;
+- any unknown or vendor custom section;
+- instruction operands, code-generation-unit output, function ordering, or
+  monomorphized executable bodies.
+
+Consequently, a change such as the executable instruction-immediate drift
+observed in `rs-soroban-sdk#1975` remains a mismatch. Ignoring it would weaken
+artifact verification because the verifier cannot prove that such a byte is
+semantically irrelevant.
+
+## Verification sequence
+
+The source verifier applies these checks in order:
+
+1. Normalize and validate the recorded 64-character deployed hash.
+2. SHA-256 the fetched deployed bytes and require an exact match with that
+   recorded hash. Failure stops verification; canonical comparison is refused.
+3. Compile the submitted source and compare its raw SHA-256 with the deployed
+   raw SHA-256. An exact match succeeds as `exact`.
+4. If raw hashes differ, canonicalize both complete artifacts with the same V1
+   algorithm and compare their canonical hashes. Equality succeeds as
+   `canonical_metadata_only` and reports the algorithm and canonical hash.
+5. Invalid WASM, executable drift, Soroban metadata drift, or any other change
+   fails closed as a source mismatch.
+
+The original raw hashes are retained in every successful result. A canonical
+hash is never compared with a raw on-chain hash.
+
+## Regression and CI coverage
+
+The focused CI job builds the repository's Soroban fixture twice into separate
+target directories, compares the two complete artifacts with the V1 tool, and
+then runs the shared WASM and verifier test suites. The synthetic drift
+fixtures cover both sides of the boundary:
+
+- different `name`/`producers` payloads produce different raw bytes but the
+  same canonical V1 hash;
+- interface fingerprints remain stable across toolchain-only metadata drift;
+- code instruction changes, `contractspecv0`, `contractenvmetav0`, and unknown
+  custom-section changes remain mismatches;
+- malformed WASM and deployed-byte/raw-hash disagreement fail closed.

--- a/docs/wasm-artifact-canonicalization.md
+++ b/docs/wasm-artifact-canonicalization.md
@@ -52,14 +52,21 @@ The source verifier applies these checks in order:
 
 1. Normalize and validate the recorded 64-character deployed hash.
 2. SHA-256 the fetched deployed bytes and require an exact match with that
-   recorded hash. Failure stops verification; canonical comparison is refused.
-3. Compile the submitted source and compare its raw SHA-256 with the deployed
-   raw SHA-256. An exact match succeeds as `exact`.
-4. If raw hashes differ, canonicalize both complete artifacts with the same V1
-   algorithm and compare their canonical hashes. Equality succeeds as
-   `canonical_metadata_only` and reports the algorithm and canonical hash.
-5. Invalid WASM, executable drift, Soroban metadata drift, or any other change
-   fails closed as a source mismatch.
+   recorded hash. Failure stops verification as `artifact_hash_mismatch`;
+   canonical comparison is refused.
+3. Validate the authoritative deployed artifact as canonicalizable WASM and
+   prepare its V1 hash. Invalid bytes stop verification as
+   `invalid_wasm_artifact` for the `deployed` artifact.
+4. Compile the submitted source and compare its raw SHA-256 with the deployed
+   raw SHA-256. An exact match succeeds as `exact`; no canonical equality
+   comparison is used for this path.
+5. Only if the raw hashes differ, canonicalize the compiled artifact with the
+   same V1 algorithm and compare it with the prepared deployed canonical hash.
+   Invalid compiled bytes fail as `invalid_wasm_artifact` for the `compiled`
+   artifact. Equality succeeds as `canonical_metadata_only` and reports the
+   algorithm and canonical hash.
+6. Valid WASM with executable drift, Soroban metadata drift, or any other
+   trust-boundary change fails closed as `source_mismatch`.
 
 The original raw hashes are retained in every successful result. A canonical
 hash is never compared with a raw on-chain hash.


### PR DESCRIPTION
## Summary

Adds a versioned, metadata-tolerant artifact comparison for reproducible Soroban contract verification while keeping the deployed raw SHA-256 authoritative.

The verifier now obtains the complete deployed WASM bytes, proves that they hash to the recorded on-chain identity, tries an exact raw match first, and only then falls back to `soroban-registry-wasm-canonical-v1`. V1 removes complete `name` and `producers` custom sections only; executable sections, Soroban ABI/environment metadata, and unknown custom sections stay inside the trust boundary.

## Related Issue

Closes #1163

## Type of Change

- [x] Bug fix — fixes an issue without changing existing behavior
- [ ] Feature — new functionality
- [ ] Documentation — updates or adds documentation only
- [ ] Refactor — code restructuring with no behavior change
- [ ] Test — adds or updates tests only
- [ ] Chore — build, CI, or tooling changes

## Changes Made

- Add validated, versioned WASM V1 canonicalization and canonical hashing in `shared`.
- Add artifact-aware verification with structured exact/canonical match results and fail-closed raw-hash/invalid-WASM guards.
- Carry fetched on-chain contract bytes internally (never in API JSON/cache) into single and batch source-verification paths.
- Document every excluded and preserved byte category, including why executable drift such as rs-soroban-sdk#1975 remains a mismatch.
- Add an independent double-build CI check plus positive and negative trust-boundary regression tests.
- Prove interface fingerprints remain stable across toolchain-only metadata drift.

## How Has This Been Tested?

### Test Commands

```bash
cargo test -p shared --lib
cargo test -p verifier --lib
cargo check -p api --lib
cargo clippy -p verifier --lib --no-deps -- -D warnings
cargo clippy -p shared --lib --no-deps -- \
  -D warnings \
  -A clippy::redundant-closure \
  -A clippy::useless-borrows-in-formatting
cargo fmt -p verifier -- --check
```

### Test Coverage

- [x] Unit tests added / updated
- [x] Integration paths compiled
- [x] Manual trust-boundary review completed

### Testing Notes

- `shared`: 155/155 tests passed.
- `verifier`: 38/38 tests passed.
- `api` library compiles successfully; its existing 67 warnings are unchanged by this PR.
- Strict verifier Clippy passes. Shared Clippy passes after allowing six unrelated pre-existing lints outside the changed code.
- Positive: `name`/`producers` drift canonicalizes to the same V1 hash.
- Negative: code, `contractspecv0`, `contractenvmetav0`, unknown custom-section, malformed-WASM, and raw deployed-hash drift fail closed.

## Checklist

- [x] My code follows the project's [style guidelines](CONTRIBUTING.md#code-standards)
- [x] I have performed a self-review of my code
- [x] I have added/updated comments for complex logic
- [x] I have updated documentation where applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] All relevant existing tests pass locally
- [x] My branch is based on the latest `main` with no merge conflicts
- [x] I have not introduced any breaking changes

## Additional Context

Canonical equality is deliberately a secondary reproducibility signal, never an artifact identity. A canonical hash is never compared with a raw on-chain hash, and the API continues to report both original raw hashes. Any future allowlist change must use a new algorithm identifier.