### PR TITLE
feat(cli): add `contract list` command for browsing registered contracts

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2784,18 +2784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
-name = "registry_client"
-version = "0.1.0"
-dependencies = [
- "futures-util",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,7 +3394,6 @@ dependencies = [
  "keyring",
  "log",
  "rand 0.8.5",
- "registry_client",
  "reqwest",
  "ripemd",
  "rustyline",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -166,6 +166,25 @@ fn normalize_network_filters(values: &[String]) -> Result<Vec<String>> {
     Ok(normalized)
 }
 
+/// Parse a comma-separated `--networks` value into the registry's network type.
+///
+/// Shared with `contract list` so every command validates network filters
+/// identically: unknown names fail here, locally, instead of being dropped
+/// server-side and silently returning unfiltered results.
+pub(crate) fn normalize_network_list(value: Option<&str>) -> Result<Vec<registry_client::Network>> {
+    let values: Vec<String> = value.into_iter().map(str::to_string).collect();
+    let normalized = normalize_network_filters(&values)?;
+    if normalized.is_empty() {
+        return Ok(Vec::new());
+    }
+    shared_networks(&normalized)
+}
+
+/// Split a comma-separated filter into trimmed, de-duplicated values.
+pub(crate) fn normalize_list_values(value: Option<&str>) -> Vec<String> {
+    normalize_filter_values(&value.into_iter().map(str::to_string).collect::<Vec<_>>())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn search(
     api_url: &str,

--- a/cli/src/contract_list.rs
+++ b/cli/src/contract_list.rs
@@ -1,0 +1,370 @@
+//! `soroban-registry contract list` - browse registered contracts.
+//!
+//! Paginates through the registry with `--limit`/`--offset`, and renders as a
+//! table, JSON or CSV. The machine-readable formats carry no decoration, so the
+//! command pipes cleanly into `jq`, `column`, or a spreadsheet.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use registry_client::{Contract, ContractSearchParams, PaginatedResponse};
+use std::io::{self, IsTerminal, Write};
+
+/// Rows per page when the caller does not choose.
+pub const DEFAULT_LIMIT: usize = 10;
+/// The registry clamps `limit` to this, so reject a larger one up front rather
+/// than silently returning fewer rows than asked for.
+pub const MAX_LIMIT: usize = 100;
+
+/// How to render the listing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListFormat {
+    Table,
+    Json,
+    Csv,
+}
+
+impl ListFormat {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_lowercase().as_str() {
+            "table" => Ok(ListFormat::Table),
+            "json" => Ok(ListFormat::Json),
+            "csv" => Ok(ListFormat::Csv),
+            other => anyhow::bail!(
+                "Unknown format '{other}'. Use one of: table, json, csv.\n\
+                 Example: soroban-registry contract list --format json"
+            ),
+        }
+    }
+}
+
+/// Everything `contract list` accepts.
+#[derive(Debug, Clone)]
+pub struct ListOptions {
+    pub limit: usize,
+    pub offset: usize,
+    pub networks: Option<String>,
+    pub category: Option<String>,
+    pub format: String,
+}
+
+pub async fn run(api_url: &str, options: ListOptions) -> Result<()> {
+    let format = ListFormat::parse(&options.format)?;
+    let limit = validate_limit(options.limit)?;
+
+    let params = build_params(&options, limit)?;
+
+    let page = crate::registry::client(api_url)
+        .await?
+        .list_contracts(&params)
+        .await
+        .map_err(|err| explain(err, api_url))?;
+
+    // Write through a locked handle rather than `println!`: `println!` panics
+    // when the reader goes away, so `contract list | head` would crash instead
+    // of stopping. A command meant to be piped treats a closed pipe as a normal
+    // end of output.
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    let result = match format {
+        ListFormat::Json => print_json(&mut out, &page, options.offset, limit),
+        ListFormat::Csv => print_csv(&mut out, &page.items),
+        ListFormat::Table => print_table(&mut out, &page, options.offset, limit),
+    }
+    .and_then(|()| out.flush());
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        Err(err) => Err(err).context("Failed to write the contract list"),
+    }
+}
+
+fn validate_limit(limit: usize) -> Result<usize> {
+    if limit == 0 {
+        anyhow::bail!(
+            "--limit must be at least 1.\n\
+             Example: soroban-registry contract list --limit {DEFAULT_LIMIT}"
+        );
+    }
+    if limit > MAX_LIMIT {
+        anyhow::bail!(
+            "--limit is capped at {MAX_LIMIT} (asked for {limit}).\n\
+             Page through the registry instead:\n  \
+             soroban-registry contract list --limit {MAX_LIMIT} --offset {MAX_LIMIT}"
+        );
+    }
+    Ok(limit)
+}
+
+fn build_params(options: &ListOptions, limit: usize) -> Result<ContractSearchParams> {
+    let mut params = ContractSearchParams {
+        limit: Some(limit as i64),
+        offset: Some(options.offset as i64),
+        ..Default::default()
+    };
+
+    // Reuse the filter normalisation `list` and `search` already share, so an
+    // unknown network fails here rather than being dropped server-side.
+    let networks = crate::commands::normalize_network_list(options.networks.as_deref())?;
+    if !networks.is_empty() {
+        params.networks = Some(networks);
+    }
+    let categories = crate::commands::normalize_list_values(options.category.as_deref());
+    if !categories.is_empty() {
+        params.categories = Some(categories);
+    }
+
+    Ok(params)
+}
+
+/// Turn a client error into something with a next step attached.
+fn explain(err: registry_client::Error, api_url: &str) -> anyhow::Error {
+    let hint = match &err {
+        registry_client::Error::Transport { .. } => format!(
+            "Could not reach the registry at {api_url}.\n\
+             Check the URL, or set one with --api-url or `soroban-registry config set api-url`."
+        ),
+        registry_client::Error::Timeout { .. } => {
+            "The registry took too long to respond. Try a smaller --limit, or retry shortly."
+                .to_string()
+        }
+        error if error.is_auth() => {
+            "The registry rejected the credentials. Run `soroban-registry auth login`.".to_string()
+        }
+        registry_client::Error::Validation(_) => {
+            "The registry rejected the filters. Check --networks and --category values.".to_string()
+        }
+        registry_client::Error::RateLimited { retry_after, .. } => match retry_after {
+            Some(after) => format!("Rate limited. Retry in {}s.", after.as_secs()),
+            None => "Rate limited. Retry shortly.".to_string(),
+        },
+        _ => "Run with -vv to see the full request and response.".to_string(),
+    };
+
+    anyhow::anyhow!("Failed to list contracts: {err}\n{hint}")
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+/// The columns this command promises, in order.
+fn row(contract: &Contract) -> [String; 5] {
+    [
+        contract.contract_id.clone(),
+        contract.name.clone(),
+        contract.network.to_string(),
+        contract.category.clone().unwrap_or_default(),
+        contract.updated_at.format("%Y-%m-%d %H:%M:%S").to_string(),
+    ]
+}
+
+fn print_json(
+    out: &mut impl Write,
+    page: &PaginatedResponse<Contract>,
+    offset: usize,
+    limit: usize,
+) -> io::Result<()> {
+    let contracts: Vec<serde_json::Value> = page
+        .items
+        .iter()
+        .map(|contract| {
+            serde_json::json!({
+                "address": contract.contract_id,
+                "name": contract.name,
+                "network": contract.network.to_string(),
+                "category": contract.category,
+                "last_update": contract.updated_at.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let document = serde_json::json!({
+        "contracts": contracts,
+        "pagination": pagination_json(page, offset, limit),
+    });
+    // Serializing a value this crate built cannot fail for any reason the user
+    // can act on, so a failure here is a bug, not a report.
+    let rendered = serde_json::to_string_pretty(&document)
+        .expect("the listing document is always serializable");
+    writeln!(out, "{rendered}")
+}
+
+fn pagination_json(
+    page: &PaginatedResponse<Contract>,
+    offset: usize,
+    limit: usize,
+) -> serde_json::Value {
+    let total = page.total.max(0) as usize;
+    serde_json::json!({
+        "count": page.items.len(),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "page": current_page(offset, limit),
+        "total_pages": total_pages(total, limit),
+        "has_more": offset + page.items.len() < total,
+    })
+}
+
+fn print_csv(out: &mut impl Write, items: &[Contract]) -> io::Result<()> {
+    // No header decoration and no colour: this is the format people pipe.
+    writeln!(out, "address,name,network,category,last_update")?;
+    for contract in items {
+        let cells = row(contract).map(|cell| csv_escape(&cell));
+        writeln!(out, "{}", cells.join(","))?;
+    }
+    Ok(())
+}
+
+/// Quote a CSV field only when it needs it, doubling any embedded quotes.
+fn csv_escape(value: &str) -> String {
+    if value.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+fn print_table(
+    out: &mut impl Write,
+    page: &PaginatedResponse<Contract>,
+    offset: usize,
+    limit: usize,
+) -> io::Result<()> {
+    let headers = ["ADDRESS", "NAME", "NETWORK", "CATEGORY", "LAST UPDATE"];
+    let rows: Vec<[String; 5]> = page.items.iter().map(row).collect();
+
+    if rows.is_empty() {
+        writeln!(
+            out,
+            "{}",
+            decorate("No contracts found.", Decoration::Warning)
+        )?;
+        return writeln!(out, "Try widening the filters, or a different --offset.");
+    }
+
+    // Size every column to its widest visible cell, so the table stays aligned
+    // whatever the data looks like.
+    let mut widths: [usize; 5] = headers.map(str::len);
+    for row in &rows {
+        for (index, cell) in row.iter().enumerate() {
+            widths[index] = widths[index].max(cell.chars().count());
+        }
+    }
+
+    let header_line: Vec<String> = headers
+        .iter()
+        .enumerate()
+        .map(|(index, header)| format!("{header:<width$}", width = widths[index]))
+        .collect();
+    writeln!(
+        out,
+        "{}",
+        decorate(&header_line.join("  "), Decoration::Header)
+    )?;
+
+    for row in &rows {
+        let line: Vec<String> = row
+            .iter()
+            .enumerate()
+            .map(|(index, cell)| format!("{cell:<width$}", width = widths[index]))
+            .collect();
+        writeln!(out, "{}", line.join("  "))?;
+    }
+
+    let total = page.total.max(0) as usize;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "Page {} of {} - showing {} of {} contract(s)",
+        current_page(offset, limit),
+        total_pages(total, limit),
+        rows.len(),
+        total
+    )?;
+    if offset + rows.len() < total {
+        writeln!(
+            out,
+            "Next page: soroban-registry contract list --limit {limit} --offset {}",
+            offset + limit
+        )?;
+    }
+    Ok(())
+}
+
+fn current_page(offset: usize, limit: usize) -> usize {
+    offset / limit.max(1) + 1
+}
+
+fn total_pages(total: usize, limit: usize) -> usize {
+    total.div_ceil(limit.max(1)).max(1)
+}
+
+enum Decoration {
+    Header,
+    Warning,
+}
+
+/// Colour only when stdout is a terminal, so a piped table stays plain text.
+fn decorate(text: &str, decoration: Decoration) -> String {
+    if !std::io::stdout().is_terminal() {
+        return text.to_string();
+    }
+    match decoration {
+        Decoration::Header => text.bold().to_string(),
+        Decoration::Warning => text.yellow().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_parse_case_insensitively() {
+        assert_eq!(ListFormat::parse("table").unwrap(), ListFormat::Table);
+        assert_eq!(ListFormat::parse("JSON").unwrap(), ListFormat::Json);
+        assert_eq!(ListFormat::parse(" csv ").unwrap(), ListFormat::Csv);
+    }
+
+    #[test]
+    fn an_unknown_format_names_the_valid_ones() {
+        let err = ListFormat::parse("yaml").expect_err("yaml is not supported");
+        let message = err.to_string();
+        assert!(message.contains("table, json, csv"), "{message}");
+        assert!(message.contains("Example:"), "errors suggest a next step");
+    }
+
+    #[test]
+    fn limits_are_bounded_to_what_the_registry_serves() {
+        assert_eq!(validate_limit(1).unwrap(), 1);
+        assert_eq!(validate_limit(MAX_LIMIT).unwrap(), MAX_LIMIT);
+
+        let err = validate_limit(MAX_LIMIT + 1).expect_err("over the cap");
+        assert!(err.to_string().contains("capped at 100"));
+        assert!(
+            err.to_string().contains("--offset"),
+            "the error should show how to page instead"
+        );
+        assert!(validate_limit(0).is_err());
+    }
+
+    #[test]
+    fn page_numbers_are_derived_from_the_offset() {
+        assert_eq!(current_page(0, 10), 1);
+        assert_eq!(current_page(10, 10), 2);
+        assert_eq!(current_page(95, 10), 10);
+        // A partial page still counts as a page.
+        assert_eq!(total_pages(0, 10), 1);
+        assert_eq!(total_pages(10, 10), 1);
+        assert_eq!(total_pages(11, 10), 2);
+        assert_eq!(total_pages(101, 10), 11);
+    }
+
+    #[test]
+    fn csv_fields_are_escaped_only_when_needed() {
+        assert_eq!(csv_escape("plain"), "plain");
+        assert_eq!(csv_escape("with,comma"), "\"with,comma\"");
+        assert_eq!(csv_escape("say \"hi\""), "\"say \"\"hi\"\"\"");
+        assert_eq!(csv_escape("two\nlines"), "\"two\nlines\"");
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -34,6 +34,7 @@ mod contract_deprecate;
 mod contract_highlight;
 mod contract_interaction;
 mod contract_interfaces;
+mod contract_list;
 mod contract_provenance;
 mod contract_register;
 mod contract_risk;
@@ -1905,6 +1906,41 @@ pub enum CategoryCommands {
 /// Sub-commands for the `contract` group (#522)
 #[derive(Debug, Subcommand)]
 pub enum ContractCommands {
+    /// List registered contracts, a page at a time
+    ///
+    /// Shows address, name, network, category and last update. JSON and CSV
+    /// carry no decoration, so they pipe cleanly into other tools.
+    ///
+    /// Examples:
+    ///   soroban-registry contract list
+    ///   soroban-registry contract list --limit 50 --offset 100
+    ///   soroban-registry contract list --networks testnet --category DeFi
+    ///   soroban-registry contract list --format json | jq '.contracts[].address'
+    ///   soroban-registry contract list --format csv > contracts.csv
+    #[command(verbatim_doc_comment)]
+    List {
+        /// Contracts per page (1-100)
+        #[arg(long, short, default_value_t = contract_list::DEFAULT_LIMIT)]
+        limit: usize,
+
+        /// Contracts to skip; use it with --limit to page through the registry
+        #[arg(long, short, default_value_t = 0)]
+        offset: usize,
+
+        /// Filter by network (comma-separated: mainnet,testnet,futurenet).
+        /// Named `networks` because the global `--network` owns that arg id.
+        #[arg(long)]
+        networks: Option<String>,
+
+        /// Filter by category (comma-separated: DeFi,NFT)
+        #[arg(long, short)]
+        category: Option<String>,
+
+        /// Output format: table, json or csv
+        #[arg(long, short, default_value = "table")]
+        format: String,
+    },
+
     /// Search the registry, one page at a time or across every page
     ///
     /// Pagination is handled for you: `--all` walks pages until the result set
@@ -4602,6 +4638,33 @@ pub async fn dispatch_command(
         },
         // ── Contract verify command (#522) ───────────────────────────────────
         Commands::Contract { action } => match action {
+            ContractCommands::List {
+                limit,
+                offset,
+                networks,
+                category,
+                format,
+            } => {
+                log::debug!(
+                    "Command: contract list | limit={} offset={} networks={:?} category={:?} format={}",
+                    limit,
+                    offset,
+                    networks,
+                    category,
+                    format
+                );
+                contract_list::run(
+                    &cli.api_url,
+                    contract_list::ListOptions {
+                        limit,
+                        offset,
+                        networks,
+                        category,
+                        format,
+                    },
+                )
+                .await?;
+            }
             ContractCommands::Search {
                 query,
                 networks,

--- a/cli/tests/contract_list_integration.rs
+++ b/cli/tests/contract_list_integration.rs
@@ -1,0 +1,451 @@
+// tests/contract_list_integration.rs
+//
+// End-to-end tests for `soroban-registry contract list`: the real binary runs
+// against a mock registry, covering each output format, pagination, filters,
+// error handling and the performance target.
+
+use std::process::{Command, Output};
+use std::time::Instant;
+
+use serde_json::{json, Value};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const BINARY: &str = env!("CARGO_BIN_EXE_soroban-registry");
+
+async fn run_cli(api_url: &str, args: &[&str]) -> Output {
+    let mut command = Command::new(BINARY);
+    command
+        .arg("--api-url")
+        .arg(api_url)
+        .arg("--no-cache")
+        .arg("contract")
+        .arg("list");
+    command.args(args);
+
+    tokio::task::spawn_blocking(move || command.output().expect("failed to run the CLI"))
+        .await
+        .expect("CLI task panicked")
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn stdout_json(output: &Output) -> Value {
+    serde_json::from_str(&stdout_of(output)).unwrap_or_else(|err| {
+        panic!(
+            "expected JSON on stdout ({err}).\nstdout: {}\nstderr: {}",
+            stdout_of(output),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+/// A `Contract` as the registry serializes it.
+fn contract(index: usize, name: &str, category: Option<&str>) -> Value {
+    json!({
+        "id": format!("11111111-1111-1111-1111-{:012}", index),
+        "contract_id": format!("CA{:054}", index),
+        "wasm_hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        "name": name,
+        "slug": format!("slug-{index}"),
+        "description": "a contract",
+        "publisher_id": "22222222-2222-2222-2222-222222222222",
+        "network": "testnet",
+        "is_verified": true,
+        "verification_status": "Verified",
+        "category": category,
+        "tags": [],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-02-03T04:05:06Z",
+        "verified_at": null,
+        "deployed_at": null,
+        "verified_by": null,
+        "verification_notes": null,
+        "last_accessed_at": null,
+        "health_score": 80,
+        "is_maintenance": false,
+        "logical_id": null,
+        "network_configs": null,
+        "organization_id": null,
+        "visibility": "public",
+        "usage_count": 3
+    })
+}
+
+fn page(count: usize, total: i64) -> Value {
+    let items: Vec<Value> = (0..count)
+        .map(|index| contract(index, &format!("contract-{index}"), Some("DeFi")))
+        .collect();
+    json!({
+        "items": items,
+        "total": total,
+        "page": 1,
+        "per_page": count.max(1),
+        "pages": 1
+    })
+}
+
+async fn registry_returning(body: Value) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+    server
+}
+
+// ── Table (default) ───────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn table_is_the_default_and_shows_the_promised_columns() {
+    let server = registry_returning(page(3, 3)).await;
+
+    let output = run_cli(&server.uri(), &[]).await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = stdout_of(&output);
+    for header in ["ADDRESS", "NAME", "NETWORK", "CATEGORY", "LAST UPDATE"] {
+        assert!(
+            stdout.contains(header),
+            "missing column {header}:\n{stdout}"
+        );
+    }
+    assert!(stdout.contains("contract-0"), "{stdout}");
+    assert!(stdout.contains("testnet"), "{stdout}");
+    assert!(stdout.contains("DeFi"), "{stdout}");
+    assert!(
+        stdout.contains("2026-02-03 04:05:06"),
+        "last update:\n{stdout}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn table_reports_the_current_page_and_total() {
+    let server = registry_returning(page(10, 95)).await;
+
+    let output = run_cli(&server.uri(), &["--limit", "10", "--offset", "20"]).await;
+
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("Page 3 of 10"),
+        "offset 20 with limit 10 is page 3 of 10:\n{stdout}"
+    );
+    assert!(stdout.contains("showing 10 of 95 contract(s)"), "{stdout}");
+    assert!(
+        stdout.contains("--offset 30"),
+        "it should show how to get the next page:\n{stdout}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_empty_registry_says_so_without_an_empty_table() {
+    let server = registry_returning(page(0, 0)).await;
+
+    let output = run_cli(&server.uri(), &[]).await;
+
+    assert!(output.status.success());
+    let stdout = stdout_of(&output);
+    assert!(stdout.contains("No contracts found"), "{stdout}");
+    assert!(!stdout.contains("ADDRESS"), "no header for an empty result");
+}
+
+// ── JSON ──────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn json_carries_the_columns_and_pagination_metadata() {
+    let server = registry_returning(page(2, 42)).await;
+
+    let output = run_cli(&server.uri(), &["--format", "json", "--limit", "2"]).await;
+
+    let body = stdout_json(&output);
+    let first = &body["contracts"][0];
+    assert_eq!(first["name"], "contract-0");
+    assert_eq!(first["network"], "testnet");
+    assert_eq!(first["category"], "DeFi");
+    assert_eq!(first["last_update"], "2026-02-03T04:05:06+00:00");
+    assert!(
+        first["address"].as_str().unwrap().starts_with("CA"),
+        "address is the on-chain contract id"
+    );
+
+    let pagination = &body["pagination"];
+    assert_eq!(pagination["count"], 2);
+    assert_eq!(pagination["total"], 42);
+    assert_eq!(pagination["page"], 1);
+    assert_eq!(pagination["total_pages"], 21);
+    assert_eq!(pagination["has_more"], true);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn json_output_is_pipeable() {
+    let server = registry_returning(page(3, 3)).await;
+
+    let output = run_cli(&server.uri(), &["--format", "json"]).await;
+
+    let stdout = stdout_of(&output);
+    // Nothing but JSON on stdout: no banner, no ANSI escapes.
+    assert!(stdout.trim_start().starts_with('{'), "{stdout}");
+    assert!(
+        !stdout.contains('\u{1b}'),
+        "piped output must not be coloured"
+    );
+    serde_json::from_str::<Value>(&stdout).expect("stdout parses as one JSON document");
+}
+
+// ── CSV ───────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn csv_has_a_header_and_one_row_per_contract() {
+    let server = registry_returning(page(3, 3)).await;
+
+    let output = run_cli(&server.uri(), &["--format", "csv"]).await;
+
+    let stdout = stdout_of(&output);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines[0], "address,name,network,category,last_update");
+    assert_eq!(lines.len(), 4, "header plus three rows:\n{stdout}");
+    assert!(
+        lines[1].contains(",contract-0,testnet,DeFi,"),
+        "{}",
+        lines[1]
+    );
+    assert!(!stdout.contains('\u{1b}'), "csv must not be coloured");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn csv_quotes_fields_that_contain_separators() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [contract(1, "Comma, Inc \"quoted\"", Some("DeFi"))],
+            "total": 1, "page": 1, "per_page": 1, "pages": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["--format", "csv"]).await;
+
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("\"Comma, Inc \"\"quoted\"\"\""),
+        "commas and quotes must be escaped:\n{stdout}"
+    );
+}
+
+// ── Pagination and filters on the wire ────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn limit_and_offset_reach_the_registry() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .and(query_param("limit", "25"))
+        .and(query_param("offset", "50"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(page(25, 200)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &["--limit", "25", "--offset", "50"]).await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn filters_are_normalised_before_they_are_sent() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .and(query_param("networks", "testnet,mainnet"))
+        .and(query_param("categories", "DeFi,NFT"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(page(1, 1)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = run_cli(
+        &server.uri(),
+        &[
+            "--networks",
+            " TESTNET , mainnet ,testnet",
+            "--category",
+            "DeFi, NFT",
+        ],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_oversized_limit_is_rejected_with_a_way_forward() {
+    let server = MockServer::start().await;
+
+    let output = run_cli(&server.uri(), &["--limit", "500"]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("capped at 100"), "{stderr}");
+    assert!(
+        stderr.contains("--offset"),
+        "suggests paging instead: {stderr}"
+    );
+    assert!(
+        server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty(),
+        "nothing should reach the registry"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unknown_format_lists_the_supported_ones() {
+    let server = MockServer::start().await;
+
+    let output = run_cli(&server.uri(), &["--format", "xml"]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("table, json, csv"), "{stderr}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unknown_network_fails_before_any_request() {
+    let server = MockServer::start().await;
+
+    let output = run_cli(&server.uri(), &["--networks", "bogusnet"]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Invalid network"), "{stderr}");
+    assert!(
+        server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty(),
+        "nothing should reach the registry"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_registry_error_explains_what_to_do_next() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/contracts"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "code": "Unauthorized",
+            "message": "Session expired"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_cli(&server.uri(), &[]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Failed to list contracts"), "{stderr}");
+    assert!(stderr.contains("auth login"), "suggests a fix: {stderr}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unreachable_registry_names_the_url() {
+    let output = run_cli("http://127.0.0.1:9", &[]).await;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Could not reach the registry"), "{stderr}");
+    assert!(stderr.contains("--api-url"), "{stderr}");
+}
+
+// ── Performance ───────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_hundred_contracts_render_quickly() {
+    let server = registry_returning(page(100, 100)).await;
+
+    let started = Instant::now();
+    let output = run_cli(&server.uri(), &["--limit", "100"]).await;
+    let elapsed = started.elapsed();
+
+    assert!(output.status.success());
+    let stdout = stdout_of(&output);
+    assert_eq!(
+        stdout.lines().count(),
+        103,
+        "header, 100 rows, blank line, summary:\n{stdout}"
+    );
+    // The target is 500ms. The ceiling here is deliberately looser because this
+    // measures process startup on a possibly cold, shared CI runner as well as
+    // the work itself; it is a regression guard, not the benchmark.
+    assert!(
+        elapsed.as_millis() < 2_000,
+        "listing 100 contracts took {elapsed:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn closing_the_pipe_early_is_not_a_crash() {
+    // `contract list --format csv | head -3` is the most ordinary thing a user
+    // will do with this command. `println!` panics on a closed pipe, so without
+    // explicit handling this exits 101 with "failed printing to stdout".
+    let server = registry_returning(page(100, 100)).await;
+    let url = server.uri();
+
+    let output = tokio::task::spawn_blocking(move || {
+        let mut child = Command::new(BINARY)
+            .args(["--api-url", &url, "--no-cache", "contract", "list"])
+            .args(["--limit", "100", "--format", "csv"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn the CLI");
+
+        // Read a few lines, then drop the pipe while the CLI is still writing.
+        {
+            use std::io::{BufRead, BufReader};
+            let stdout = child.stdout.take().expect("stdout");
+            let mut reader = BufReader::new(stdout);
+            let mut line = String::new();
+            for _ in 0..3 {
+                line.clear();
+                let _ = reader.read_line(&mut line);
+            }
+        }
+
+        child.wait_with_output().expect("wait for the CLI")
+    })
+    .await
+    .expect("CLI task panicked");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "a closed pipe must not panic: {stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "a closed pipe is a normal end, got {:?}: {stderr}",
+        output.status.code()
+    );
+}


### PR DESCRIPTION
This pull request introduces a new `contract list` command to the CLI, allowing users to browse registered contracts with flexible filtering, pagination, and output formatting options. The implementation includes robust validation and user-friendly error handling, and supports output as a table, JSON, or CSV for easy integration with other tools.

**New `contract list` command and related changes:**

* Added a new `contract list` subcommand to `ContractCommands`, with options for pagination (`--limit`, `--offset`), filtering by network and category, and output format (`--format`). The command is documented with usage examples and argument descriptions.
* Implemented the `contract_list` module (`cli/src/contract_list.rs`) with all logic for fetching, filtering, validating, and rendering contract listings. This includes format parsing, filter normalization, error handling, and output rendering in table, JSON, and CSV formats.
* Integrated the new command into the main CLI dispatch logic, wiring up argument parsing and calling the `contract_list::run` function with the appropriate options.
* Added utility functions in `commands.rs` for normalizing network and category filters, ensuring consistent validation across commands.
* Registered the new `contract_list` module in the main CLI module imports.
closes #823 